### PR TITLE
feat(krun): add init path configuration to KernelBuilder API

### DIFF
--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -385,6 +385,7 @@ impl VmBuilder {
             self.exec.uid,
             self.exec.gid,
             self.kernel.krunfw_path,
+            self.kernel.init_path,
         ))
     }
 }

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -57,6 +57,7 @@ pub struct MachineBuilder {
 pub struct KernelBuilder {
     pub(crate) cmdline: Option<String>,
     pub(crate) krunfw_path: Option<PathBuf>,
+    pub(crate) init_path: Option<String>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -325,6 +326,15 @@ impl KernelBuilder {
     /// When not set, the OS dynamic linker's default search path is used.
     pub fn krunfw_path(mut self, path: impl AsRef<Path>) -> Self {
         self.krunfw_path = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    /// Set the path to the init binary inside the guest.
+    ///
+    /// This controls the kernel `init=` parameter. When not set, defaults
+    /// to `/init.krun`.
+    pub fn init_path(mut self, path: impl AsRef<Path>) -> Self {
+        self.init_path = Some(path.as_ref().to_string_lossy().to_string());
         self
     }
 }

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -42,6 +42,7 @@ pub struct Vm {
     uid: Option<u32>,
     gid: Option<u32>,
     krunfw_path: Option<PathBuf>,
+    init_path: Option<String>,
     /// Keeps the libkrunfw library loaded so kernel memory pointers remain valid.
     _krunfw_library: Option<libloading::Library>,
 }
@@ -63,6 +64,7 @@ impl Vm {
         uid: Option<u32>,
         gid: Option<u32>,
         krunfw_path: Option<PathBuf>,
+        init_path: Option<String>,
     ) -> Self {
         Self {
             vmr,
@@ -74,6 +76,7 @@ impl Vm {
             uid,
             gid,
             krunfw_path,
+            init_path,
             _krunfw_library: None,
         }
     }
@@ -107,9 +110,10 @@ impl Vm {
         }
 
         // Build kernel command line
+        let init = self.init_path.as_deref().unwrap_or(INIT_PATH);
         let kernel_cmdline = KernelCmdlineConfig {
             prolog: Some(format!(
-                "{} root=/dev/root init={INIT_PATH}",
+                "{} root=/dev/root init={init}",
                 vmm::vmm_config::kernel_cmdline::DEFAULT_KERNEL_CMDLINE,
             )),
             krun_env: Some(format!(


### PR DESCRIPTION
## Summary
- Add configurable `init_path` to `KernelBuilder` for overriding the guest init binary path
- Allows users to set a custom kernel `init=` boot parameter instead of the hardcoded `/init.krun`
- Enables flexibility for custom guest environments that use a different init binary location
- Falls back to the default `INIT_PATH` constant when not explicitly set

## Changes
- `src/krun/src/api/builders.rs`: Added `init_path: Option<String>` field to `KernelBuilder` struct and a `pub fn init_path()` builder method that accepts `impl AsRef<Path>`
- `src/krun/src/api/vm.rs`: Added `init_path` field to `Vm` struct and `Vm::new()` constructor; updated `Vm::start()` to use the custom init path in the kernel command line with fallback to `INIT_PATH`
- `src/krun/src/api/builder.rs`: Forward `self.kernel.init_path` through `VmBuilder::build()` to `Vm::new()`

## Test Plan
- Run `cargo build -p msb-krun` to verify compilation
- Run `cargo check --workspace` to ensure no breakage across the workspace
- Verify the default behavior is unchanged when `init_path` is not set (should use `/init.krun`)
- Test with a custom init path: `.kernel(|k| k.init_path("/custom/init"))` and verify the kernel cmdline contains `init=/custom/init`