### PR TITLE
feat(krun): add net builder convenience methods and wire up build()

### DIFF
--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -116,7 +116,6 @@ impl Net {
     pub fn id(&self) -> &str {
         &self.id
     }
-
 }
 
 impl VirtioDevice for Net {

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -13,7 +13,7 @@ use crate::virtio::{
 };
 use crate::Error as DeviceError;
 
-use super::backend::{ReadError, WriteError};
+use super::backend::{NetBackend, ReadError, WriteError};
 use super::worker::NetWorker;
 
 use std::cmp;
@@ -59,7 +59,6 @@ struct VirtioNetConfig {
 // Safe because it only has data and has no implicit padding.
 unsafe impl ByteValued for VirtioNetConfig {}
 
-#[derive(Clone)]
 pub enum VirtioNetBackend {
     UnixstreamFd(RawFd),
     UnixstreamPath(PathBuf),
@@ -67,11 +66,12 @@ pub enum VirtioNetBackend {
     UnixgramPath(PathBuf, bool),
     #[cfg(target_os = "linux")]
     Tap(String),
+    Custom(Box<dyn NetBackend + Send>),
 }
 
 pub struct Net {
     id: String,
-    pub cfg_backend: VirtioNetBackend,
+    pub cfg_backend: Option<VirtioNetBackend>,
 
     avail_features: u64,
     acked_features: u64,
@@ -102,7 +102,7 @@ impl Net {
 
         Ok(Net {
             id,
-            cfg_backend,
+            cfg_backend: Some(cfg_backend),
 
             avail_features,
             acked_features: 0u64,
@@ -117,10 +117,6 @@ impl Net {
         &self.id
     }
 
-    /// Provides the virtio-net backend of this net device.
-    pub fn backend(&self) -> &VirtioNetBackend {
-        &self.cfg_backend
-    }
 }
 
 impl VirtioDevice for Net {
@@ -181,13 +177,18 @@ impl VirtioDevice for Net {
             ActivateError::BadActivate
         })?;
 
+        let cfg_backend = self.cfg_backend.take().ok_or_else(|| {
+            error!("Cannot activate net device: backend already taken");
+            ActivateError::BadActivate
+        })?;
+
         match NetWorker::new(
             rx_q,
             tx_q,
             interrupt.clone(),
             mem.clone(),
             self.acked_features,
-            self.cfg_backend.clone(),
+            cfg_backend,
         ) {
             Ok(worker) => {
                 worker.run();

--- a/src/devices/src/virtio/net/worker.rs
+++ b/src/devices/src/virtio/net/worker.rs
@@ -65,6 +65,7 @@ impl NetWorker {
             VirtioNetBackend::Tap(tap_name) => {
                 Box::new(Tap::new(tap_name, _vnet_features)?) as Box<dyn NetBackend + Send>
             }
+            VirtioNetBackend::Custom(backend) => backend,
         };
 
         Ok(Self {

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -16,11 +16,18 @@ use super::builders::DiskBuilder;
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 use super::builders::FsConfig;
 #[cfg(feature = "net")]
-use super::builders::NetBuilder;
+use super::builders::{NetBuilder, NetConfig};
 use super::builders::{ConsoleBuilder, ExecBuilder, FsBuilder, KernelBuilder, MachineBuilder};
 
 use super::error::{ConfigError, Error, Result};
 use super::vm::Vm;
+
+#[cfg(feature = "net")]
+use devices::virtio::net::device::VirtioNetBackend;
+#[cfg(feature = "net")]
+use std::os::fd::IntoRawFd;
+#[cfg(feature = "net")]
+use vmm::vmm_config::net::NetworkInterfaceConfig;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -158,11 +165,27 @@ impl VmBuilder {
     ///
     /// Can be called multiple times to add multiple devices.
     ///
-    /// # Example
+    /// # Examples
+    ///
+    /// Unixgram from a pre-opened fd:
     ///
     /// ```rust,ignore
     /// VmBuilder::new()
-    ///     .net(|n| n.mac([0x52, 0x54, 0x00, 0x12, 0x34, 0x56]).custom(my_backend));
+    ///     .net(|n| n.mac([0x52, 0x54, 0x00, 0x12, 0x34, 0x56]).unixgram(fd));
+    /// ```
+    ///
+    /// Unixgram connecting to a socket path:
+    ///
+    /// ```rust,ignore
+    /// VmBuilder::new()
+    ///     .net(|n| n.unixgram_path("/tmp/net.sock", true));
+    /// ```
+    ///
+    /// Custom backend:
+    ///
+    /// ```rust,ignore
+    /// VmBuilder::new()
+    ///     .net(|n| n.custom(Box::new(my_backend)));
     /// ```
     #[cfg(feature = "net")]
     pub fn net(mut self, f: impl FnOnce(NetBuilder) -> NetBuilder) -> Self {
@@ -338,6 +361,46 @@ impl VmBuilder {
             vmr.disable_implicit_console = true;
         }
 
+        // Apply network configuration
+        #[cfg(feature = "net")]
+        for (i, config) in self.net.configs.into_iter().enumerate() {
+            let (mac, backend) = match config {
+                NetConfig::UnixgramFd { mac, fd } => {
+                    (mac, VirtioNetBackend::UnixgramFd(fd.into_raw_fd()))
+                }
+                NetConfig::UnixgramPath {
+                    mac,
+                    path,
+                    send_vfkit_magic,
+                } => (mac, VirtioNetBackend::UnixgramPath(path, send_vfkit_magic)),
+                NetConfig::UnixstreamFd { mac, fd } => {
+                    (mac, VirtioNetBackend::UnixstreamFd(fd.into_raw_fd()))
+                }
+                NetConfig::UnixstreamPath { mac, path } => {
+                    (mac, VirtioNetBackend::UnixstreamPath(path))
+                }
+                #[cfg(target_os = "linux")]
+                NetConfig::Tap { mac, name } => (mac, VirtioNetBackend::Tap(name)),
+                NetConfig::Custom { mac, backend } => {
+                    (mac, VirtioNetBackend::Custom(backend))
+                }
+            };
+
+            let mac = mac.unwrap_or_else(|| generate_mac(i));
+            let iface_id = format!("eth{i}");
+
+            let net_config = NetworkInterfaceConfig {
+                iface_id,
+                backend,
+                mac,
+                features: 0,
+            };
+
+            vmr.net
+                .insert(net_config)
+                .map_err(|e| Error::Config(ConfigError::Network(e.to_string())))?;
+        }
+
         // Format execution configuration
         let exec_path = self.exec.path;
 
@@ -402,4 +465,14 @@ impl Default for VmBuilder {
     fn default() -> Self {
         Self::new()
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Generate a locally-administered MAC address from an interface index.
+#[cfg(feature = "net")]
+fn generate_mac(index: usize) -> [u8; 6] {
+    [0x52, 0x54, 0x00, 0x12, 0x34, 0x56u8.wrapping_add(index as u8)]
 }

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -15,9 +15,9 @@ use vmm::vmm_config::fs::FsDeviceConfig;
 use super::builders::DiskBuilder;
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 use super::builders::FsConfig;
+use super::builders::{ConsoleBuilder, ExecBuilder, FsBuilder, KernelBuilder, MachineBuilder};
 #[cfg(feature = "net")]
 use super::builders::{NetBuilder, NetConfig};
-use super::builders::{ConsoleBuilder, ExecBuilder, FsBuilder, KernelBuilder, MachineBuilder};
 
 use super::error::{ConfigError, Error, Result};
 use super::vm::Vm;
@@ -381,9 +381,7 @@ impl VmBuilder {
                 }
                 #[cfg(target_os = "linux")]
                 NetConfig::Tap { mac, name } => (mac, VirtioNetBackend::Tap(name)),
-                NetConfig::Custom { mac, backend } => {
-                    (mac, VirtioNetBackend::Custom(backend))
-                }
+                NetConfig::Custom { mac, backend } => (mac, VirtioNetBackend::Custom(backend)),
             };
 
             let mac = mac.unwrap_or_else(|| generate_mac(i));
@@ -474,5 +472,12 @@ impl Default for VmBuilder {
 /// Generate a locally-administered MAC address from an interface index.
 #[cfg(feature = "net")]
 fn generate_mac(index: usize) -> [u8; 6] {
-    [0x52, 0x54, 0x00, 0x12, 0x34, 0x56u8.wrapping_add(index as u8)]
+    [
+        0x52,
+        0x54,
+        0x00,
+        0x12,
+        0x34,
+        0x56u8.wrapping_add(index as u8),
+    ]
 }

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -139,10 +139,7 @@ pub struct NetBuilder {
 #[cfg(feature = "net")]
 pub enum NetConfig {
     /// Unixgram backend from a pre-opened fd.
-    UnixgramFd {
-        mac: Option<[u8; 6]>,
-        fd: OwnedFd,
-    },
+    UnixgramFd { mac: Option<[u8; 6]>, fd: OwnedFd },
     /// Unixgram backend connecting to a socket path.
     UnixgramPath {
         mac: Option<[u8; 6]>,
@@ -150,21 +147,12 @@ pub enum NetConfig {
         send_vfkit_magic: bool,
     },
     /// Unixstream backend from a pre-opened fd.
-    UnixstreamFd {
-        mac: Option<[u8; 6]>,
-        fd: OwnedFd,
-    },
+    UnixstreamFd { mac: Option<[u8; 6]>, fd: OwnedFd },
     /// Unixstream backend connecting to a socket path.
-    UnixstreamPath {
-        mac: Option<[u8; 6]>,
-        path: PathBuf,
-    },
+    UnixstreamPath { mac: Option<[u8; 6]>, path: PathBuf },
     /// TAP backend (Linux only).
     #[cfg(target_os = "linux")]
-    Tap {
-        mac: Option<[u8; 6]>,
-        name: String,
-    },
+    Tap { mac: Option<[u8; 6]>, name: String },
     /// Custom network backend.
     Custom {
         mac: Option<[u8; 6]>,

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -9,6 +9,9 @@ use vmm::resources::PortConfig;
 use crate::backends::fs::DynFileSystem;
 
 #[cfg(feature = "net")]
+use std::os::fd::OwnedFd;
+
+#[cfg(feature = "net")]
 use crate::backends::net::NetBackend;
 
 //--------------------------------------------------------------------------------------------------
@@ -135,6 +138,33 @@ pub struct NetBuilder {
 /// Configuration for a single network device.
 #[cfg(feature = "net")]
 pub enum NetConfig {
+    /// Unixgram backend from a pre-opened fd.
+    UnixgramFd {
+        mac: Option<[u8; 6]>,
+        fd: OwnedFd,
+    },
+    /// Unixgram backend connecting to a socket path.
+    UnixgramPath {
+        mac: Option<[u8; 6]>,
+        path: PathBuf,
+        send_vfkit_magic: bool,
+    },
+    /// Unixstream backend from a pre-opened fd.
+    UnixstreamFd {
+        mac: Option<[u8; 6]>,
+        fd: OwnedFd,
+    },
+    /// Unixstream backend connecting to a socket path.
+    UnixstreamPath {
+        mac: Option<[u8; 6]>,
+        path: PathBuf,
+    },
+    /// TAP backend (Linux only).
+    #[cfg(target_os = "linux")]
+    Tap {
+        mac: Option<[u8; 6]>,
+        name: String,
+    },
     /// Custom network backend.
     Custom {
         mac: Option<[u8; 6]>,
@@ -432,6 +462,52 @@ impl NetBuilder {
     /// Set the MAC address for the next network device.
     pub fn mac(mut self, mac: [u8; 6]) -> Self {
         self.current_mac = Some(mac);
+        self
+    }
+
+    /// Attach a unixgram network backend from a pre-opened fd.
+    pub fn unixgram(mut self, fd: OwnedFd) -> Self {
+        let mac = self.current_mac.take();
+        self.configs.push(NetConfig::UnixgramFd { mac, fd });
+        self
+    }
+
+    /// Attach a unixgram network backend connecting to a socket path.
+    pub fn unixgram_path(mut self, path: impl AsRef<Path>, send_vfkit_magic: bool) -> Self {
+        let mac = self.current_mac.take();
+        self.configs.push(NetConfig::UnixgramPath {
+            mac,
+            path: path.as_ref().to_path_buf(),
+            send_vfkit_magic,
+        });
+        self
+    }
+
+    /// Attach a unixstream network backend from a pre-opened fd.
+    pub fn unixstream(mut self, fd: OwnedFd) -> Self {
+        let mac = self.current_mac.take();
+        self.configs.push(NetConfig::UnixstreamFd { mac, fd });
+        self
+    }
+
+    /// Attach a unixstream network backend connecting to a socket path.
+    pub fn unixstream_path(mut self, path: impl AsRef<Path>) -> Self {
+        let mac = self.current_mac.take();
+        self.configs.push(NetConfig::UnixstreamPath {
+            mac,
+            path: path.as_ref().to_path_buf(),
+        });
+        self
+    }
+
+    /// Attach a TAP network backend.
+    #[cfg(target_os = "linux")]
+    pub fn tap(mut self, name: impl Into<String>) -> Self {
+        let mac = self.current_mac.take();
+        self.configs.push(NetConfig::Tap {
+            mac,
+            name: name.into(),
+        });
         self
     }
 

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -381,8 +381,8 @@ impl TryFrom<ContextConfig> for NitroEnclave {
                     let device = list.pop_front().unwrap();
                     let device = device.lock().unwrap();
 
-                    let fd = match device.cfg_backend {
-                        VirtioNetBackend::UnixstreamFd(fd) => RawFd::from(fd),
+                    let fd = match device.cfg_backend.as_ref() {
+                        Some(VirtioNetBackend::UnixstreamFd(fd)) => RawFd::from(*fd),
                         _ => return Err(libc::EINVAL),
                     };
 


### PR DESCRIPTION
## Summary

- Add dedicated NetBuilder methods for known network backends (unixgram, unixstream, tap) so users don't need to manually construct and box backends via `.custom()`
- Wire up `VmBuilder::build()` to apply net configs to `VmResources`, fixing the bug where all network configuration was silently dropped
- Add `VirtioNetBackend::Custom` variant to support passing trait object backends through the device layer
- Change `cfg_backend` to `Option<VirtioNetBackend>` with `.take()` semantics to avoid requiring `Clone` on the enum

## Changes

- `src/krun/src/api/builders.rs`: Expand `NetConfig` enum with `UnixgramFd`, `UnixgramPath`, `UnixstreamFd`, `UnixstreamPath`, `Tap` (linux-only), and `Custom` variants. Add convenience methods `.unixgram(fd)`, `.unixgram_path(path, send_vfkit_magic)`, `.unixstream(fd)`, `.unixstream_path(path)`, `.tap(name)` to `NetBuilder`
- `src/krun/src/api/builder.rs`: Wire up `self.net.configs` in `build()` to create `NetworkInterfaceConfig` entries and insert into `vmr.net`. Add `generate_mac()` helper for auto-assigning locally-administered MACs. Update doc examples to show new convenience methods
- `src/devices/src/virtio/net/device.rs`: Add `Custom(Box<dyn NetBackend + Send>)` variant to `VirtioNetBackend`. Remove `#[derive(Clone)]`. Change `cfg_backend` to `Option<VirtioNetBackend>` and use `.take()` in `activate()`. Remove unused `backend()` method
- `src/devices/src/virtio/net/worker.rs`: Handle `VirtioNetBackend::Custom` variant in `NetWorker::new()`
- `src/libkrun/src/lib.rs`: Update pattern match to handle `Option<VirtioNetBackend>` via `.as_ref()`

## Test Plan

- Run `cargo check --features net` to verify compilation with net feature enabled
- Run `cargo check` to verify compilation without net feature (no warnings)
- Verify the `examples/rust_vm` example still compiles
- Verify the C API in `src/libkrun` still compiles