### PR TITLE
feat(fs): Add file-backed symlinks with stat virtualization for Linux

### DIFF
--- a/src/devices/src/virtio/fs/tests/overlayfs/create.rs
+++ b/src/devices/src/virtio/fs/tests/overlayfs/create.rs
@@ -821,7 +821,7 @@ fn test_symlink_nested() -> io::Result<()> {
         // On macOS, verify regular symlinks
         for (dir, link) in &[("dir1", "link_to_file1"), ("dir2", "link_to_file2"), ("dir3", "link_to_top_file")] {
             let link_path = top_layer.join(dir).join(link);
-            assert!(link_path.exists(), "{}/{} should exist", dir, link);
+            assert!(link_path.symlink_metadata().is_ok(), "{}/{} should exist", dir, link);
             
             let metadata = fs::symlink_metadata(&link_path)?;
             assert!(metadata.file_type().is_symlink(), 
@@ -999,7 +999,9 @@ fn test_symlink_multiple_layers() -> io::Result<()> {
     {
         for (link, target, description) in &test_cases {
             let link_path = top_layer.join(link);
-            assert!(link_path.exists(), 
+            // Use symlink_metadata to check if the symlink itself exists
+            // (not whether its target exists)
+            assert!(link_path.symlink_metadata().is_ok(), 
                 "{}: Symlink should exist in top layer", description);
             
             // Verify it's a regular symlink
@@ -1037,7 +1039,7 @@ fn test_symlink_multiple_layers() -> io::Result<()> {
     
     // Verify the symlink was created in the top layer's shared_dir
     let shared_link_path = top_layer.join("shared_dir/shared_link");
-    assert!(shared_link_path.exists(),
+    assert!(shared_link_path.symlink_metadata().is_ok(),
         "Symlink in shared directory should exist in top layer");
     
     let shared_target_read = fs.readlink(ctx, shared_link_entry.inode)?;

--- a/src/devices/src/virtio/fs/tests/overlayfs/mod.rs
+++ b/src/devices/src/virtio/fs/tests/overlayfs/mod.rs
@@ -244,6 +244,10 @@ mod helper {
         let key_cstr = CString::new(key)?;
 
         let mut buf = vec![0u8; 256];
+        
+        // Check if path is a symlink to determine if we need XATTR_NOFOLLOW
+        let metadata = fs::symlink_metadata(path)?;
+        let is_symlink = metadata.file_type().is_symlink();
 
         #[cfg(target_os = "macos")]
         let res = unsafe {
@@ -253,7 +257,7 @@ mod helper {
                 buf.as_mut_ptr() as *mut libc::c_void,
                 buf.len(),
                 0,
-                0,
+                if is_symlink { libc::XATTR_NOFOLLOW } else { 0 },
             )
         };
 


### PR DESCRIPTION
## Summary

This PR implements a dual symlink representation system for Linux filesystems (overlayfs and passthrough) to enable stat virtualization on symlinks. This solves the limitation where many Linux filesystems don't support extended attributes on symlinks.

## Problem

On Linux, most filesystems (ext4, btrfs, etc.) don't support extended attributes on symlinks. This prevents us from virtualizing uid/gid/mode on symlinks, which is required for proper container filesystem isolation.

## Solution

Implemented a file-backed symlink representation that:
- Creates symlinks as regular files when stat virtualization is needed
- Stores the link target as file content
- Preserves the S_IFLNK file type in the override_stat xattr
- Remains transparent to the VFS layer - applications see normal symlinks

## Implementation Details

### Core Changes
- **Symlink Creation**: On Linux, symlinks are created as regular files (mode 0600) with the target path as content
- **Stat Override**: The xattr format `uid:gid:mode` preserves the S_IFLNK file type
- **Readlink Support**: Enhanced to detect and read file-backed symlinks transparently
- **Bug Fix**: Fixed readlink to use `/proc/self/fd/` for O_PATH file descriptors

### Platform Behavior
- **Linux**: Uses file-backed symlinks to support xattr-based stat virtualization
- **macOS**: Continues using regular symlinks (macOS supports xattrs on symlinks)

### Test Coverage
- Comprehensive test updates with platform-specific verification
- Tests for copy-up behavior, nested directories, and multiple layers
- Verification of xattr content and physical file representation
- All tests handle both symlink representations correctly
