### PR TITLE
feat(krun): inject boot start timestamp into kernel cmdline

### DIFF
--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -2,6 +2,7 @@
 
 use std::convert::Infallible;
 use std::path::PathBuf;
+use std::time::SystemTime;
 
 #[cfg(target_os = "linux")]
 use std::env;
@@ -109,6 +110,12 @@ impl Vm {
             self.load_krunfw()?;
         }
 
+        // Capture boot start timestamp (epoch nanoseconds) for guest-side timing.
+        let boot_start_ns = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+
         // Build kernel command line
         let init = self.init_path.as_deref().unwrap_or(INIT_PATH);
         let kernel_cmdline = KernelCmdlineConfig {
@@ -117,7 +124,7 @@ impl Vm {
                 vmm::vmm_config::kernel_cmdline::DEFAULT_KERNEL_CMDLINE,
             )),
             krun_env: Some(format!(
-                " {} {} {} {}",
+                " {} {} {} {} KRUN_BOOT_START_NS={boot_start_ns}",
                 self.get_exec_path(),
                 self.get_workdir(),
                 self.get_rlimits(),


### PR DESCRIPTION
## Summary
- Capture host wall-clock time (epoch nanoseconds) in `Vm::enter()` right before kernel cmdline assembly
- Inject it as `KRUN_BOOT_START_NS` into the `krun_env` section of the kernel cmdline
- The Linux kernel exposes `KEY=VALUE` pairs from the cmdline as environment variables to PID 1, so the guest init process can read this value to compute end-to-end VM boot time
- Part of the boot time measurement feature for microsandbox/agentd

## Changes
- Modified `src/krun/src/api/vm.rs`:
  - Added `use std::time::SystemTime` import
  - Capture `SystemTime::now()` as epoch nanoseconds before kernel cmdline construction
  - Appended `KRUN_BOOT_START_NS={boot_start_ns}` to the `krun_env` format string alongside existing `KRUN_INIT`, `KRUN_WORKDIR`, `KRUN_RLIMITS`, and `KRUN_ENV`
- No new dependencies added (uses `std::time::SystemTime`)
- No breaking changes

## Test Plan
- Run `cargo check --package msb_krun` to verify compilation
- Run `cargo build` to verify full workspace builds
- Boot a VM and verify `KRUN_BOOT_START_NS` appears in `/proc/cmdline` inside the guest
- Verify the value is a valid epoch nanosecond timestamp