### PR TITLE
feat: forward kill_priv in DynFileSystem, add disable_implicit console

### DIFF
--- a/src/devices/src/virtio/fs/dyn_filesystem.rs
+++ b/src/devices/src/virtio/fs/dyn_filesystem.rs
@@ -153,7 +153,13 @@ pub trait DynFileSystem: Send + Sync {
     }
 
     /// Open a file.
-    fn open(&self, ctx: Context, inode: u64, flags: u32) -> io::Result<(Option<u64>, OpenOptions)> {
+    fn open(
+        &self,
+        ctx: Context,
+        inode: u64,
+        kill_priv: bool,
+        flags: u32,
+    ) -> io::Result<(Option<u64>, OpenOptions)> {
         Ok((None, OpenOptions::empty()))
     }
 
@@ -165,6 +171,7 @@ pub trait DynFileSystem: Send + Sync {
         parent: u64,
         name: &CStr,
         mode: u32,
+        kill_priv: bool,
         flags: u32,
         umask: u32,
         extensions: Extensions,
@@ -580,10 +587,10 @@ impl FileSystem for DynFileSystemAdapter {
         &self,
         ctx: Context,
         inode: u64,
-        _kill_priv: bool,
+        kill_priv: bool,
         flags: u32,
     ) -> io::Result<(Option<u64>, OpenOptions)> {
-        self.0.open(ctx, inode, flags)
+        self.0.open(ctx, inode, kill_priv, flags)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -593,13 +600,13 @@ impl FileSystem for DynFileSystemAdapter {
         parent: u64,
         name: &CStr,
         mode: u32,
-        _kill_priv: bool,
+        kill_priv: bool,
         flags: u32,
         umask: u32,
         extensions: Extensions,
     ) -> io::Result<(Entry, Option<u64>, OpenOptions)> {
         self.0
-            .create(ctx, parent, name, mode, flags, umask, extensions)
+            .create(ctx, parent, name, mode, kill_priv, flags, umask, extensions)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -334,6 +334,10 @@ impl VmBuilder {
                 .push(VirtioConsoleConfigMode::Explicit(self.console.ports));
         }
 
+        if self.console.disable_implicit {
+            vmr.disable_implicit_console = true;
+        }
+
         // Format execution configuration
         let exec_path = self.exec.path;
 

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -171,6 +171,7 @@ pub enum NetConfig {
 pub struct ConsoleBuilder {
     pub(crate) output: Option<PathBuf>,
     pub(crate) ports: Vec<PortConfig>,
+    pub(crate) disable_implicit: bool,
     #[cfg(feature = "snd")]
     pub(crate) sound: bool,
     #[cfg(feature = "gpu")]
@@ -510,6 +511,15 @@ impl ConsoleBuilder {
             name: name.to_string(),
             tty_fd,
         });
+        self
+    }
+
+    /// Disable the implicit console device.
+    ///
+    /// By default libkrun creates an implicit console that reads from `STDIN_FILENO`.
+    /// Call this to suppress that console when using only explicit ports.
+    pub fn disable_implicit(mut self) -> Self {
+        self.disable_implicit = true;
         self
     }
 }


### PR DESCRIPTION
## Summary
- Forward the `kill_priv` parameter through `DynFileSystem::open` and `DynFileSystem::create` trait methods instead of discarding it in the adapter, allowing implementations to handle FUSE privilege-killing semantics correctly.
- Add `ConsoleBuilder::disable_implicit()` API to suppress the default stdin-based console device when only explicit console ports are configured.
- These changes improve correctness of the virtio-fs layer and give consumers more control over console device creation.

## Changes
- **src/devices/src/virtio/fs/dyn_filesystem.rs**: Added `kill_priv: bool` parameter to `DynFileSystem::open` and `DynFileSystem::create` trait methods. Updated `DynFileSystemAdapter` to forward `kill_priv` to the inner implementation instead of ignoring it with `_kill_priv`.
- **src/krun/src/api/builders.rs**: Added `disable_implicit: bool` field to `ConsoleBuilder` and a public `disable_implicit()` builder method with documentation.
- **src/krun/src/api/builder.rs**: Wired `ConsoleBuilder::disable_implicit` into `VmBuilder::build()` to set `vmr.disable_implicit_console` when enabled.

## Test Plan
- Run `cargo build` to verify successful compilation
- Run `cargo build --all-features` to ensure all feature combinations work
- Verify that existing tests pass: `cargo test`
- Manually confirm that custom `DynFileSystem` implementations now receive the `kill_priv` flag in `open` and `create` calls
- Test `ConsoleBuilder::disable_implicit()` suppresses the default console when only explicit ports are used