### PR TITLE
build: sync init binary to devices crate after compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ ifeq ($(BUILD_INIT),1)
 INIT_BINARY = init/init
 $(INIT_BINARY): $(INIT_SRC) $(SYSROOT_TARGET)
 	$(CC_LINUX) -O2 -static -Wall $(INIT_DEFS) -o $@ $(INIT_SRC) $(INIT_DEFS)
+	cp $@ src/devices/init
 endif
 
 AWS_NITRO_INIT_BINARY= init/aws-nitro/init


### PR DESCRIPTION
## Summary
- Add a cp step in the Makefile to copy the compiled init binary to `src/devices/init`
- After PR #26 moved the `include_bytes!` path to read from inside the devices crate, the Makefile still only outputs to `init/init`
- Prevents stale binary issues where a recompiled init would not be picked up by the devices crate

## Changes
- Added `cp $@ src/devices/init` after the init compilation step in the Makefile
- This ensures `init/init` and `src/devices/init` stay in sync after every build

## Test Plan
- Run `make` and verify that `src/devices/init` is updated alongside `init/init`
- Run `cargo build` to confirm the devices crate picks up the correct binary