### PR TITLE
feat(krun): add krunfw_path, Vm::enter(), version-pin deps, and Alpine rootfs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples/rust_vm/rootfs-alpine"]
+	path = examples/rust_vm/rootfs-alpine
+	url = https://github.com/zerocore-ai/rootfs-alpine

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,6 +1431,7 @@ dependencies = [
 name = "rust_vm"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
  "msb_krun",
 ]
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,7 +11,7 @@ CFLAGS = -O2 -g -I../include
 ROOTFS_DISTRO := fedora
 ROOTFS_DIR = rootfs_$(ROOTFS_DISTRO)
 
-.PHONY: clean rootfs
+.PHONY: clean rootfs rust_vm
 
 EXAMPLES := boot_efi chroot_vm external_kernel consoles
 ifeq ($(SEV),1)
@@ -51,6 +51,12 @@ endif
 
 consoles: consoles.c
 	gcc -o $@ $< $(CFLAGS) $(LDFLAGS_$(ARCH)_$(OS))
+
+rust_vm:
+	cargo build --bin rust_vm --manifest-path ../Cargo.toml
+ifeq ($(OS),Darwin)
+	codesign --entitlements chroot_vm.entitlements --force -s - ../target/debug/rust_vm
+endif
 
 nitro: nitro.c
 	gcc -o $@ $< $(CFLAGS) $(LDFLAGS_nitro)

--- a/examples/rust_vm/Cargo.toml
+++ b/examples/rust_vm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust_vm"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [features]
 tee = ["msb_krun/tee"]
@@ -9,4 +10,5 @@ amd-sev = ["tee", "msb_krun/amd-sev"]
 tdx = ["tee", "msb_krun/tdx"]
 
 [dependencies]
+env_logger = "0.11"
 msb_krun = { path = "../../src/krun" }

--- a/examples/rust_vm/src/main.rs
+++ b/examples/rust_vm/src/main.rs
@@ -1,27 +1,39 @@
-//! Simple example demonstrating the krun-api Rust API.
+//! Simple example demonstrating the msb_krun Rust API.
 //!
 //! Prerequisites:
-//! - libkrunfw installed (provides the kernel)
-//! - A rootfs with /init.krun or specify your own executable
+//! - libkrunfw shared library (set KRUNFW_PATH or install system-wide)
+//! - The rootfs-alpine git submodule initialized
+//!
+//! On macOS, the binary must be codesigned with the hypervisor entitlement:
+//!   cd examples && make rust_vm
 
 use msb_krun::{Result, VmBuilder};
 
 fn main() -> Result<()> {
-    // Create a simple VM that runs /bin/sh
-    let builder = VmBuilder::new().machine(|m| m.vcpus(2).memory_mib(1024));
+    env_logger::init();
 
-    #[cfg(not(feature = "tee"))]
-    let builder = builder.fs(|fs| fs.root("/")); // Share host root as guest root
+    let krunfw_path =
+        std::env::var("KRUNFW_PATH").unwrap_or_else(|_| "libkrunfw.5.dylib".to_string());
 
-    let exit_code = builder
+    let rootfs_path = format!(
+        "{}/rootfs-alpine/{}",
+        env!("CARGO_MANIFEST_DIR"),
+        std::env::consts::ARCH,
+    );
+
+    eprintln!("Entering VM (rootfs={rootfs_path})");
+
+    VmBuilder::new()
+        .machine(|m| m.vcpus(2).memory_mib(1024))
+        .kernel(|k| k.krunfw_path(&krunfw_path))
+        .fs(|fs| fs.root(&rootfs_path))
         .exec(|e| {
             e.path("/bin/echo")
                 .args(["Hello from libkrun VM!"])
                 .env("HOME", "/root")
         })
         .build()?
-        .run()?;
+        .enter()?;
 
-    println!("VM exited with code: {}", exit_code);
-    Ok(())
+    unreachable!()
 }

--- a/examples/rust_vm/src/main.rs
+++ b/examples/rust_vm/src/main.rs
@@ -23,10 +23,14 @@ fn main() -> Result<()> {
 
     eprintln!("Entering VM (rootfs={rootfs_path})");
 
-    VmBuilder::new()
+    let builder = VmBuilder::new()
         .machine(|m| m.vcpus(2).memory_mib(1024))
-        .kernel(|k| k.krunfw_path(&krunfw_path))
-        .fs(|fs| fs.root(&rootfs_path))
+        .kernel(|k| k.krunfw_path(&krunfw_path));
+
+    #[cfg(not(feature = "tee"))]
+    let builder = builder.fs(|fs| fs.root(&rootfs_path));
+
+    builder
         .exec(|e| {
             e.path("/bin/echo")
                 .args(["Hello from libkrun VM!"])

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -17,9 +17,9 @@ libc = ">=0.2.39"
 vm-memory = { version = ">=0.13", features = ["backend-mmap"] }
 vmm-sys-util = ">= 0.14"
 
-arch_gen = { package = "msb_krun_arch_gen", path = "../arch_gen" }
-smbios = { package = "msb_krun_smbios", path = "../smbios" }
-utils = { package = "msb_krun_utils", path = "../utils" }
+arch_gen = { package = "msb_krun_arch_gen", version = "0.1.0", path = "../arch_gen" }
+smbios = { package = "msb_krun_smbios", version = "0.1.0", path = "../smbios" }
+utils = { package = "msb_krun_utils", version = "0.1.0", path = "../utils" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
@@ -27,4 +27,4 @@ kvm-ioctls = ">=0.21"
 tdx = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
-utils = { package = "msb_krun_utils", path = "../utils" }
+utils = { package = "msb_krun_utils", version = "0.1.0", path = "../utils" }

--- a/src/aws_nitro/Cargo.toml
+++ b/src/aws_nitro/Cargo.toml
@@ -14,7 +14,7 @@ nix = { version = "0.30", features = ["poll"] }
 tar = "0.4"
 vsock = "0.5"
 
-devices = { package = "msb_krun_devices", path = "../devices" }
+devices = { package = "msb_krun_devices", version = "0.1.0", path = "../devices" }
 log = "0.4"
 signal-hook = "0.3"
 

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -34,21 +34,21 @@ thiserror = { version = "2.0", optional = true }
 virtio-bindings = "0.2.0"
 vm-memory = { version = ">=0.13", features = ["backend-mmap"] }
 zerocopy = { version = "0.8.26", optional = true, features = ["derive"] }
-krun_display = { package = "msb_krun_display", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
-krun_input = { package = "msb_krun_input", path = "../krun_input", features = ["bindgen_clang_runtime"], optional = true }
+krun_display = { package = "msb_krun_display", version = "0.1.0", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
+krun_input = { package = "msb_krun_input", version = "0.1.0", path = "../krun_input", features = ["bindgen_clang_runtime"], optional = true }
 
-arch = { package = "msb_krun_arch", path = "../arch" }
-utils = { package = "msb_krun_utils", path = "../utils" }
-polly = { package = "msb_krun_polly", path = "../polly" }
-rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
+arch = { package = "msb_krun_arch", version = "0.1.0", path = "../arch" }
+utils = { package = "msb_krun_utils", version = "0.1.0", path = "../utils" }
+polly = { package = "msb_krun_polly", version = "0.1.0", path = "../polly" }
+rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.0", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
 imago = { version = "0.2.1", features = ["sync-wrappers", "vm-memory"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "msb_krun_hvf", path = "../hvf" }
+hvf = { package = "msb_krun_hvf", version = "0.1.0", path = "../hvf" }
 lru = ">=0.9"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", path = "../rutabaga_gfx", features = ["x"], optional = true }
+rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.0", path = "../rutabaga_gfx", features = ["x"], optional = true }
 caps = "0.5.5"
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"

--- a/src/hvf/Cargo.toml
+++ b/src/hvf/Cargo.toml
@@ -3,6 +3,7 @@ name = "msb_krun_hvf"
 version = "0.1.0"
 authors = ["Sergio Lopez <slp@sinrega.org>"]
 edition = "2021"
+build = "build.rs"
 license = "Apache-2.0"
 description = "Apple Hypervisor.framework backend for msb_krun microVMs"
 
@@ -11,4 +12,4 @@ crossbeam-channel = ">=0.5.15"
 libloading = "0.8"
 log = "0.4.0"
 
-arch = { package = "msb_krun_arch", path = "../arch" }
+arch = { package = "msb_krun_arch", version = "0.1.0", path = "../arch" }

--- a/src/hvf/build.rs
+++ b/src/hvf/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-lib=framework=Hypervisor");
+}

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -8,4 +8,4 @@ description = "Kernel loading utilities for msb_krun microVMs"
 [dependencies]
 vm-memory = { version = ">=0.13", features = ["backend-mmap"] }
 
-utils = { package = "msb_krun_utils", path = "../utils" }
+utils = { package = "msb_krun_utils", version = "0.1.0", path = "../utils" }

--- a/src/krun/Cargo.toml
+++ b/src/krun/Cargo.toml
@@ -26,21 +26,21 @@ libc = ">=0.2.39"
 libloading = "0.8"
 log = "0.4.0"
 
-devices = { package = "msb_krun_devices", path = "../devices" }
-polly = { package = "msb_krun_polly", path = "../polly" }
-utils = { package = "msb_krun_utils", path = "../utils" }
-vmm = { package = "msb_krun_vmm", path = "../vmm" }
+devices = { package = "msb_krun_devices", version = "0.1.0", path = "../devices" }
+polly = { package = "msb_krun_polly", version = "0.1.0", path = "../polly" }
+utils = { package = "msb_krun_utils", version = "0.1.0", path = "../utils" }
+vmm = { package = "msb_krun_vmm", version = "0.1.0", path = "../vmm" }
 
 # Optional dependencies
-krun_display = { package = "msb_krun_display", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
-krun_input = { package = "msb_krun_input", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
+krun_display = { package = "msb_krun_display", version = "0.1.0", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
+krun_input = { package = "msb_krun_input", version = "0.1.0", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "msb_krun_hvf", path = "../hvf" }
+hvf = { package = "msb_krun_hvf", version = "0.1.0", path = "../hvf" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"
 vm-memory = { version = ">=0.13", features = ["backend-mmap"] }
-aws-nitro = { package = "msb_krun_aws_nitro", path = "../aws_nitro", optional = true }
+aws-nitro = { package = "msb_krun_aws_nitro", version = "0.1.0", path = "../aws_nitro", optional = true }
 nitro-enclaves = { version = "0.6.0", optional = true }

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -88,7 +88,12 @@ impl VmBuilder {
     /// ```rust,no_run
     /// # use msb_krun::VmBuilder;
     /// VmBuilder::new()
-    ///     .machine(|m| m.vcpus(4).memory_mib(2048).nested_virt(true));
+    ///     .machine(|m| {
+    ///         m.vcpus(4)
+    ///             .memory_mib(2048)
+    ///             .hyperthreading(true)
+    ///             .nested_virt(true)
+    ///     });
     /// ```
     pub fn machine(mut self, f: impl FnOnce(MachineBuilder) -> MachineBuilder) -> Self {
         self.machine = f(self.machine);
@@ -102,7 +107,10 @@ impl VmBuilder {
     /// ```rust,no_run
     /// # use msb_krun::VmBuilder;
     /// VmBuilder::new()
-    ///     .kernel(|k| k.cmdline("console=hvc0 debug"));
+    ///     .kernel(|k| {
+    ///         k.krunfw_path("/path/to/libkrunfw.dylib")
+    ///             .cmdline("debug")
+    ///     });
     /// ```
     pub fn kernel(mut self, f: impl FnOnce(KernelBuilder) -> KernelBuilder) -> Self {
         self.kernel = f(self.kernel);
@@ -113,13 +121,31 @@ impl VmBuilder {
     ///
     /// Can be called multiple times to add multiple mounts.
     ///
-    /// # Example
+    /// # Examples
+    ///
+    /// Root filesystem only:
+    ///
+    /// ```rust,no_run
+    /// # use msb_krun::VmBuilder;
+    /// VmBuilder::new()
+    ///     .fs(|fs| fs.root("/path/to/rootfs"));
+    /// ```
+    ///
+    /// Root filesystem with additional named mounts:
     ///
     /// ```rust,no_run
     /// # use msb_krun::VmBuilder;
     /// VmBuilder::new()
     ///     .fs(|fs| fs.root("/path/to/rootfs"))
-    ///     .fs(|fs| fs.tag("data").path("/host/data"));
+    ///     .fs(|fs| fs.tag("data").shm_size(1 << 30).path("/host/data"))
+    ///     .fs(|fs| fs.tag("logs").path("/host/logs"));
+    /// ```
+    ///
+    /// Custom filesystem backend:
+    ///
+    /// ```rust,ignore
+    /// VmBuilder::new()
+    ///     .fs(|fs| fs.tag("myfs").custom(Box::new(my_backend)));
     /// ```
     #[cfg(not(feature = "tee"))]
     pub fn fs(mut self, f: impl FnOnce(FsBuilder) -> FsBuilder) -> Self {
@@ -134,10 +160,9 @@ impl VmBuilder {
     ///
     /// # Example
     ///
-    /// ```rust,no_run
-    /// # use msb_krun::VmBuilder;
-    /// // VmBuilder::new()
-    /// //     .net(|n| n.mac([0x52, 0x54, 0x00, 0x12, 0x34, 0x56]).custom(my_backend));
+    /// ```rust,ignore
+    /// VmBuilder::new()
+    ///     .net(|n| n.mac([0x52, 0x54, 0x00, 0x12, 0x34, 0x56]).custom(my_backend));
     /// ```
     #[cfg(feature = "net")]
     pub fn net(mut self, f: impl FnOnce(NetBuilder) -> NetBuilder) -> Self {
@@ -154,8 +179,8 @@ impl VmBuilder {
     ///
     /// ```rust,no_run
     /// # use msb_krun::VmBuilder;
-    /// // VmBuilder::new()
-    /// //     .disk(|d| d.path("/path/to/disk.img").read_only(true));
+    /// VmBuilder::new()
+    ///     .disk(|d| d.path("/path/to/disk.img").read_only(true));
     /// ```
     #[cfg(feature = "blk")]
     pub fn disk(mut self, f: impl FnOnce(DiskBuilder) -> DiskBuilder) -> Self {
@@ -173,6 +198,18 @@ impl VmBuilder {
     /// VmBuilder::new()
     ///     .console(|c| c.output("/tmp/vm.log"));
     /// ```
+    ///
+    /// With the `gpu` and `snd` features:
+    ///
+    /// ```rust,ignore
+    /// VmBuilder::new()
+    ///     .console(|c| {
+    ///         c.output("/tmp/vm.log")
+    ///             .sound(true)
+    ///             .gpu_virgl_flags(0x1)
+    ///             .gpu_shm_size(1 << 28)
+    ///     });
+    /// ```
     pub fn console(mut self, f: impl FnOnce(ConsoleBuilder) -> ConsoleBuilder) -> Self {
         self.console = f(self.console);
         self
@@ -180,18 +217,34 @@ impl VmBuilder {
 
     /// Configure execution settings.
     ///
-    /// # Example
+    /// # Examples
+    ///
+    /// Setting environment variables one at a time with `.env()`:
     ///
     /// ```rust,no_run
     /// # use msb_krun::VmBuilder;
     /// VmBuilder::new()
-    ///     .exec(|e| e
-    ///         .path("/bin/myapp")
-    ///         .args(["--flag", "value"])
-    ///         .env("HOME", "/root")
-    ///         .workdir("/app")
-    ///         .uid(1000)
-    ///         .gid(1000));
+    ///     .exec(|e| {
+    ///         e.path("/bin/myapp")
+    ///             .args(["--flag", "value"])
+    ///             .env("HOME", "/root")
+    ///             .env("LANG", "en_US.UTF-8")
+    ///             .workdir("/app")
+    ///             .uid(1000)
+    ///             .gid(1000)
+    ///             .rlimit("NOFILE", 1024, 4096)
+    ///     });
+    /// ```
+    ///
+    /// Setting environment variables in bulk with `.envs()`:
+    ///
+    /// ```rust,no_run
+    /// # use msb_krun::VmBuilder;
+    /// VmBuilder::new()
+    ///     .exec(|e| {
+    ///         e.path("/bin/myapp")
+    ///             .envs([("HOME", "/root"), ("LANG", "en_US.UTF-8")])
+    ///     });
     /// ```
     pub fn exec(mut self, f: impl FnOnce(ExecBuilder) -> ExecBuilder) -> Self {
         self.exec = f(self.exec);
@@ -325,6 +378,7 @@ impl VmBuilder {
             rlimits,
             self.exec.uid,
             self.exec.gid,
+            self.kernel.krunfw_path,
         ))
     }
 }

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -13,6 +13,19 @@ use crate::backends::net::NetBackend;
 //--------------------------------------------------------------------------------------------------
 
 /// Builder for machine configuration (vCPUs, memory, etc.).
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use msb_krun::VmBuilder;
+/// VmBuilder::new()
+///     .machine(|m| {
+///         m.vcpus(4)
+///             .memory_mib(2048)
+///             .hyperthreading(true)
+///             .nested_virt(true)
+///     });
+/// ```
 #[derive(Debug, Clone)]
 pub struct MachineBuilder {
     pub(crate) vcpus: u8,
@@ -26,9 +39,21 @@ pub struct MachineBuilder {
 //--------------------------------------------------------------------------------------------------
 
 /// Builder for kernel configuration.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use msb_krun::VmBuilder;
+/// VmBuilder::new()
+///     .kernel(|k| {
+///         k.krunfw_path("/path/to/libkrunfw.dylib")
+///             .cmdline("debug")
+///     });
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct KernelBuilder {
     pub(crate) cmdline: Option<String>,
+    pub(crate) krunfw_path: Option<PathBuf>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -36,6 +61,33 @@ pub struct KernelBuilder {
 //--------------------------------------------------------------------------------------------------
 
 /// Builder for filesystem configuration.
+///
+/// # Examples
+///
+/// Root filesystem only:
+///
+/// ```rust,no_run
+/// # use msb_krun::VmBuilder;
+/// VmBuilder::new()
+///     .fs(|fs| fs.root("/path/to/rootfs"));
+/// ```
+///
+/// Root filesystem with additional named mounts:
+///
+/// ```rust,no_run
+/// # use msb_krun::VmBuilder;
+/// VmBuilder::new()
+///     .fs(|fs| fs.root("/path/to/rootfs"))
+///     .fs(|fs| fs.tag("data").shm_size(1 << 30).path("/host/data"))
+///     .fs(|fs| fs.tag("logs").path("/host/logs"));
+/// ```
+///
+/// Custom filesystem backend:
+///
+/// ```rust,ignore
+/// VmBuilder::new()
+///     .fs(|fs| fs.tag("myfs").custom(Box::new(my_backend)));
+/// ```
 pub struct FsBuilder {
     pub(crate) configs: Vec<FsConfig>,
     current_tag: Option<String>,
@@ -63,6 +115,13 @@ pub enum FsConfig {
 //--------------------------------------------------------------------------------------------------
 
 /// Builder for network configuration.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// VmBuilder::new()
+///     .net(|n| n.mac([0x52, 0x54, 0x00, 0x12, 0x34, 0x56]).custom(my_backend));
+/// ```
 #[cfg(feature = "net")]
 pub struct NetBuilder {
     pub(crate) configs: Vec<NetConfig>,
@@ -84,6 +143,26 @@ pub enum NetConfig {
 //--------------------------------------------------------------------------------------------------
 
 /// Builder for console/output configuration.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use msb_krun::VmBuilder;
+/// VmBuilder::new()
+///     .console(|c| c.output("/tmp/vm.log"));
+/// ```
+///
+/// With the `gpu` and `snd` features:
+///
+/// ```rust,ignore
+/// VmBuilder::new()
+///     .console(|c| {
+///         c.output("/tmp/vm.log")
+///             .sound(true)
+///             .gpu_virgl_flags(0x1)
+///             .gpu_shm_size(1 << 28)
+///     });
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct ConsoleBuilder {
     pub(crate) output: Option<PathBuf>,
@@ -100,6 +179,36 @@ pub struct ConsoleBuilder {
 //--------------------------------------------------------------------------------------------------
 
 /// Builder for execution configuration.
+///
+/// # Examples
+///
+/// Setting environment variables one at a time with `.env()`:
+///
+/// ```rust,no_run
+/// # use msb_krun::VmBuilder;
+/// VmBuilder::new()
+///     .exec(|e| {
+///         e.path("/bin/myapp")
+///             .args(["--flag", "value"])
+///             .env("HOME", "/root")
+///             .env("LANG", "en_US.UTF-8")
+///             .workdir("/app")
+///             .uid(1000)
+///             .gid(1000)
+///             .rlimit("NOFILE", 1024, 4096)
+///     });
+/// ```
+///
+/// Setting environment variables in bulk with `.envs()`:
+///
+/// ```rust,no_run
+/// # use msb_krun::VmBuilder;
+/// VmBuilder::new()
+///     .exec(|e| {
+///         e.path("/bin/myapp")
+///             .envs([("HOME", "/root"), ("LANG", "en_US.UTF-8")])
+///     });
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct ExecBuilder {
     pub(crate) path: Option<String>,
@@ -116,6 +225,14 @@ pub struct ExecBuilder {
 //--------------------------------------------------------------------------------------------------
 
 /// Builder for block device configuration.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use msb_krun::VmBuilder;
+/// VmBuilder::new()
+///     .disk(|d| d.path("/path/to/disk.img").read_only(true));
+/// ```
 #[cfg(feature = "blk")]
 #[derive(Debug, Clone, Default)]
 pub struct DiskBuilder {
@@ -198,6 +315,14 @@ impl KernelBuilder {
         }
         self
     }
+
+    /// Set an explicit path to the libkrunfw shared library.
+    ///
+    /// When not set, the OS dynamic linker's default search path is used.
+    pub fn krunfw_path(mut self, path: impl AsRef<Path>) -> Self {
+        self.krunfw_path = Some(path.as_ref().to_path_buf());
+        self
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -214,10 +339,12 @@ impl FsBuilder {
         }
     }
 
-    /// Set the root filesystem path (tag: "krun_root").
+    /// Set the root filesystem path.
+    ///
+    /// Uses the virtiofs tag `/dev/root`, matching the kernel's expected root device name.
     pub fn root(mut self, path: impl AsRef<Path>) -> Self {
         self.configs.push(FsConfig::Path {
-            tag: "krun_root".to_string(),
+            tag: "/dev/root".to_string(),
             path: path.as_ref().to_path_buf(),
             shm_size: None,
         });

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -1,6 +1,6 @@
 //! Native Rust API for libkrun.
 //!
-//! This module provides a builder-pattern API for creating and running microVMs
+//! This module provides a builder-pattern API for creating and entering microVMs
 //! using nested builders for organized configuration.
 //!
 //! # Example
@@ -9,15 +9,17 @@
 //! use msb_krun::{VmBuilder, Result};
 //!
 //! fn main() -> Result<()> {
-//!     let exit_code = VmBuilder::new()
+//!     // enter() hands process lifecycle to the VMM.
+//!     // On normal guest exit, the process terminates directly.
+//!     // It only returns on early setup errors.
+//!     VmBuilder::new()
 //!         .machine(|m| m.vcpus(4).memory_mib(2048))
 //!         .fs(|fs| fs.root("/path/to/rootfs"))
 //!         .exec(|e| e.path("/bin/myapp").args(["--flag"]).env("HOME", "/root"))
 //!         .build()?
-//!         .run()?;
+//!         .enter()?;
 //!
-//!     println!("VM exited with code: {}", exit_code);
-//!     Ok(())
+//!     unreachable!()
 //! }
 //! ```
 

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -145,9 +145,8 @@ impl Vm {
         // Build the microVM
         let (sender, _receiver) = unbounded();
 
-        let _vmm =
-            vmm::builder::build_microvm(&self.vmr, &mut event_manager, shutdown_efd, sender)
-                .map_err(|e| Error::Build(BuildError::Start(format!("build_microvm: {e:?}"))))?;
+        let _vmm = vmm::builder::build_microvm(&self.vmr, &mut event_manager, shutdown_efd, sender)
+            .map_err(|e| Error::Build(BuildError::Start(format!("build_microvm: {e:?}"))))?;
 
         // Start worker threads if needed
         #[cfg(target_os = "macos")]

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -1,4 +1,7 @@
-//! VM handle for running microVMs.
+//! VM handle for entering microVMs.
+
+use std::convert::Infallible;
+use std::path::PathBuf;
 
 #[cfg(target_os = "linux")]
 use std::env;
@@ -8,6 +11,7 @@ use std::ffi::CString;
 use crossbeam_channel::unbounded;
 use log::error;
 use polly::event_manager::EventManager;
+use utils::eventfd::EventFd;
 use vmm::resources::VmResources;
 use vmm::vmm_config::kernel_bundle::KernelBundle;
 use vmm::vmm_config::kernel_cmdline::KernelCmdlineConfig;
@@ -19,15 +23,15 @@ use super::error::{BuildError, Error, Result, RuntimeError};
 // Constants
 //--------------------------------------------------------------------------------------------------
 
-const DEFAULT_KERNEL_CMDLINE: &str =
-    "reboot=k panic=-1 panic_print=0 nomodule console=hvc0 quiet 8250.nr_uarts=0";
 const INIT_PATH: &str = "/init.krun";
 
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// Handle to a configured VM ready to run.
+/// Handle to a configured VM ready to enter.
+///
+/// Created via [`VmBuilder::build()`](super::builder::VmBuilder::build).
 pub struct Vm {
     vmr: VmResources,
     exec_path: Option<String>,
@@ -37,6 +41,9 @@ pub struct Vm {
     rlimits: Option<String>,
     uid: Option<u32>,
     gid: Option<u32>,
+    krunfw_path: Option<PathBuf>,
+    /// Keeps the libkrunfw library loaded so kernel memory pointers remain valid.
+    _krunfw_library: Option<libloading::Library>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -55,6 +62,7 @@ impl Vm {
         rlimits: Option<String>,
         uid: Option<u32>,
         gid: Option<u32>,
+        krunfw_path: Option<PathBuf>,
     ) -> Self {
         Self {
             vmr,
@@ -65,20 +73,16 @@ impl Vm {
             rlimits,
             uid,
             gid,
+            krunfw_path,
+            _krunfw_library: None,
         }
     }
 
-    /// Run the VM.
+    /// Start the VM. This call never returns on success — the VMM calls
+    /// `_exit()` when the guest shuts down, killing the entire process.
     ///
-    /// This method blocks until the VM exits. Returns the exit code on success.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - The kernel cannot be loaded
-    /// - The VM fails to build
-    /// - The event loop encounters an error
-    pub fn run(mut self) -> Result<i32> {
+    /// Only returns `Err` if something fails before the VMM takes over.
+    pub fn enter(mut self) -> Result<Infallible> {
         // Set process name on Linux
         #[cfg(target_os = "linux")]
         {
@@ -104,7 +108,10 @@ impl Vm {
 
         // Build kernel command line
         let kernel_cmdline = KernelCmdlineConfig {
-            prolog: Some(format!("{DEFAULT_KERNEL_CMDLINE} init={INIT_PATH}")),
+            prolog: Some(format!(
+                "{} root=/dev/root init={INIT_PATH}",
+                vmm::vmm_config::kernel_cmdline::DEFAULT_KERNEL_CMDLINE,
+            )),
             krun_env: Some(format!(
                 " {} {} {} {}",
                 self.get_exec_path(),
@@ -125,11 +132,22 @@ impl Vm {
         // Set UID/GID if specified
         self.set_credentials()?;
 
+        // Create shutdown EventFd on macOS aarch64 (needed for GPIO shutdown device)
+        let shutdown_efd = if cfg!(target_arch = "aarch64") && cfg!(target_os = "macos") {
+            Some(
+                EventFd::new(utils::eventfd::EFD_NONBLOCK)
+                    .map_err(|e| Error::Build(BuildError::Start(format!("shutdown_efd: {e:?}"))))?,
+            )
+        } else {
+            None
+        };
+
         // Build the microVM
         let (sender, _receiver) = unbounded();
 
-        let _vmm = vmm::builder::build_microvm(&self.vmr, &mut event_manager, None, sender)
-            .map_err(|e| Error::Build(BuildError::Start(format!("build_microvm: {e:?}"))))?;
+        let _vmm =
+            vmm::builder::build_microvm(&self.vmr, &mut event_manager, shutdown_efd, sender)
+                .map_err(|e| Error::Build(BuildError::Start(format!("build_microvm: {e:?}"))))?;
 
         // Start worker threads if needed
         #[cfg(target_os = "macos")]
@@ -148,7 +166,7 @@ impl Vm {
         vmm::worker::start_worker_thread(_vmm.clone(), _receiver.clone())
             .map_err(|e| Error::Runtime(RuntimeError::EventLoop(format!("{e:?}"))))?;
 
-        // Run the event loop
+        // Run the event loop. On normal guest exit, the VMM calls _exit() directly.
         loop {
             match event_manager.run() {
                 Ok(_) => {}
@@ -162,8 +180,7 @@ impl Vm {
 
     /// Load kernel from libkrunfw.
     fn load_krunfw(&mut self) -> Result<()> {
-        // Try to load libkrunfw
-        let krunfw = load_krunfw_library()?;
+        let krunfw = load_krunfw_library(self.krunfw_path.as_deref())?;
 
         // Get kernel from libkrunfw
         let mut kernel_guest_addr: u64 = 0;
@@ -188,6 +205,9 @@ impl Vm {
         self.vmr
             .set_kernel_bundle(kernel_bundle)
             .map_err(|e| Error::Build(BuildError::Krunfw(format!("{e:?}"))))?;
+
+        // Keep the library alive so the kernel memory pointers remain valid.
+        self._krunfw_library = Some(krunfw.library);
 
         Ok(())
     }
@@ -296,8 +316,7 @@ impl Vm {
 /// Bindings to libkrunfw functions.
 struct KrunfwBindings {
     get_kernel: unsafe extern "C" fn(*mut u64, *mut u64, *mut usize) -> *mut std::ffi::c_char,
-    #[allow(dead_code)]
-    _library: libloading::Library,
+    library: libloading::Library,
 }
 
 /// Library name for libkrunfw.
@@ -307,9 +326,19 @@ const KRUNFW_NAME: &str = "libkrunfw.so.5";
 const KRUNFW_NAME: &str = "libkrunfw.5.dylib";
 
 /// Load the libkrunfw library.
-fn load_krunfw_library() -> Result<KrunfwBindings> {
-    let library = unsafe { libloading::Library::new(KRUNFW_NAME) }
-        .map_err(|e| Error::Build(BuildError::Krunfw(format!("load {KRUNFW_NAME}: {e}"))))?;
+///
+/// If `path` is provided, loads from that exact path. Otherwise falls back to the
+/// default library name, which lets the OS dynamic linker search standard paths.
+fn load_krunfw_library(path: Option<&std::path::Path>) -> Result<KrunfwBindings> {
+    let name = path
+        .map(|p| p.as_os_str().to_os_string())
+        .unwrap_or_else(|| std::ffi::OsString::from(KRUNFW_NAME));
+    let library = unsafe { libloading::Library::new(&name) }.map_err(|e| {
+        Error::Build(BuildError::Krunfw(format!(
+            "load {}: {e}",
+            name.to_string_lossy()
+        )))
+    })?;
 
     let get_kernel = unsafe {
         *library
@@ -321,6 +350,6 @@ fn load_krunfw_library() -> Result<KrunfwBindings> {
 
     Ok(KrunfwBindings {
         get_kernel,
-        _library: library,
+        library,
     })
 }

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -1,7 +1,13 @@
 //! msb_krun - Native Rust API for libkrun microVMs.
 //!
-//! This crate provides a builder-pattern API for creating and running microVMs
+//! This crate provides a builder-pattern API for creating and entering microVMs
 //! using libkrun's VMM infrastructure.
+//!
+//! # Lifecycle
+//!
+//! [`Vm::enter()`] never returns on success. When the guest shuts down, the
+//! VMM calls `_exit()`, killing the entire process. `enter()` only returns
+//! `Err` if something fails before the VMM takes over.
 //!
 //! # Example
 //!
@@ -9,15 +15,14 @@
 //! use msb_krun::{VmBuilder, Result};
 //!
 //! fn main() -> Result<()> {
-//!     let exit_code = VmBuilder::new()
+//!     VmBuilder::new()
 //!         .machine(|m| m.vcpus(4).memory_mib(2048))
 //!         .fs(|fs| fs.root("/path/to/rootfs"))
 //!         .exec(|e| e.path("/bin/myapp").args(["--flag"]).env("HOME", "/root"))
 //!         .build()?
-//!         .run()?;
+//!         .enter()?;
 //!
-//!     println!("VM exited with code: {}", exit_code);
-//!     Ok(())
+//!     unreachable!()
 //! }
 //! ```
 

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -3,6 +3,7 @@ name = "libkrun"
 version = "1.17.3"
 authors = ["The libkrun Authors"]
 edition = "2021"
+publish = false
 build = "build.rs"
 
 [features]

--- a/src/polly/Cargo.toml
+++ b/src/polly/Cargo.toml
@@ -8,4 +8,4 @@ description = "Event polling abstraction for msb_krun microVMs"
 
 [dependencies]
 libc = ">=0.2.39"
-utils = { package = "msb_krun_utils", path = "../utils" }
+utils = { package = "msb_krun_utils", version = "0.1.0", path = "../utils" }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -27,15 +27,15 @@ log = "0.4.0"
 nix = { version = "0.30.1", features = ["fs", "term"] }
 vm-memory = { version = ">=0.13", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.14"
-krun_display = { package = "msb_krun_display", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
-krun_input = { package = "msb_krun_input", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
+krun_display = { package = "msb_krun_display", version = "0.1.0", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
+krun_input = { package = "msb_krun_input", version = "0.1.0", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
 
-arch = { package = "msb_krun_arch", path = "../arch" }
-arch_gen = { package = "msb_krun_arch_gen", path = "../arch_gen" }
-devices = { package = "msb_krun_devices", path = "../devices" }
-kernel = { package = "msb_krun_kernel", path = "../kernel" }
-utils = { package = "msb_krun_utils", path = "../utils" }
-polly = { package = "msb_krun_polly", path = "../polly" }
+arch = { package = "msb_krun_arch", version = "0.1.0", path = "../arch" }
+arch_gen = { package = "msb_krun_arch_gen", version = "0.1.0", path = "../arch_gen" }
+devices = { package = "msb_krun_devices", version = "0.1.0", path = "../devices" }
+kernel = { package = "msb_krun_kernel", version = "0.1.0", path = "../kernel" }
+utils = { package = "msb_krun_utils", version = "0.1.0", path = "../utils" }
+polly = { package = "msb_krun_polly", version = "0.1.0", path = "../polly" }
 
 # Dependencies for amd-sev
 kbs-types = { version = "0.13.0", optional = true }
@@ -47,7 +47,7 @@ bitflags = { version = "2.10.0", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 bzip2 = "0.5"
-cpuid = { package = "msb_krun_cpuid", path = "../cpuid" }
+cpuid = { package = "msb_krun_cpuid", version = "0.1.0", path = "../cpuid" }
 zstd = "0.13"
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -56,7 +56,7 @@ kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "msb_krun_hvf", path = "../hvf" }
+hvf = { package = "msb_krun_hvf", version = "0.1.0", path = "../hvf" }
 
 [dev-dependencies]
-devices = { package = "msb_krun_devices", path = "../devices", features = ["test_utils"] }
+devices = { package = "msb_krun_devices", version = "0.1.0", path = "../devices", features = ["test_utils"] }


### PR DESCRIPTION
## Summary
- Replace `Vm::run()` with `Vm::enter()` to accurately reflect that the VMM takes over the process and never returns on success
- Add `KernelBuilder::krunfw_path()` so callers can specify a custom libkrunfw shared library path
- Pin all workspace path dependencies with `version = "0.1.0"` for crates.io compatibility
- Add Alpine Linux rootfs git submodule with multi-arch support (x86_64/aarch64) for the rust_vm example

## Changes
- **src/krun/src/api/vm.rs**: Replace `Vm::run() -> Result<i32>` with `Vm::enter() -> Result<Infallible>`; add `krunfw_path` and `_krunfw_library` fields to keep libkrunfw loaded; add shutdown EventFd for macOS aarch64; use vmm's `DEFAULT_KERNEL_CMDLINE` constant; accept custom krunfw path in `load_krunfw_library()`
- **src/krun/src/api/builders.rs**: Add `krunfw_path` field and `KernelBuilder::krunfw_path()` method; change root virtiofs tag from `"krun_root"` to `"/dev/root"`; add comprehensive doc examples to all builder types (~130 lines of documentation)
- **src/krun/src/api/builder.rs**: Pass `krunfw_path` through to `Vm::new()`; expand and improve doc examples for all builder methods
- **src/krun/src/api/mod.rs** and **src/krun/src/lib.rs**: Update module docs to reflect `enter()` semantics and lifecycle
- **Cargo.toml changes** (arch, aws_nitro, devices, hvf, kernel, krun, polly, vmm): Add `version = "0.1.0"` to all workspace path dependencies so crates resolve on crates.io
- **src/libkrun/Cargo.toml**: Mark with `publish = false`
- **src/hvf/Cargo.toml** and **src/hvf/build.rs**: Add build script to hvf crate
- **examples/rust_vm/src/main.rs**: Rewrite to use Alpine rootfs submodule with multi-arch path resolution via `std::env::consts::ARCH`; add `env_logger`, `KRUNFW_PATH` env var support, and codesign instructions
- **examples/rust_vm/Cargo.toml**: Add `env_logger` dep and `publish = false`
- **examples/Makefile**: Add `rust_vm` target with cargo build and macOS codesigning
- **.gitmodules** and **examples/rust_vm/rootfs-alpine**: Add rootfs-alpine git submodule from zerocore-ai/rootfs-alpine

## Test Plan
- Run `cargo build --manifest-path src/krun/Cargo.toml` to verify the krun crate compiles
- Run `cargo doc --manifest-path src/krun/Cargo.toml --no-deps` to verify doc examples are valid
- On macOS: `cd examples && make rust_vm` to build and codesign the example binary
- Run the example with `KRUNFW_PATH=/path/to/libkrunfw.5.dylib ../target/debug/rust_vm` to verify it boots the Alpine rootfs
- Verify submodule initializes: `git submodule update --init examples/rust_vm/rootfs-alpine`