### PR TITLE
chore: prepare crates for crates.io publishing

### DIFF
--- a/examples/gui_vm/Cargo.toml
+++ b/examples/gui_vm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gui_vm"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 gtk_display = { path = "../krun_gtk_display" }

--- a/examples/krun_gtk_display/Cargo.toml
+++ b/examples/krun_gtk_display/Cargo.toml
@@ -3,6 +3,7 @@ name = "gtk_display"
 description = "Reference implementation of a display backend for libkrun"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 utils = { path = "../../src/utils", package = "msb_krun_utils" } # Our version of rust vmm-sys-util

--- a/krun-sys/Cargo.toml
+++ b/krun-sys/Cargo.toml
@@ -2,6 +2,7 @@
 name = "krun-sys"
 version = "1.11.1"
 edition = "2021"
+publish = false
 rust-version = "1.77.0"
 description = "Rust bindings for libkrun"
 repository = "https://github.com/containers/libkrun"

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Chromium OS Authors"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
 description = "Architecture-specific support for msb_krun microVMs"
+repository = "https://github.com/containers/libkrun"
 
 [features]
 tee = []

--- a/src/arch_gen/Cargo.toml
+++ b/src/arch_gen/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
 description = "Generated architecture definitions for msb_krun microVMs"
+repository = "https://github.com/containers/libkrun"
 
 [dependencies]

--- a/src/aws_nitro/Cargo.toml
+++ b/src/aws_nitro/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "AWS Nitro Enclaves support for msb_krun microVMs"
+repository = "https://github.com/containers/libkrun"
 
 [features]
 aws-nitro = []

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
 description = "CPUID handling for msb_krun microVMs"
+repository = "https://github.com/containers/libkrun"
 
 [features]
 tdx = []

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Chromium OS Authors"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
 description = "Virtio device implementations for msb_krun microVMs"
+repository = "https://github.com/containers/libkrun"
 
 [features]
 tee = []

--- a/src/hvf/Cargo.toml
+++ b/src/hvf/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 build = "build.rs"
 license = "Apache-2.0"
 description = "Apple Hypervisor.framework backend for msb_krun microVMs"
+repository = "https://github.com/containers/libkrun"
 
 [dependencies]
 crossbeam-channel = ">=0.5.15"

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
 description = "Kernel loading utilities for msb_krun microVMs"
+repository = "https://github.com/containers/libkrun"
 
 [dependencies]
 vm-memory = { version = ">=0.13", features = ["backend-mmap"] }

--- a/src/krun/Cargo.toml
+++ b/src/krun/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["The libkrun Authors"]
 edition = "2021"
 description = "Native Rust API for libkrun microVMs"
-repository = "https://github.com/containers/libkrun"
+repository = "https://github.com/zerocore-ai/libkrun"
 license = "Apache-2.0"
 
 [features]

--- a/src/krun_display/Cargo.toml
+++ b/src/krun_display/Cargo.toml
@@ -4,6 +4,7 @@ description = "Rust bindings for implemeting display backends in Rust for libkru
 version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"
+repository = "https://github.com/containers/libkrun"
 
 [dependencies]
 thiserror = "2.0.12"

--- a/src/krun_input/Cargo.toml
+++ b/src/krun_input/Cargo.toml
@@ -4,6 +4,7 @@ description = "Rust bindings for implementing input backends in Rust for libkrun
 version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"
+repository = "https://github.com/containers/libkrun"
 
 [dependencies]
 thiserror = "2.0.12"

--- a/src/polly/Cargo.toml
+++ b/src/polly/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "Event polling abstraction for msb_krun microVMs"
+repository = "https://github.com/containers/libkrun"
 
 [dependencies]
 libc = ">=0.2.39"

--- a/src/rutabaga_gfx/Cargo.toml
+++ b/src/rutabaga_gfx/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The ChromiumOS Authors + Android Open Source Project"]
 edition = "2021"
 description = "[highly unstable] Handling virtio-gpu protocols"
 license = "BSD-3-Clause"
+repository = "https://github.com/containers/libkrun"
 
 [features]
 gfxstream = []

--- a/src/rutabaga_gfx/ffi/Cargo.toml
+++ b/src/rutabaga_gfx/ffi/Cargo.toml
@@ -3,6 +3,7 @@ name = "rutabaga_gfx_ffi"
 version = "0.1.2"
 authors = ["The ChromiumOS Authors + Android Open Source Project"]
 edition = "2021"
+publish = false
 description = "Handling virtio-gpu protocols with C API"
 license-file = "LICENSE"
 

--- a/src/smbios/Cargo.toml
+++ b/src/smbios/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "SMBIOS table generation for msb_krun microVMs"
+repository = "https://github.com/containers/libkrun"
 
 [dependencies]
 vm-memory = { version = ">=0.13", features = ["backend-mmap"] }

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
 description = "Shared utilities for msb_krun microVMs"
+repository = "https://github.com/containers/libkrun"
 
 [dependencies]
 bitflags = "1.2.0"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
 description = "Virtual machine monitor for msb_krun microVMs"
+repository = "https://github.com/containers/libkrun"
 
 [features]
 tee = []

--- a/tests/guest-agent/Cargo.toml
+++ b/tests/guest-agent/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "guest-agent"
 edition = "2021"
+publish = false
 
 [dependencies]
 test_cases = { path = "../test_cases", features = ["guest"] }

--- a/tests/macros/Cargo.toml
+++ b/tests/macros/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "macros"
 edition = "2021"
+publish = false
 
 [lib]
 proc-macro = true

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "runner"
 edition = "2021"
+publish = false
 
 [dependencies]
 test_cases = { path = "../test_cases", features = ["host"] }

--- a/tests/test_cases/Cargo.toml
+++ b/tests/test_cases/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "test_cases"
 edition = "2021"
+publish = false
 
 [features]
 host = ["krun-sys"]


### PR DESCRIPTION
## Summary
- Remove `publish = false` from all 15 publishable msb_krun_* crates to enable crates.io publishing
- Add `repository` metadata to crates that were missing it
- Explicitly mark non-publishable crates (examples, tests, krun-sys, rutabaga_gfx_ffi) with `publish = false`
- Update msb_krun repository URL to point to the zerocore-ai fork

## Changes
- Removed `publish = false` from 15 src/ crates: msb_krun_utils, msb_krun_smbios, msb_krun_arch_gen, msb_krun_cpuid, msb_krun_display, msb_krun_input, msb_krun_rutabaga_gfx, msb_krun_polly, msb_krun_arch, msb_krun_kernel, msb_krun_hvf, msb_krun_devices, msb_krun_vmm, msb_krun_aws_nitro, msb_krun
- Added `repository = "https://github.com/containers/libkrun"` to 14 crates missing it
- Updated msb_krun repository URL from containers/libkrun to zerocore-ai/libkrun
- Added `publish = false` to examples (gui_vm, gtk_display), tests (guest-agent, macros, runner, test_cases), krun-sys, and rutabaga_gfx_ffi

## Test Plan
- Run `cargo publish --dry-run -p msb_krun_utils` to verify a leaf crate passes publish checks
- Run `cargo check` to ensure no Cargo.toml syntax issues were introduced
- Verify with `grep -r 'publish = false' src/` that no publishable crates are blocked