### PR TITLE
feat(vsock): make subnet optional for Group scope IP filtering

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -325,7 +325,12 @@ int32_t krun_set_port_map(uint32_t ctx_id, const char *const port_map[]);
  *  "ctx_id"   - the configuration context ID.
  *  "c_ip"     - an optional null-terminated string representing the guest's static IPv4 address.
  *  "c_subnet" - an optional null-terminated string representing the guest's subnet in CIDR notation (e.g., "192.168.1.0/24").
- *  "scope"    - an integer specifying the scope (0-3). Refer to TSI documentation for details.
+ *               If scope is 1 and subnet is not provided, all connections will be blocked.
+ *  "scope"    - an integer specifying the scope (0-3):
+ *               0: None - Block all IP communication
+ *               1: Group - Allow within subnet (if specified; otherwise, block all like scope 0)
+ *               2: Public - Allow public IPs
+ *               3: Any - Allow any IP
  *
  * Returns:
  *  Zero on success or a negative error number on failure.

--- a/src/devices/src/virtio/vsock/muxer.rs
+++ b/src/devices/src/virtio/vsock/muxer.rs
@@ -127,7 +127,7 @@ impl VsockMuxer {
         ip_filter: IpFilterConfig,
     ) -> Self {
         if !ip_filter.is_valid() {
-            warn!("Invalid IpFilterConfig provided during VsockMuxer creation: {:?}. Check configuration.", ip_filter);
+            warn!("Invalid IpFilterConfig provided during VsockMuxer creation: {:?}. Scope value must be between 0 and 3.", ip_filter);
         }
 
         VsockMuxer {


### PR DESCRIPTION
When using scope 1 (Group) for IP filtering, subnet specification is now optional. If no subnet is provided, all connections will be blocked, matching scope 0 behavior. This provides more flexibility in network configuration while maintaining security.

- Update IpFilterConfig to make subnet optional for scope 1
- Modify is_valid() to accept scope 1 without subnet
- Update documentation in libkrun.h to clarify scope behaviors
- Improve warning message specificity in VsockMuxer creation