### PR TITLE
fix: Add RUNPATH to libkrun Linux build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,12 @@ endif
 endif
 
 $(LIBRARY_RELEASE_$(OS)): $(INIT_BINARY)
+ifeq ($(OS),Darwin)
 	cargo build --release $(FEATURE_FLAGS)
+else
+	cd monocore && RUSTFLAGS="-C link-args=-Wl,-rpath,$(DESTDIR)$(PREFIX)/$(LIBDIR_$(OS))/" \
+		cargo build --release $(FEATURE_FLAGS)
+endif
 ifeq ($(SEV),1)
 	mv target/release/libkrun.so target/release/$(KRUN_BASE_$(OS))
 endif


### PR DESCRIPTION
This PR addresses issues with dynamic library resolution in `libkrun` and its dependent binaries (`monocore` and `monokrun`). Previously, binaries could not find the necessary shared libraries (`libkrunfw.so.4`, `libkrun.so.1`) at runtime without explicitly setting `LD_LIBRARY_PATH`. The root cause was improper `RUNPATH` configuration during the build process.

#### Changes:
1. **Updated Makefile**:
   - Added `RUSTFLAGS` to set `-rpath` during the build for Linux.
   - Ensured `RUNPATH` points to the appropriate destination directory (`$(DESTDIR)$(PREFIX)/$(LIBDIR_$(OS))`).

2. **Fixed RUNPATH**:
   - Verified `RUNPATH` is embedded correctly in the resulting binaries and shared libraries.
   - `monocore`, `monokrun`, and `libkrun.so.1` now include `/usr/local/lib64` in their `RUNPATH`.

3. **Improved Compatibility**:
   - Resolved the issue where binaries failed to run without manually setting `LD_LIBRARY_PATH`.

#### Testing:
- Verified `RUNPATH` using `readelf` on all binaries and libraries:
  ```bash
  readelf -d /usr/local/bin/monocore | grep PATH
  readelf -d /usr/local/bin/monokrun | grep PATH
  readelf -d /usr/local/lib64/libkrun.so.1 | grep PATH
  ```
- Confirmed binaries (`monocore`, `monokrun`) execute correctly without requiring `LD_LIBRARY_PATH`.

#### Impact:
This fix simplifies deployment and usage by eliminating the need for additional environment configuration. The binaries and libraries now work out-of-the-box with proper dynamic library resolution.
