### PR TITLE
feat(fs): expose overlayfs API for macOS

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -59,8 +59,33 @@ int32_t krun_set_vm_config(uint32_t ctx_id, uint8_t num_vcpus, uint32_t ram_mib)
  *
  * Returns:
  *  Zero on success or a negative error number on failure.
+ *  Documented errors:
+ *       -EEXIST when a root device is already set
+ *
+ * Notes:
+ *  This function is mutually exclusive with krun_set_overlayfs_root.
  */
 int32_t krun_set_root(uint32_t ctx_id, const char *root_path);
+
+/**
+ * Sets up an OverlayFS to be used as root for the microVM. Not available in libkrun-SEV.
+ *
+ * Arguments:
+ *  "ctx_id"      - the configuration context ID.
+ *  "root_layers" - an array of string pointers to filesystem paths representing
+ *                  the layers to be used for the OverlayFS. The array must be
+ *                  NULL-terminated and contain at least one layer.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ *  Documented errors:
+ *       -EINVAL when no layers are provided
+ *       -EEXIST when a root device is already set
+ *
+ * Notes:
+ *  This function is mutually exclusive with krun_set_root.
+ */
+int32_t krun_set_overlayfs_root(uint32_t ctx_id, const char *const root_layers[]);
 
 /**
  * DEPRECATED. Use krun_add_disk instead.

--- a/src/devices/src/virtio/fs/kinds.rs
+++ b/src/devices/src/virtio/fs/kinds.rs
@@ -1,0 +1,647 @@
+use std::{ffi::CStr, io, path::PathBuf, time::Duration};
+
+use crossbeam_channel::Sender;
+use hvf::MemoryMapping;
+
+use crate::virtio::bindings;
+
+use super::{
+    filesystem::{
+        Context, DirEntry, Entry, Extensions, FileSystem, GetxattrReply, ListxattrReply,
+        ZeroCopyReader, ZeroCopyWriter,
+    },
+    fuse::{FsOptions, OpenOptions, RemovemappingOne, SetattrValid},
+    overlayfs::{self, OverlayFs},
+    passthrough::{self, PassthroughFs},
+};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub enum FsImplConfig {
+    Passthrough(passthrough::Config),
+    Overlayfs(overlayfs::Config),
+}
+
+pub enum FsImpl {
+    Passthrough(PassthroughFs),
+    Overlayfs(OverlayFs),
+}
+
+#[derive(Clone, Debug)]
+pub enum FsImplShare {
+    Passthrough(String),
+    Overlayfs(Vec<PathBuf>),
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+impl FileSystem for FsImpl {
+    type Inode = u64;
+    type Handle = u64;
+
+    fn init(&self, capable: FsOptions) -> io::Result<FsOptions> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.init(capable),
+            FsImpl::Overlayfs(fs) => fs.init(capable),
+        }
+    }
+
+    fn destroy(&self) {
+        match self {
+            FsImpl::Passthrough(fs) => fs.destroy(),
+            FsImpl::Overlayfs(fs) => fs.destroy(),
+        }
+    }
+
+    fn lookup(&self, ctx: Context, parent: Self::Inode, name: &CStr) -> io::Result<Entry> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.lookup(ctx, parent, name),
+            FsImpl::Overlayfs(fs) => fs.lookup(ctx, parent, name),
+        }
+    }
+
+    fn forget(&self, ctx: Context, inode: Self::Inode, count: u64) {
+        match self {
+            FsImpl::Passthrough(fs) => fs.forget(ctx, inode, count),
+            FsImpl::Overlayfs(fs) => fs.forget(ctx, inode, count),
+        }
+    }
+
+    fn batch_forget(&self, ctx: Context, requests: Vec<(Self::Inode, u64)>) {
+        match self {
+            FsImpl::Passthrough(fs) => fs.batch_forget(ctx, requests),
+            FsImpl::Overlayfs(fs) => fs.batch_forget(ctx, requests),
+        }
+    }
+
+    fn getattr(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Option<Self::Handle>,
+    ) -> io::Result<(bindings::stat64, Duration)> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.getattr(ctx, inode, handle),
+            FsImpl::Overlayfs(fs) => fs.getattr(ctx, inode, handle),
+        }
+    }
+
+    fn setattr(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        attr: bindings::stat64,
+        handle: Option<Self::Handle>,
+        valid: SetattrValid,
+    ) -> io::Result<(bindings::stat64, Duration)> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.setattr(ctx, inode, attr, handle, valid),
+            FsImpl::Overlayfs(fs) => fs.setattr(ctx, inode, attr, handle, valid),
+        }
+    }
+
+    fn readlink(&self, ctx: Context, inode: Self::Inode) -> io::Result<Vec<u8>> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.readlink(ctx, inode),
+            FsImpl::Overlayfs(fs) => fs.readlink(ctx, inode),
+        }
+    }
+
+    fn symlink(
+        &self,
+        ctx: Context,
+        linkname: &CStr,
+        parent: Self::Inode,
+        name: &CStr,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.symlink(ctx, linkname, parent, name, extensions),
+            FsImpl::Overlayfs(fs) => fs.symlink(ctx, linkname, parent, name, extensions),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn mknod(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        name: &CStr,
+        mode: u32,
+        rdev: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.mknod(ctx, inode, name, mode, rdev, umask, extensions),
+            FsImpl::Overlayfs(fs) => fs.mknod(ctx, inode, name, mode, rdev, umask, extensions),
+        }
+    }
+
+    fn mkdir(
+        &self,
+        ctx: Context,
+        parent: Self::Inode,
+        name: &CStr,
+        mode: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.mkdir(ctx, parent, name, mode, umask, extensions),
+            FsImpl::Overlayfs(fs) => fs.mkdir(ctx, parent, name, mode, umask, extensions),
+        }
+    }
+
+    fn unlink(&self, ctx: Context, parent: Self::Inode, name: &CStr) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.unlink(ctx, parent, name),
+            FsImpl::Overlayfs(fs) => fs.unlink(ctx, parent, name),
+        }
+    }
+
+    fn rmdir(&self, ctx: Context, parent: Self::Inode, name: &CStr) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.rmdir(ctx, parent, name),
+            FsImpl::Overlayfs(fs) => fs.rmdir(ctx, parent, name),
+        }
+    }
+
+    fn rename(
+        &self,
+        ctx: Context,
+        olddir: Self::Inode,
+        oldname: &CStr,
+        newdir: Self::Inode,
+        newname: &CStr,
+        flags: u32,
+    ) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.rename(ctx, olddir, oldname, newdir, newname, flags),
+            FsImpl::Overlayfs(fs) => fs.rename(ctx, olddir, oldname, newdir, newname, flags),
+        }
+    }
+
+    fn link(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        newparent: Self::Inode,
+        newname: &CStr,
+    ) -> io::Result<Entry> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.link(ctx, inode, newparent, newname),
+            FsImpl::Overlayfs(fs) => fs.link(ctx, inode, newparent, newname),
+        }
+    }
+
+    fn open(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        flags: u32,
+    ) -> io::Result<(Option<Self::Handle>, OpenOptions)> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.open(ctx, inode, flags),
+            FsImpl::Overlayfs(fs) => fs.open(ctx, inode, flags),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn create(
+        &self,
+        ctx: Context,
+        parent: Self::Inode,
+        name: &CStr,
+        mode: u32,
+        flags: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<(Entry, Option<Self::Handle>, OpenOptions)> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.create(ctx, parent, name, mode, flags, umask, extensions),
+            FsImpl::Overlayfs(fs) => fs.create(ctx, parent, name, mode, flags, umask, extensions),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn read<W: io::Write + ZeroCopyWriter>(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        w: W,
+        size: u32,
+        offset: u64,
+        lock_owner: Option<u64>,
+        flags: u32,
+    ) -> io::Result<usize> {
+        match self {
+            FsImpl::Passthrough(fs) => {
+                fs.read(ctx, inode, handle, w, size, offset, lock_owner, flags)
+            }
+            FsImpl::Overlayfs(fs) => {
+                fs.read(ctx, inode, handle, w, size, offset, lock_owner, flags)
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn write<R: io::Read + ZeroCopyReader>(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        r: R,
+        size: u32,
+        offset: u64,
+        lock_owner: Option<u64>,
+        delayed_write: bool,
+        kill_priv: bool,
+        flags: u32,
+    ) -> io::Result<usize> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.write(
+                ctx,
+                inode,
+                handle,
+                r,
+                size,
+                offset,
+                lock_owner,
+                delayed_write,
+                kill_priv,
+                flags,
+            ),
+            FsImpl::Overlayfs(fs) => fs.write(
+                ctx,
+                inode,
+                handle,
+                r,
+                size,
+                offset,
+                lock_owner,
+                delayed_write,
+                kill_priv,
+                flags,
+            ),
+        }
+    }
+
+    fn flush(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        lock_owner: u64,
+    ) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.flush(ctx, inode, handle, lock_owner),
+            FsImpl::Overlayfs(fs) => fs.flush(ctx, inode, handle, lock_owner),
+        }
+    }
+
+    fn fsync(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        datasync: bool,
+        handle: Self::Handle,
+    ) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.fsync(ctx, inode, datasync, handle),
+            FsImpl::Overlayfs(fs) => fs.fsync(ctx, inode, datasync, handle),
+        }
+    }
+
+    fn fallocate(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        mode: u32,
+        offset: u64,
+        length: u64,
+    ) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.fallocate(ctx, inode, handle, mode, offset, length),
+            FsImpl::Overlayfs(fs) => fs.fallocate(ctx, inode, handle, mode, offset, length),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn release(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        flags: u32,
+        handle: Self::Handle,
+        flush: bool,
+        flock_release: bool,
+        lock_owner: Option<u64>,
+    ) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => {
+                fs.release(ctx, inode, flags, handle, flush, flock_release, lock_owner)
+            }
+            FsImpl::Overlayfs(fs) => {
+                fs.release(ctx, inode, flags, handle, flush, flock_release, lock_owner)
+            }
+        }
+    }
+
+    fn statfs(&self, ctx: Context, inode: Self::Inode) -> io::Result<bindings::statvfs64> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.statfs(ctx, inode),
+            FsImpl::Overlayfs(fs) => fs.statfs(ctx, inode),
+        }
+    }
+
+    fn setxattr(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        name: &CStr,
+        value: &[u8],
+        flags: u32,
+    ) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.setxattr(ctx, inode, name, value, flags),
+            FsImpl::Overlayfs(fs) => fs.setxattr(ctx, inode, name, value, flags),
+        }
+    }
+
+    fn getxattr(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        name: &CStr,
+        size: u32,
+    ) -> io::Result<GetxattrReply> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.getxattr(ctx, inode, name, size),
+            FsImpl::Overlayfs(fs) => fs.getxattr(ctx, inode, name, size),
+        }
+    }
+
+    fn listxattr(&self, ctx: Context, inode: Self::Inode, size: u32) -> io::Result<ListxattrReply> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.listxattr(ctx, inode, size),
+            FsImpl::Overlayfs(fs) => fs.listxattr(ctx, inode, size),
+        }
+    }
+
+    fn removexattr(&self, ctx: Context, inode: Self::Inode, name: &CStr) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.removexattr(ctx, inode, name),
+            FsImpl::Overlayfs(fs) => fs.removexattr(ctx, inode, name),
+        }
+    }
+
+    fn opendir(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        flags: u32,
+    ) -> io::Result<(Option<Self::Handle>, OpenOptions)> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.opendir(ctx, inode, flags),
+            FsImpl::Overlayfs(fs) => fs.opendir(ctx, inode, flags),
+        }
+    }
+
+    fn readdir<F>(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        size: u32,
+        offset: u64,
+        add_entry: F,
+    ) -> io::Result<()>
+    where
+        F: FnMut(DirEntry) -> io::Result<usize>,
+    {
+        match self {
+            FsImpl::Passthrough(fs) => fs.readdir(ctx, inode, handle, size, offset, add_entry),
+            FsImpl::Overlayfs(fs) => fs.readdir(ctx, inode, handle, size, offset, add_entry),
+        }
+    }
+
+    fn readdirplus<F>(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        size: u32,
+        offset: u64,
+        add_entry: F,
+    ) -> io::Result<()>
+    where
+        F: FnMut(DirEntry, Entry) -> io::Result<usize>,
+    {
+        match self {
+            FsImpl::Passthrough(fs) => fs.readdirplus(ctx, inode, handle, size, offset, add_entry),
+            FsImpl::Overlayfs(fs) => fs.readdirplus(ctx, inode, handle, size, offset, add_entry),
+        }
+    }
+
+    fn fsyncdir(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        datasync: bool,
+        handle: Self::Handle,
+    ) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.fsyncdir(ctx, inode, datasync, handle),
+            FsImpl::Overlayfs(fs) => fs.fsyncdir(ctx, inode, datasync, handle),
+        }
+    }
+
+    fn releasedir(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        flags: u32,
+        handle: Self::Handle,
+    ) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.releasedir(ctx, inode, flags, handle),
+            FsImpl::Overlayfs(fs) => fs.releasedir(ctx, inode, flags, handle),
+        }
+    }
+
+    fn access(&self, ctx: Context, inode: Self::Inode, mask: u32) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.access(ctx, inode, mask),
+            FsImpl::Overlayfs(fs) => fs.access(ctx, inode, mask),
+        }
+    }
+
+    fn lseek(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        offset: u64,
+        whence: u32,
+    ) -> io::Result<u64> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.lseek(ctx, inode, handle, offset, whence),
+            FsImpl::Overlayfs(fs) => fs.lseek(ctx, inode, handle, offset, whence),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn copyfilerange(
+        &self,
+        ctx: Context,
+        inode_in: Self::Inode,
+        handle_in: Self::Handle,
+        offset_in: u64,
+        inode_out: Self::Inode,
+        handle_out: Self::Handle,
+        offset_out: u64,
+        len: u64,
+        flags: u64,
+    ) -> io::Result<usize> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.copyfilerange(
+                ctx, inode_in, handle_in, offset_in, inode_out, handle_out, offset_out, len, flags,
+            ),
+            FsImpl::Overlayfs(fs) => fs.copyfilerange(
+                ctx, inode_in, handle_in, offset_in, inode_out, handle_out, offset_out, len, flags,
+            ),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn setupmapping(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        foffset: u64,
+        len: u64,
+        flags: u64,
+        moffset: u64,
+        host_shm_base: u64,
+        shm_size: u64,
+        #[cfg(target_os = "macos")] map_sender: &Option<Sender<MemoryMapping>>,
+    ) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.setupmapping(
+                ctx,
+                inode,
+                handle,
+                foffset,
+                len,
+                flags,
+                moffset,
+                host_shm_base,
+                shm_size,
+                map_sender,
+            ),
+            FsImpl::Overlayfs(fs) => fs.setupmapping(
+                ctx,
+                inode,
+                handle,
+                foffset,
+                len,
+                flags,
+                moffset,
+                host_shm_base,
+                shm_size,
+                map_sender,
+            ),
+        }
+    }
+
+    fn removemapping(
+        &self,
+        ctx: Context,
+        requests: Vec<RemovemappingOne>,
+        host_shm_base: u64,
+        shm_size: u64,
+        #[cfg(target_os = "macos")] map_sender: &Option<Sender<MemoryMapping>>,
+    ) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => {
+                fs.removemapping(ctx, requests, host_shm_base, shm_size, map_sender)
+            }
+            FsImpl::Overlayfs(fs) => {
+                fs.removemapping(ctx, requests, host_shm_base, shm_size, map_sender)
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn ioctl(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        flags: u32,
+        cmd: u32,
+        arg: u64,
+        in_size: u32,
+        out_size: u32,
+    ) -> io::Result<Vec<u8>> {
+        match self {
+            FsImpl::Passthrough(fs) => {
+                fs.ioctl(ctx, inode, handle, flags, cmd, arg, in_size, out_size)
+            }
+            FsImpl::Overlayfs(fs) => {
+                fs.ioctl(ctx, inode, handle, flags, cmd, arg, in_size, out_size)
+            }
+        }
+    }
+
+    fn getlk(&self) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.getlk(),
+            FsImpl::Overlayfs(fs) => fs.getlk(),
+        }
+    }
+
+    fn setlk(&self) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.setlk(),
+            FsImpl::Overlayfs(fs) => fs.setlk(),
+        }
+    }
+
+    fn setlkw(&self) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.setlkw(),
+            FsImpl::Overlayfs(fs) => fs.setlkw(),
+        }
+    }
+
+    fn bmap(&self) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.bmap(),
+            FsImpl::Overlayfs(fs) => fs.bmap(),
+        }
+    }
+
+    fn poll(&self) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.poll(),
+            FsImpl::Overlayfs(fs) => fs.poll(),
+        }
+    }
+
+    fn notify_reply(&self) -> io::Result<()> {
+        match self {
+            FsImpl::Passthrough(fs) => fs.notify_reply(),
+            FsImpl::Overlayfs(fs) => fs.notify_reply(),
+        }
+    }
+}

--- a/src/devices/src/virtio/fs/macos/overlayfs/fs.rs
+++ b/src/devices/src/virtio/fs/macos/overlayfs/fs.rs
@@ -2970,7 +2970,6 @@ impl FileSystem for OverlayFs {
     ) -> io::Result<usize> {
         #[cfg(not(feature = "efi"))]
         if inode == self.init_inode {
-            println!("init inode");
             return w.write(&INIT_BINARY[offset as usize..(offset + (size as u64)) as usize]);
         }
 
@@ -3158,8 +3157,6 @@ impl FileSystem for OverlayFs {
         let c_path = self.inode_number_to_vol_path(inode)?;
 
         let st = Self::patched_stat(&FileId::Path(c_path))?;
-
-        println!("st: {:?}", st);
 
         let mode = mask as i32 & (libc::R_OK | libc::W_OK | libc::X_OK);
 

--- a/src/devices/src/virtio/fs/macos/overlayfs/tests.rs
+++ b/src/devices/src/virtio/fs/macos/overlayfs/tests.rs
@@ -154,8 +154,12 @@ mod helper {
             temp_dirs.push(temp_dir);
         }
 
-        let cfg = Config::default();
-        let overlayfs = OverlayFs::new(layer_paths, cfg)?;
+        let cfg = Config {
+            layers: layer_paths,
+            ..Default::default()
+        };
+        
+        let overlayfs = OverlayFs::new(cfg)?;
         Ok((overlayfs, temp_dirs))
     }
 

--- a/src/devices/src/virtio/fs/macos/overlayfs/tests/create.rs
+++ b/src/devices/src/virtio/fs/macos/overlayfs/tests/create.rs
@@ -1,10 +1,4 @@
-use std::{
-    ffi::CString,
-    fs::{self, FileType},
-    io,
-    os::unix::fs::FileTypeExt,
-    path::Path,
-};
+use std::{ffi::CString, fs, io};
 
 use crate::virtio::{
     bindings,
@@ -1409,12 +1403,12 @@ fn test_mknod_basic() -> io::Result<()> {
     let ctx = Context::default();
 
     // Test creating different types of nodes
-    let test_cases: Vec<(&str, u32, &str)> = vec![
-        ("fifo1", libc::S_IFIFO as u32 | 0o644, "named pipe"),
-        ("sock1", libc::S_IFSOCK as u32 | 0o644, "unix domain socket"),
+    let test_cases: Vec<(&str, u32)> = vec![
+        ("fifo1", libc::S_IFIFO as u32 | 0o644),
+        ("sock1", libc::S_IFSOCK as u32 | 0o644),
     ];
 
-    for (name, mode, node_type) in test_cases {
+    for (name, mode) in test_cases {
         let node_name = CString::new(name).unwrap();
         let entry = fs.mknod(ctx, 1, &node_name, mode, 0, 0o022, Extensions::default())?;
 

--- a/src/devices/src/virtio/fs/macos/overlayfs/tests/metadata.rs
+++ b/src/devices/src/virtio/fs/macos/overlayfs/tests/metadata.rs
@@ -1,6 +1,12 @@
 use std::{collections::HashSet, ffi::CString, fs, io};
 
-use crate::virtio::{bindings::{self, LINUX_ENODATA, LINUX_ENOSYS}, fs::filesystem::{Context, FileSystem, GetxattrReply, ListxattrReply}, fuse::{FsOptions, SetattrValid}, linux_errno::LINUX_ERANGE, macos::overlayfs::{Config, OverlayFs}};
+use crate::virtio::{
+    bindings::{self, LINUX_ENODATA, LINUX_ENOSYS},
+    fs::filesystem::{Context, FileSystem, GetxattrReply, ListxattrReply},
+    fuse::{FsOptions, SetattrValid},
+    linux_errno::LINUX_ERANGE,
+    macos::overlayfs::{Config, OverlayFs},
+};
 
 use super::helper;
 
@@ -508,7 +514,9 @@ fn test_xattrs() -> io::Result<()> {
         .map(|dir| dir.path().to_path_buf())
         .collect::<Vec<_>>();
 
-    let overlayfs = OverlayFs::new(layer_paths, cfg)?;
+    cfg.layers = layer_paths;
+
+    let overlayfs = OverlayFs::new(cfg)?;
     helper::debug_print_layers(&temp_dirs, false)?;
 
     // Initialize filesystem
@@ -836,14 +844,12 @@ fn test_xattrs() -> io::Result<()> {
     // Create a new overlayfs with xattr disabled
     let mut cfg_no_xattr = Config::default();
     cfg_no_xattr.xattr = false;
+    cfg_no_xattr.layers = temp_dirs
+        .iter()
+        .map(|dir| dir.path().to_path_buf())
+        .collect();
 
-    let overlayfs_no_xattr = OverlayFs::new(
-        temp_dirs
-            .iter()
-            .map(|dir| dir.path().to_path_buf())
-            .collect(),
-        cfg_no_xattr,
-    )?;
+    let overlayfs_no_xattr = OverlayFs::new(cfg_no_xattr)?;
 
     overlayfs_no_xattr.init(FsOptions::empty())?;
 

--- a/src/devices/src/virtio/fs/macos/overlayfs/tests/open.rs
+++ b/src/devices/src/virtio/fs/macos/overlayfs/tests/open.rs
@@ -127,8 +127,6 @@ fn test_open_whiteout() -> io::Result<()> {
     // Verify lookup fails
     assert!(result.is_err());
 
-    // Since we can't directly check the error code with assert_eq! due to Debug trait issues,
-    // we'll just verify the file doesn't exist by trying to open a non-existent inode
     let non_existent_inode = 999; // Use a high number that shouldn't exist
     let open_result = fs.open(ctx, non_existent_inode, libc::O_RDONLY as u32);
     assert!(open_result.is_err());

--- a/src/devices/src/virtio/fs/mod.rs
+++ b/src/devices/src/virtio/fs/mod.rs
@@ -1,10 +1,11 @@
 mod device;
 #[allow(dead_code)]
 mod filesystem;
+mod server;
 pub mod fuse;
+mod kinds;
 #[allow(dead_code)]
 mod multikey;
-mod server;
 mod worker;
 
 #[cfg(target_os = "linux")]
@@ -15,8 +16,11 @@ pub use linux::fs_utils;
 pub use linux::passthrough;
 #[cfg(target_os = "macos")]
 pub mod macos;
+pub use kinds::*;
 #[cfg(target_os = "macos")]
 pub use macos::fs_utils;
+#[cfg(target_os = "macos")]
+pub use macos::overlayfs;
 #[cfg(target_os = "macos")]
 pub use macos::passthrough;
 

--- a/src/devices/src/virtio/fs/server.rs
+++ b/src/devices/src/virtio/fs/server.rs
@@ -1,7 +1,3 @@
-// Copyright 2019 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 #[cfg(target_os = "macos")]
 use crossbeam_channel::Sender;
 #[cfg(target_os = "macos")]
@@ -17,61 +13,47 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use vm_memory::ByteValued;
 
 use super::super::linux_errno::linux_error;
-use super::bindings;
 use super::descriptor_utils::{Reader, Writer};
-use super::filesystem::{
-    Context, DirEntry, Entry, Extensions, FileSystem, GetxattrReply, ListxattrReply, SecContext,
-    ZeroCopyReader, ZeroCopyWriter,
-};
+use super::filesystem::{Context, DirEntry, Entry, Extensions, FileSystem, GetxattrReply, ListxattrReply, SecContext, ZeroCopyReader, ZeroCopyWriter};
 use super::fs_utils::einval;
 use super::fuse::*;
+use super::{bindings, FsImpl};
 use super::{FsError as Error, Result};
 use crate::virtio::VirtioShmRegion;
 
-const MAX_BUFFER_SIZE: u32 = 1 << 20;
-const BUFFER_HEADER_SIZE: u32 = 0x1000;
-const DIRENT_PADDING: [u8; 8] = [0; 8];
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
 
-struct ZCReader<'a>(Reader<'a>);
+pub(super) const MAX_BUFFER_SIZE: u32 = 1 << 20;
+pub(super) const BUFFER_HEADER_SIZE: u32 = 0x1000;
+pub(super) const DIRENT_PADDING: [u8; 8] = [0; 8];
 
-impl ZeroCopyReader for ZCReader<'_> {
-    fn read_to(&mut self, f: &File, count: usize, off: u64) -> io::Result<usize> {
-        self.0.read_to_at(f, count, off)
-    }
-}
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
 
-impl io::Read for ZCReader<'_> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.0.read(buf)
-    }
-}
-
-struct ZCWriter<'a>(Writer<'a>);
-
-impl ZeroCopyWriter for ZCWriter<'_> {
-    fn write_from(&mut self, f: &File, count: usize, off: u64) -> io::Result<usize> {
-        self.0.write_from_at(f, count, off)
-    }
-}
-
-impl io::Write for ZCWriter<'_> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.0.flush()
-    }
-}
-
-pub struct Server<F: FileSystem + Sync> {
-    fs: F,
+/// `FsImplServer` is a concrete FUSE server implementation designed to work with specific
+/// filesystem implementations provided by libkrun, particularly:
+///
+/// - [`PassthroughFs`]: For direct passthrough access to the host filesystem
+/// - [`OverlayFs`]: For overlayfs functionality to combine multiple filesystem layers
+pub struct FsImplServer {
+    fs: FsImpl,
     options: AtomicU64,
 }
 
-impl<F: FileSystem + Sync> Server<F> {
-    pub fn new(fs: F) -> Server<F> {
-        Server {
+struct ZCReader<'a>(Reader<'a>);
+
+struct ZCWriter<'a>(Writer<'a>);
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl FsImplServer {
+    pub fn new(fs: FsImpl) -> FsImplServer {
+        FsImplServer {
             fs,
             options: AtomicU64::new(FsOptions::empty().bits()),
         }
@@ -94,7 +76,7 @@ impl<F: FileSystem + Sync> Server<F> {
                 w,
             );
         }
-        debug!("opcode: {}", in_header.opcode);
+
         match in_header.opcode {
             x if x == Opcode::Lookup as u32 => self.lookup(in_header, r, w),
             x if x == Opcode::Forget as u32 => self.forget(in_header, r), // No reply.
@@ -1408,6 +1390,42 @@ impl<F: FileSystem + Sync> Server<F> {
         }
     }
 }
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl ZeroCopyReader for ZCReader<'_> {
+    fn read_to(&mut self, f: &File, count: usize, off: u64) -> io::Result<usize> {
+        self.0.read_to_at(f, count, off)
+    }
+}
+
+impl io::Read for ZCReader<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl ZeroCopyWriter for ZCWriter<'_> {
+    fn write_from(&mut self, f: &File, count: usize, off: u64) -> io::Result<usize> {
+        self.0.write_from_at(f, count, off)
+    }
+}
+
+impl io::Write for ZCWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
 
 fn reply_ok<T: ByteValued>(
     out: Option<T>,

--- a/src/devices/src/virtio/fs/worker.rs
+++ b/src/devices/src/virtio/fs/worker.rs
@@ -15,8 +15,10 @@ use vm_memory::GuestMemoryMmap;
 use super::super::{FsError, Queue, VIRTIO_MMIO_INT_VRING};
 use super::defs::{HPQ_INDEX, REQ_INDEX};
 use super::descriptor_utils::{Reader, Writer};
-use super::passthrough::{self, PassthroughFs};
-use super::server::Server;
+use super::server::FsImplServer;
+use super::overlayfs::OverlayFs;
+use super::passthrough::PassthroughFs;
+use super::{FsImpl, FsImplConfig};
 use crate::legacy::GicV3;
 use crate::virtio::VirtioShmRegion;
 
@@ -30,7 +32,7 @@ pub struct FsWorker {
 
     mem: GuestMemoryMmap,
     shm_region: Option<VirtioShmRegion>,
-    server: Server<PassthroughFs>,
+    server: FsImplServer,
     stop_fd: EventFd,
     #[cfg(target_os = "macos")]
     map_sender: Option<Sender<MemoryMapping>>,
@@ -47,10 +49,19 @@ impl FsWorker {
         irq_line: Option<u32>,
         mem: GuestMemoryMmap,
         shm_region: Option<VirtioShmRegion>,
-        passthrough_cfg: passthrough::Config,
+        fs_config: FsImplConfig,
         stop_fd: EventFd,
         #[cfg(target_os = "macos")] map_sender: Option<Sender<MemoryMapping>>,
     ) -> Self {
+        let server = match fs_config {
+            FsImplConfig::Passthrough(passthrough_cfg) => FsImplServer::new(FsImpl::Passthrough(
+                PassthroughFs::new(passthrough_cfg).unwrap(),
+            )),
+            FsImplConfig::Overlayfs(overlayfs_cfg) => {
+                FsImplServer::new(FsImpl::Overlayfs(OverlayFs::new(overlayfs_cfg).unwrap()))
+            }
+        };
+
         Self {
             queues,
             queue_evts,
@@ -58,10 +69,9 @@ impl FsWorker {
             interrupt_evt,
             intc,
             irq_line,
-
             mem,
             shm_region,
-            server: Server::new(PassthroughFs::new(passthrough_cfg).unwrap()),
+            server,
             stop_fd,
             #[cfg(target_os = "macos")]
             map_sender,

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -20,6 +20,7 @@ use std::sync::Mutex;
 use crossbeam_channel::unbounded;
 #[cfg(feature = "blk")]
 use devices::virtio::block::ImageType;
+use devices::virtio::fs::FsImplShare;
 #[cfg(feature = "net")]
 use devices::virtio::net::device::VirtioNetBackend;
 #[cfg(feature = "blk")]
@@ -404,14 +405,76 @@ pub unsafe extern "C" fn krun_set_root(ctx_id: u32, c_root_path: *const c_char) 
     };
 
     let fs_id = "/dev/root".to_string();
-    let shared_dir = root_path.to_string();
+    let fs_share = FsImplShare::Passthrough(root_path.to_string());
 
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => {
             let cfg = ctx_cfg.get_mut();
+
+            // Check if root device is already set
+            for device in &cfg.vmr.fs {
+                if device.fs_id == fs_id {
+                    return -libc::EEXIST;
+                }
+            }
+
             cfg.vmr.add_fs_device(FsDeviceConfig {
                 fs_id,
-                shared_dir,
+                fs_share,
+                // Default to a conservative 512 MB window.
+                shm_size: Some(1 << 29),
+            });
+        }
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+
+    KRUN_SUCCESS
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+#[cfg(not(feature = "tee"))]
+pub unsafe extern "C" fn krun_set_overlayfs_root(
+    ctx_id: u32,
+    c_root_layers: *const *const c_char,
+) -> i32 {
+    let mut layers = Vec::new();
+    let layers_array: &[*const c_char] = slice::from_raw_parts(c_root_layers, MAX_ARGS);
+
+    for item in layers_array.iter().take(MAX_ARGS) {
+        if item.is_null() {
+            break;
+        } else {
+            let layer_path = match CStr::from_ptr(*item).to_str() {
+                Ok(path) => path,
+                Err(_) => return -libc::EINVAL,
+            };
+            layers.push(PathBuf::from(layer_path));
+        }
+    }
+
+    // Need at least one layer
+    if layers.is_empty() {
+        return -libc::EINVAL;
+    }
+
+    let fs_id = "/dev/root".to_string();
+    let fs_share = FsImplShare::Overlayfs(layers);
+
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => {
+            let cfg = ctx_cfg.get_mut();
+
+            // Check if root device is already set
+            for device in &cfg.vmr.fs {
+                if device.fs_id == fs_id {
+                    return -libc::EEXIST;
+                }
+            }
+
+            cfg.vmr.add_fs_device(FsDeviceConfig {
+                fs_id,
+                fs_share,
                 // Default to a conservative 512 MB window.
                 shm_size: Some(1 << 29),
             });
@@ -442,9 +505,18 @@ pub unsafe extern "C" fn krun_add_virtiofs(
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => {
             let cfg = ctx_cfg.get_mut();
+
+            // Check if a device with the same tag already exists
+            let fs_id = tag.to_string();
+            for device in &cfg.vmr.fs {
+                if device.fs_id == fs_id {
+                    return -libc::EEXIST;
+                }
+            }
+
             cfg.vmr.add_fs_device(FsDeviceConfig {
-                fs_id: tag.to_string(),
-                shared_dir: path.to_string(),
+                fs_id,
+                fs_share: FsImplShare::Passthrough(path.to_string()),
                 shm_size: None,
             });
         }
@@ -475,9 +547,18 @@ pub unsafe extern "C" fn krun_add_virtiofs2(
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => {
             let cfg = ctx_cfg.get_mut();
+
+            // Check if a device with the same tag already exists
+            let fs_id = tag.to_string();
+            for device in &cfg.vmr.fs {
+                if device.fs_id == fs_id {
+                    return -libc::EEXIST;
+                }
+            }
+
             cfg.vmr.add_fs_device(FsDeviceConfig {
-                fs_id: tag.to_string(),
-                shared_dir: path.to_string(),
+                fs_id,
+                fs_share: FsImplShare::Passthrough(path.to_string()),
                 shm_size: Some(shm_size.try_into().unwrap()),
             });
         }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1203,7 +1203,7 @@ fn attach_fs_devices(
 
     for (i, config) in fs_devs.iter().enumerate() {
         let fs = Arc::new(Mutex::new(
-            devices::virtio::Fs::new(config.fs_id.clone(), config.shared_dir.clone()).unwrap(),
+            devices::virtio::Fs::new(config.fs_id.clone(), config.fs_share.clone()).unwrap(),
         ));
 
         let id = format!("{}{}", String::from(fs.lock().unwrap().id()), i);

--- a/src/vmm/src/vmm_config/fs.rs
+++ b/src/vmm/src/vmm_config/fs.rs
@@ -1,6 +1,8 @@
+use devices::virtio::fs::FsImplShare;
+
 #[derive(Clone, Debug)]
 pub struct FsDeviceConfig {
     pub fs_id: String,
-    pub shared_dir: String,
+    pub fs_share: FsImplShare,
     pub shm_size: Option<usize>,
 }


### PR DESCRIPTION
Add public API for using OverlayFS functionality in libkrun on macOS by exposing the implementation through a new FsImplConfig enum. This allows clients to configure either passthrough or overlayfs filesystem modes.

Key changes:
- Add FsImplConfig enum to select between Passthrough and Overlayfs modes
- Add FsImplShare enum to handle different sharing configurations
- Refactor Fs implementation to delegate operations to selected backend
- Update Config struct to include layers configuration
- Clean up and reorganize filesystem server code
- Add comprehensive test coverage for overlayfs operations

The implementation maintains the existing passthrough functionality while adding the ability to configure overlayfs mode with multiple read-only layers and a writable top layer.