### PR TITLE
feat(net): Implement IP filtering for TSI backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
  "hvf",
  "imago",
  "intaglio",
+ "ipnetwork",
  "libc",
  "log",
  "lru",
@@ -707,6 +708,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8972d5be69940353d5347a1344cb375d9b457d6809b428b05bb1ca2fb9ce007"
 
 [[package]]
+name = "ipnetwork"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +803,7 @@ dependencies = [
  "devices",
  "env_logger",
  "hvf",
+ "ipnetwork",
  "libc",
  "log",
  "once_cell",
@@ -1663,6 +1671,7 @@ dependencies = [
  "devices",
  "env_logger",
  "hvf",
+ "ipnetwork",
  "kbs-types",
  "kernel",
  "kvm-bindings",

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -318,6 +318,30 @@ int32_t krun_set_net_mac(uint32_t ctx_id, uint8_t *const c_mac);
  */
 int32_t krun_set_port_map(uint32_t ctx_id, const char *const port_map[]);
 
+/**
+ * Configures the static IP, subnet, and reachability mode for the TSI network backend.
+ *
+ * Arguments:
+ *  "ctx_id"   - the configuration context ID.
+ *  "c_ip"     - an optional null-terminated string representing the guest's static IPv4 address.
+ *  "c_subnet" - an optional null-terminated string representing the guest's subnet in CIDR notation (e.g., "192.168.1.0/24").
+ *  "reach"    - an integer specifying the reachability mode (0-3). Refer to TSI documentation for details.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ *  Documented errors:
+ *       -EINVAL if reach value is > 3 or IP/subnet strings are invalid.
+ *       -ENOTSUP if the network mode is not TSI.
+ *
+ * Notes:
+ *  This function is only effective when the default TSI network backend is used (i.e., neither
+ *  krun_set_passt_fd nor krun_set_gvproxy_path has been called).
+ */
+int32_t krun_set_tsi_reach(uint32_t ctx_id,
+                           const char *c_ip,
+                           const char *c_subnet,
+                           uint8_t reach);
+
 /* Flags for virglrenderer.  Copied from virglrenderer bindings. */
 #define VIRGLRENDERER_USE_EGL 1 << 0
 #define VIRGLRENDERER_THREAD_SYNC 1 << 1

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -319,28 +319,28 @@ int32_t krun_set_net_mac(uint32_t ctx_id, uint8_t *const c_mac);
 int32_t krun_set_port_map(uint32_t ctx_id, const char *const port_map[]);
 
 /**
- * Configures the static IP, subnet, and reachability mode for the TSI network backend.
+ * Configures the static IP, subnet, and scope for the TSI network backend.
  *
  * Arguments:
  *  "ctx_id"   - the configuration context ID.
  *  "c_ip"     - an optional null-terminated string representing the guest's static IPv4 address.
  *  "c_subnet" - an optional null-terminated string representing the guest's subnet in CIDR notation (e.g., "192.168.1.0/24").
- *  "reach"    - an integer specifying the reachability mode (0-3). Refer to TSI documentation for details.
+ *  "scope"    - an integer specifying the scope (0-3). Refer to TSI documentation for details.
  *
  * Returns:
  *  Zero on success or a negative error number on failure.
  *  Documented errors:
- *       -EINVAL if reach value is > 3 or IP/subnet strings are invalid.
+ *       -EINVAL if scope value is > 3 or IP/subnet strings are invalid.
  *       -ENOTSUP if the network mode is not TSI.
  *
  * Notes:
  *  This function is only effective when the default TSI network backend is used (i.e., neither
  *  krun_set_passt_fd nor krun_set_gvproxy_path has been called).
  */
-int32_t krun_set_tsi_reach(uint32_t ctx_id,
+int32_t krun_set_tsi_scope(uint32_t ctx_id,
                            const char *c_ip,
                            const char *c_subnet,
-                           uint8_t reach);
+                           uint8_t scope);
 
 /* Flags for virglrenderer.  Copied from virglrenderer bindings. */
 #define VIRGLRENDERER_USE_EGL 1 << 0

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -29,6 +29,7 @@ virtio-bindings = "0.2.0"
 vm-memory = { version = ">=0.13", features = ["backend-mmap"] }
 zerocopy = { version = "0.6.3", optional = true }
 zerocopy-derive = { version = "0.6.3", optional = true }
+ipnetwork = "0.21"
 
 arch = { path = "../arch" }
 utils = { path = "../utils" }

--- a/src/devices/src/virtio/vsock/ip_filter.rs
+++ b/src/devices/src/virtio/vsock/ip_filter.rs
@@ -1,0 +1,93 @@
+use ipnetwork::Ipv4Network;
+use std::net::Ipv4Addr;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Configuration for IP-based filtering in the Vsock Muxer.
+#[derive(Clone, Debug)]
+pub struct IpFilterConfig {
+    /// Defines the scope of allowed connections/bindings.
+    /// 0: None (Block all IP communication)
+    /// 1: Group (Allow within `subnet`, bind only to `ip` if specified)
+    /// 2: Public (Allow public IPs, bind only to `ip` if specified)
+    /// 3: Any (Allow any IP, bind only to `ip` if specified)
+    pub scope: u8,
+
+    /// If specified, binding/listening is ONLY allowed on this specific IP address
+    /// (ignored if scope is 0).
+    pub ip: Option<Ipv4Addr>,
+
+    /// The allowed subnet for Scope 1 (Group). Required if scope is 1.
+    pub subnet: Option<Ipv4Network>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl IpFilterConfig {
+    /// Checks if the configuration is logically valid.
+    pub fn is_valid(&self) -> bool {
+        match self.scope {
+            0 | 2 | 3 => true, // Scopes 0, 2, 3 are valid without extra checks (ip is optional)
+            1 => self.subnet.is_some(), // Scope 1 requires a subnet
+            _ => false, // Invalid scope number
+        }
+    }
+
+    /// Checks if an IP address is considered private.
+    /// (Includes loopback, private ranges, link-local, broadcast, documentation, shared CGN)
+    fn is_private(ip: Ipv4Addr) -> bool {
+        ip.is_loopback()
+            || ip.is_private()
+            || ip.is_link_local()
+            || ip.is_broadcast()
+            || ip.is_documentation()
+            || match ip.octets() {
+                [100, b, _, _] if b >= 64 && b <= 127 => true, // Shared Address Space (RFC 6598)
+                _ => false,
+            }
+    }
+
+    /// Checks if connecting to a given destination IP is allowed by the filter rules.
+    pub fn is_allowed_connect(&self, dest_ip: Ipv4Addr) -> bool {
+        match self.scope {
+            0 => false, // Scope 0: Deny all connections
+            1 => {
+                // Scope 1: Group - Allow connection only if dest_ip is within the specified subnet
+                self.subnet.map_or(false, |subnet| subnet.contains(dest_ip))
+            }
+            2 => {
+                // Scope 2: Public - Allow connection only if dest_ip is NOT private
+                !Self::is_private(dest_ip)
+            }
+            3 => true, // Scope 3: Any - Allow connection to any IP
+            _ => false, // Invalid scope
+        }
+    }
+
+    /// Checks if binding to a given IP is allowed by the filter rules.
+    pub fn is_allowed_bind(&self, bind_ip: Ipv4Addr) -> bool {
+        if self.scope == 0 {
+            return false; // Scope 0: Deny all binding
+        }
+
+        // Rule: "if ip specified, only the ip can be bound to or listened on."
+        if let Some(allowed_bind_ip) = self.ip {
+            return bind_ip == allowed_bind_ip;
+        }
+
+        // No specific IP specified, check based on scope rules for the bind_ip itself
+        match self.scope {
+            // Scope 1: Group - Allow binding within the subnet if no specific IP given
+            1 => self.subnet.map_or(false, |subnet| subnet.contains(bind_ip)),
+            // Scope 2: Public - Allow binding to public IPs if no specific IP given
+            2 => !Self::is_private(bind_ip),
+            // Scope 3: Any - Allow binding to any IP if no specific IP given
+            3 => true,
+            _ => false, // Invalid scope (scope 0 already handled)
+        }
+    }
+}

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -19,6 +19,7 @@ mod tcp;
 mod timesync;
 mod udp;
 mod unix;
+mod ip_filter;
 
 pub use self::defs::uapi::VIRTIO_ID_VSOCK as TYPE_VSOCK;
 pub use self::device::Vsock;

--- a/src/devices/src/virtio/vsock/muxer.rs
+++ b/src/devices/src/virtio/vsock/muxer.rs
@@ -27,6 +27,8 @@ use vm_memory::GuestMemoryMmap;
 
 use std::net::Ipv4Addr;
 
+use super::ip_filter::IpFilterConfig;
+
 pub type ProxyMap = Arc<RwLock<HashMap<u64, Mutex<Box<dyn Proxy>>>>>;
 
 /// A muxer RX queue item.
@@ -112,6 +114,7 @@ pub struct VsockMuxer {
     proxy_map: ProxyMap,
     reaper_sender: Option<Sender<u64>>,
     unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
+    ip_filter: IpFilterConfig,
 }
 
 impl VsockMuxer {
@@ -121,7 +124,12 @@ impl VsockMuxer {
         interrupt_evt: EventFd,
         interrupt_status: Arc<AtomicUsize>,
         unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
+        ip_filter: IpFilterConfig,
     ) -> Self {
+        if !ip_filter.is_valid() {
+            warn!("Invalid IpFilterConfig provided during VsockMuxer creation: {:?}. Check configuration.", ip_filter);
+        }
+
         VsockMuxer {
             cid,
             host_port_map,
@@ -136,6 +144,7 @@ impl VsockMuxer {
             proxy_map: Arc::new(RwLock::new(HashMap::new())),
             reaper_sender: None,
             unix_ipc_port_map,
+            ip_filter,
         }
     }
 
@@ -321,6 +330,15 @@ impl VsockMuxer {
     fn process_connect(&self, pkt: &VsockPacket) {
         debug!("vsock: proxy connect request");
         if let Some(req) = pkt.read_connect_req() {
+            if !self.check_destination_ip(req.addr) {
+                warn!(
+                    "vsock: connect filtered: connection from guest:{}:{} to host:{} denied by IP filter rules",
+                    pkt.src_cid(), pkt.src_port(), req.addr
+                );
+                self.send_connect_rsp(pkt.src_port(), pkt.dst_port(), -libc::ECONNREFUSED);
+                return;
+            }
+
             let id = (req.peer_port as u64) << 32 | defs::TSI_PROXY_PORT as u64;
             debug!("vsock: proxy connect request: id={}", id);
             let update = self
@@ -333,6 +351,9 @@ impl VsockMuxer {
             if let Some(update) = update {
                 self.process_proxy_update(id, update);
             }
+        } else {
+            warn!("vsock: could not parse connect request buffer for filtering");
+            self.send_connect_rsp(pkt.src_port(), pkt.dst_port(), -libc::EINVAL);
         }
     }
 
@@ -354,6 +375,17 @@ impl VsockMuxer {
     fn process_sendto_addr(&self, pkt: &VsockPacket) {
         debug!("vsock: new DGRAM sendto addr: src={}", pkt.src_port());
         if let Some(req) = pkt.read_sendto_addr() {
+            if !self.check_destination_ip(req.addr) {
+                warn!(
+                    "vsock: sendto_addr filtered: send from guest:{}:{} to host:{} denied by IP filter rules",
+                    pkt.src_cid(), pkt.src_port(), req.addr
+                );
+
+                // Send error response back to the guest
+                self.send_sendto_addr_error_rsp(pkt.src_port(), -libc::ECONNREFUSED);
+                return;
+            }
+
             let id = (req.peer_port as u64) << 32 | defs::TSI_PROXY_PORT as u64;
             debug!("vsock: new DGRAM sendto addr: id={}", id);
             let update = self
@@ -380,6 +412,15 @@ impl VsockMuxer {
     fn process_listen_request(&self, pkt: &VsockPacket) {
         debug!("vsock: DGRAM listen request: src={}", pkt.src_port());
         if let Some(req) = pkt.read_listen_req() {
+            if !self.check_bind_ip(req.addr) {
+                warn!(
+                    "vsock: listen filtered: attempt to listen on host:{} from guest:{}:{} denied by IP filter rules",
+                    req.addr, pkt.src_cid(), pkt.src_port()
+                );
+                self.send_listen_rsp(pkt.src_port(), pkt.dst_port(), -libc::EACCES);
+                return;
+            }
+
             let id = (req.peer_port as u64) << 32 | defs::TSI_PROXY_PORT as u64;
             debug!("vsock: DGRAM listen request: id={}", id);
             let update = self
@@ -667,5 +708,83 @@ impl VsockMuxer {
             _ => warn!("stream: unhandled op={}", pkt.op()),
         }
         Ok(())
+    }
+
+    #[inline]
+    fn check_destination_ip(&self, dest_ip: Ipv4Addr) -> bool {
+        self.ip_filter.is_allowed_connect(dest_ip)
+    }
+
+    #[inline]
+    fn check_bind_ip(&self, bind_ip: Ipv4Addr) -> bool {
+        self.ip_filter.is_allowed_bind(bind_ip)
+    }
+
+    // Helper function to send different types of responses back to the guest
+    fn send_response(&self, rx: MuxerRx) {
+        // Get references to the needed components
+        let mem = match self.mem.as_ref() {
+            Some(m) => m,
+            None => {
+                error!("vsock: cannot send response: mem is None");
+                return;
+            }
+        };
+        let queue = match self.queue.as_ref() {
+            Some(q) => q,
+            None => {
+                error!("vsock: cannot send response: queue is None");
+                return;
+            }
+        };
+
+        // Send the response to the guest
+        push_packet(self.cid, rx, &self.rxq, queue, mem);
+    }
+
+    // Helper function for sending sendto_addr error responses
+    fn send_sendto_addr_error_rsp(&self, peer_port: u32, result: i32) {
+        debug!(
+            "vsock: sending sendto_addr error response: peer_port={}, result={}",
+            peer_port, result
+        );
+
+        // This response goes to the control port (DGRAM)
+        let rx = MuxerRx::ConnResponse {
+            local_port: defs::TSI_SENDTO_ADDR,
+            peer_port,
+            result,
+        };
+        self.send_response(rx);
+    }
+
+    fn send_connect_rsp(&self, local_port: u32, peer_port: u32, result: i32) {
+        debug!(
+            "vsock: sending connect response: local_port={}, peer_port={}, result={}",
+            local_port, peer_port, result
+        );
+
+        // This response goes to the control port (DGRAM)
+        let rx = MuxerRx::ConnResponse {
+            local_port: defs::TSI_CONNECT, // TSI_CONNECT = 1025
+            peer_port,
+            result,
+        };
+        self.send_response(rx);
+    }
+
+    fn send_listen_rsp(&self, local_port: u32, peer_port: u32, result: i32) {
+        debug!(
+            "vsock: sending listen response: local_port={}, peer_port={}, result={}",
+            local_port, peer_port, result
+        );
+
+        // This response goes to the control port (DGRAM)
+        let rx = MuxerRx::ListenResponse {
+            local_port: defs::TSI_LISTEN, // TSI_LISTEN = 1029
+            peer_port,
+            result,
+        };
+        self.send_response(rx);
     }
 }

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -21,6 +21,7 @@ env_logger = "0.9.0"
 libc = ">=0.2.39"
 log = "0.4.0"
 once_cell = "1.4.1"
+ipnetwork = "0.21"
 
 devices = { path = "../devices" }
 polly = { path = "../polly" }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = { version = "1.0.64", optional = true }
 sev = { version = "4.0.0", features = ["openssl"], optional = true }
 curl = { version = "0.4", optional = true }
 nix = "0.24.1"
+ipnetwork = "0.21"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 cpuid = { path = "../cpuid" }


### PR DESCRIPTION
This commit introduces IP-based filtering capabilities for the default TSI (Transparent Socket Impersonation) network backend in libkrun.

A new C API function, `krun_set_tsi_scope`, allows users to configure:
- An optional static IP address for the guest within the host network namespace. If specified, the guest can only bind/listen on this IP.
- An optional subnet (in CIDR notation) defining the allowed communication group when scope 1 is used.
- A reachability scope (0-3) controlling network access:
    - 0: Deny all IP communication.
    - 1: Allow communication only within the specified `subnet`.
    - 2: Allow communication only with public (non-private) IPs.
    - 3: Allow communication with any IP.

The filtering logic is implemented in `src/devices/src/virtio/vsock/ip_filter.rs` and integrated into the `VsockMuxer`. It checks destination IPs for connect/sendto operations and bind IPs for listen operations against the configured rules. If an operation is denied, an appropriate error (ECONNREFUSED or EACCES) is sent back to the guest via a vsock control message.

This feature enhances security by allowing finer-grained control over the network connectivity of krun virtual machines when using the TSI backend.

Changes include:
- Added `krun_set_tsi_scope` to `libkrun.h` and implementation in `lib.rs`.
- Added `ipnetwork` dependency to relevant Cargo.toml files.
- Created `ip_filter.rs` module for filtering logic.
- Updated `Vsock` device, `VsockMuxer`, and `VsockDeviceConfig` to handle IP, subnet, and scope configuration.
- Integrated filtering checks into `VsockMuxer`'s packet processing methods.
- Added helper functions in `VsockMuxer` to send error responses to the guest.