### PR TITLE
chore: bump msb_krun crates from 0.1.1 to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -961,11 +961,11 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.1"
+version = "0.1.2"
 
 [[package]]
 name = "msb_krun_aws_nitro"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "libc",
  "log",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_display"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bindgen 0.72.0",
  "bitflags 2.10.0",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "crossbeam-channel",
  "libloading",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_input"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bindgen 0.72.0",
  "bitflags 2.10.0",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "msb_krun_utils",
  "vm-memory",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_rutabaga_gfx"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1086,14 +1086,14 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -723,7 +723,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "msb_krun_display"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bindgen",
  "bitflags 2.9.1",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_input"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bindgen",
  "bitflags 2.9.1",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_arch"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Chromium OS Authors"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
@@ -18,9 +18,9 @@ libc = ">=0.2.39"
 vm-memory = { version = "~0.16", features = ["backend-mmap"] }
 vmm-sys-util = ">= 0.14"
 
-arch_gen = { package = "msb_krun_arch_gen", version = "0.1.1", path = "../arch_gen" }
-smbios = { package = "msb_krun_smbios", version = "0.1.1", path = "../smbios" }
-utils = { package = "msb_krun_utils", version = "0.1.1", path = "../utils" }
+arch_gen = { package = "msb_krun_arch_gen", version = "0.1.2", path = "../arch_gen" }
+smbios = { package = "msb_krun_smbios", version = "0.1.2", path = "../smbios" }
+utils = { package = "msb_krun_utils", version = "0.1.2", path = "../utils" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
@@ -28,4 +28,4 @@ kvm-ioctls = ">=0.21"
 tdx = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
-utils = { package = "msb_krun_utils", version = "0.1.1", path = "../utils" }
+utils = { package = "msb_krun_utils", version = "0.1.2", path = "../utils" }

--- a/src/arch_gen/Cargo.toml
+++ b/src/arch_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_arch_gen"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"

--- a/src/aws_nitro/Cargo.toml
+++ b/src/aws_nitro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_aws_nitro"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "AWS Nitro Enclaves support for msb_krun microVMs"
@@ -15,7 +15,7 @@ nix = { version = "0.30", features = ["poll"] }
 tar = "0.4"
 vsock = "0.5"
 
-devices = { package = "msb_krun_devices", version = "0.1.1", path = "../devices" }
+devices = { package = "msb_krun_devices", version = "0.1.2", path = "../devices" }
 log = "0.4"
 signal-hook = "0.3"
 

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_cpuid"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_devices"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Chromium OS Authors"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
@@ -35,21 +35,21 @@ thiserror = { version = "2.0", optional = true }
 virtio-bindings = "0.2.0"
 vm-memory = { version = "~0.16", features = ["backend-mmap"] }
 zerocopy = { version = "0.8.26", optional = true, features = ["derive"] }
-krun_display = { package = "msb_krun_display", version = "0.1.1", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
-krun_input = { package = "msb_krun_input", version = "0.1.1", path = "../krun_input", features = ["bindgen_clang_runtime"], optional = true }
+krun_display = { package = "msb_krun_display", version = "0.1.2", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
+krun_input = { package = "msb_krun_input", version = "0.1.2", path = "../krun_input", features = ["bindgen_clang_runtime"], optional = true }
 
-arch = { package = "msb_krun_arch", version = "0.1.1", path = "../arch" }
-utils = { package = "msb_krun_utils", version = "0.1.1", path = "../utils" }
-polly = { package = "msb_krun_polly", version = "0.1.1", path = "../polly" }
-rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.1", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
+arch = { package = "msb_krun_arch", version = "0.1.2", path = "../arch" }
+utils = { package = "msb_krun_utils", version = "0.1.2", path = "../utils" }
+polly = { package = "msb_krun_polly", version = "0.1.2", path = "../polly" }
+rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.2", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
 imago = { version = "0.2.1", features = ["sync-wrappers", "vm-memory"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "msb_krun_hvf", version = "0.1.1", path = "../hvf" }
+hvf = { package = "msb_krun_hvf", version = "0.1.2", path = "../hvf" }
 lru = ">=0.9"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.1", path = "../rutabaga_gfx", features = ["x"], optional = true }
+rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.2", path = "../rutabaga_gfx", features = ["x"], optional = true }
 caps = "0.5.5"
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"

--- a/src/hvf/Cargo.toml
+++ b/src/hvf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_hvf"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Sergio Lopez <slp@sinrega.org>"]
 edition = "2021"
 build = "build.rs"
@@ -13,4 +13,4 @@ crossbeam-channel = ">=0.5.15"
 libloading = "0.8"
 log = "0.4.0"
 
-arch = { package = "msb_krun_arch", version = "0.1.1", path = "../arch" }
+arch = { package = "msb_krun_arch", version = "0.1.2", path = "../arch" }

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_kernel"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
 description = "Kernel loading utilities for msb_krun microVMs"
@@ -9,4 +9,4 @@ repository = "https://github.com/containers/libkrun"
 [dependencies]
 vm-memory = { version = "~0.16", features = ["backend-mmap"] }
 
-utils = { package = "msb_krun_utils", version = "0.1.1", path = "../utils" }
+utils = { package = "msb_krun_utils", version = "0.1.2", path = "../utils" }

--- a/src/krun/Cargo.toml
+++ b/src/krun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The libkrun Authors"]
 edition = "2021"
 description = "Native Rust API for libkrun microVMs"
@@ -26,21 +26,21 @@ libc = ">=0.2.39"
 libloading = "0.8"
 log = "0.4.0"
 
-devices = { package = "msb_krun_devices", version = "0.1.1", path = "../devices" }
-polly = { package = "msb_krun_polly", version = "0.1.1", path = "../polly" }
-utils = { package = "msb_krun_utils", version = "0.1.1", path = "../utils" }
-vmm = { package = "msb_krun_vmm", version = "0.1.1", path = "../vmm" }
+devices = { package = "msb_krun_devices", version = "0.1.2", path = "../devices" }
+polly = { package = "msb_krun_polly", version = "0.1.2", path = "../polly" }
+utils = { package = "msb_krun_utils", version = "0.1.2", path = "../utils" }
+vmm = { package = "msb_krun_vmm", version = "0.1.2", path = "../vmm" }
 
 # Optional dependencies
-krun_display = { package = "msb_krun_display", version = "0.1.1", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
-krun_input = { package = "msb_krun_input", version = "0.1.1", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
+krun_display = { package = "msb_krun_display", version = "0.1.2", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
+krun_input = { package = "msb_krun_input", version = "0.1.2", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "msb_krun_hvf", version = "0.1.1", path = "../hvf" }
+hvf = { package = "msb_krun_hvf", version = "0.1.2", path = "../hvf" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"
 vm-memory = { version = "~0.16", features = ["backend-mmap"] }
-aws-nitro = { package = "msb_krun_aws_nitro", version = "0.1.1", path = "../aws_nitro", optional = true }
+aws-nitro = { package = "msb_krun_aws_nitro", version = "0.1.2", path = "../aws_nitro", optional = true }
 nitro-enclaves = { version = "0.6.0", optional = true }

--- a/src/krun_display/Cargo.toml
+++ b/src/krun_display/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msb_krun_display"
 description = "Rust bindings for implemeting display backends in Rust for libkrun"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/containers/libkrun"

--- a/src/krun_input/Cargo.toml
+++ b/src/krun_input/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msb_krun_input"
 description = "Rust bindings for implementing input backends in Rust for libkrun"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/containers/libkrun"

--- a/src/polly/Cargo.toml
+++ b/src/polly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_polly"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -9,4 +9,4 @@ repository = "https://github.com/containers/libkrun"
 
 [dependencies]
 libc = ">=0.2.39"
-utils = { package = "msb_krun_utils", version = "0.1.1", path = "../utils" }
+utils = { package = "msb_krun_utils", version = "0.1.2", path = "../utils" }

--- a/src/rutabaga_gfx/Cargo.toml
+++ b/src/rutabaga_gfx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_rutabaga_gfx"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The ChromiumOS Authors + Android Open Source Project"]
 edition = "2021"
 description = "[highly unstable] Handling virtio-gpu protocols"

--- a/src/smbios/Cargo.toml
+++ b/src/smbios/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_smbios"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "SMBIOS table generation for msb_krun microVMs"

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_utils"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_vmm"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
@@ -28,15 +28,15 @@ log = "0.4.0"
 nix = { version = "0.30.1", features = ["fs", "term"] }
 vm-memory = { version = "~0.16", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.14"
-krun_display = { package = "msb_krun_display", version = "0.1.1", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
-krun_input = { package = "msb_krun_input", version = "0.1.1", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
+krun_display = { package = "msb_krun_display", version = "0.1.2", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
+krun_input = { package = "msb_krun_input", version = "0.1.2", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
 
-arch = { package = "msb_krun_arch", version = "0.1.1", path = "../arch" }
-arch_gen = { package = "msb_krun_arch_gen", version = "0.1.1", path = "../arch_gen" }
-devices = { package = "msb_krun_devices", version = "0.1.1", path = "../devices" }
-kernel = { package = "msb_krun_kernel", version = "0.1.1", path = "../kernel" }
-utils = { package = "msb_krun_utils", version = "0.1.1", path = "../utils" }
-polly = { package = "msb_krun_polly", version = "0.1.1", path = "../polly" }
+arch = { package = "msb_krun_arch", version = "0.1.2", path = "../arch" }
+arch_gen = { package = "msb_krun_arch_gen", version = "0.1.2", path = "../arch_gen" }
+devices = { package = "msb_krun_devices", version = "0.1.2", path = "../devices" }
+kernel = { package = "msb_krun_kernel", version = "0.1.2", path = "../kernel" }
+utils = { package = "msb_krun_utils", version = "0.1.2", path = "../utils" }
+polly = { package = "msb_krun_polly", version = "0.1.2", path = "../polly" }
 
 # Dependencies for amd-sev
 kbs-types = { version = "0.13.0", optional = true }
@@ -48,7 +48,7 @@ bitflags = { version = "2.10.0", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 bzip2 = "0.5"
-cpuid = { package = "msb_krun_cpuid", version = "0.1.1", path = "../cpuid" }
+cpuid = { package = "msb_krun_cpuid", version = "0.1.2", path = "../cpuid" }
 zstd = "0.13"
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -57,7 +57,7 @@ kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "msb_krun_hvf", version = "0.1.1", path = "../hvf" }
+hvf = { package = "msb_krun_hvf", version = "0.1.2", path = "../hvf" }
 
 [dev-dependencies]
-devices = { package = "msb_krun_devices", version = "0.1.1", path = "../devices", features = ["test_utils"] }
+devices = { package = "msb_krun_devices", version = "0.1.2", path = "../devices", features = ["test_utils"] }


### PR DESCRIPTION
## Summary
- Bump all 15 msb_krun* workspace crates from 0.1.1 to 0.1.2
- Update inter-crate dependency version references to match
- Prepare for crates.io publish after recent feature additions

Changes since 0.1.1:
- feat(krun): add net builder convenience methods and wire up build() (#33)

## Changes
- Updated `version` field from "0.1.1" to "0.1.2" in all 15 msb_krun* crate Cargo.toml files
- Updated all inter-crate dependency references (35 occurrences) to require "0.1.2"
- Cargo.lock regenerated to reflect new versions
- Affected crates: msb_krun, msb_krun_arch, msb_krun_arch_gen, msb_krun_aws_nitro, msb_krun_cpuid, msb_krun_devices, msb_krun_display, msb_krun_hvf, msb_krun_input, msb_krun_kernel, msb_krun_polly, msb_krun_rutabaga_gfx, msb_krun_smbios, msb_krun_utils, msb_krun_vmm
- No code changes, only version metadata updates

## Test Plan
- Run `cargo build` to verify successful compilation with updated versions
- Verify Cargo.lock is consistent with the version changes