### PR TITLE
feat(krun): add blk builder with disk format support and wire up build()

### DIFF
--- a/src/krun/Cargo.toml
+++ b/src/krun/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 [features]
 default = []
 net = ["devices/net", "vmm/net"]
-blk = []
+blk = ["devices/blk", "vmm/blk"]
 gpu = ["krun_display"]
 snd = []
 tee = []

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -22,6 +22,13 @@ use super::builders::{NetBuilder, NetConfig};
 use super::error::{ConfigError, Error, Result};
 use super::vm::Vm;
 
+#[cfg(feature = "blk")]
+use devices::virtio::block::ImageType;
+#[cfg(feature = "blk")]
+use devices::virtio::CacheType;
+#[cfg(feature = "blk")]
+use vmm::vmm_config::block::BlockDeviceConfig;
+
 #[cfg(feature = "net")]
 use devices::virtio::net::device::VirtioNetBackend;
 #[cfg(feature = "net")]
@@ -397,6 +404,26 @@ impl VmBuilder {
             vmr.net
                 .insert(net_config)
                 .map_err(|e| Error::Config(ConfigError::Network(e.to_string())))?;
+        }
+
+        // Apply block device configuration
+        #[cfg(feature = "blk")]
+        for (i, config) in self.disk.configs.into_iter().enumerate() {
+            let block_id = format!("vd{}", (b'a' + i as u8) as char);
+            let image_type: ImageType = config.format.into();
+
+            let blk_config = BlockDeviceConfig {
+                block_id,
+                cache_type: CacheType::Writeback,
+                disk_image_path: config.path.to_string_lossy().to_string(),
+                disk_image_format: image_type,
+                is_disk_read_only: config.read_only,
+                direct_io: false,
+                sync_mode: devices::virtio::block::SyncMode::default(),
+            };
+
+            vmr.add_block_device(blk_config)
+                .map_err(|e| Error::Config(ConfigError::Block(e.to_string())))?;
         }
 
         // Format execution configuration

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -248,6 +248,15 @@ pub struct ExecBuilder {
 // Types: Disk Builder
 //--------------------------------------------------------------------------------------------------
 
+/// Supported disk image formats.
+#[cfg(feature = "blk")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiskImageFormat {
+    Raw,
+    Qcow2,
+    Vmdk,
+}
+
 /// Builder for block device configuration.
 ///
 /// # Example
@@ -258,11 +267,12 @@ pub struct ExecBuilder {
 ///     .disk(|d| d.path("/path/to/disk.img").read_only(true));
 /// ```
 #[cfg(feature = "blk")]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct DiskBuilder {
     pub(crate) configs: Vec<DiskConfig>,
     current_path: Option<PathBuf>,
     current_read_only: bool,
+    current_format: DiskImageFormat,
 }
 
 /// Configuration for a single block device.
@@ -271,6 +281,7 @@ pub struct DiskBuilder {
 pub struct DiskConfig {
     pub path: PathBuf,
     pub read_only: bool,
+    pub format: DiskImageFormat,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -667,7 +678,18 @@ impl ExecBuilder {
 impl DiskBuilder {
     /// Create a new disk builder.
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            configs: Vec::new(),
+            current_path: None,
+            current_read_only: false,
+            current_format: DiskImageFormat::Raw,
+        }
+    }
+
+    /// Set the disk image format for the current disk.
+    pub fn format(mut self, format: DiskImageFormat) -> Self {
+        self.current_format = format;
+        self
     }
 
     /// Set the path for a block device.
@@ -677,8 +699,10 @@ impl DiskBuilder {
             self.configs.push(DiskConfig {
                 path: pending_path,
                 read_only: self.current_read_only,
+                format: self.current_format,
             });
             self.current_read_only = false;
+            self.current_format = DiskImageFormat::Raw;
         }
 
         self.current_path = Some(path.as_ref().to_path_buf());
@@ -697,8 +721,31 @@ impl DiskBuilder {
             self.configs.push(DiskConfig {
                 path,
                 read_only: self.current_read_only,
+                format: self.current_format,
             });
         }
         self
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations: Disk Builder
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(feature = "blk")]
+impl Default for DiskBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "blk")]
+impl From<DiskImageFormat> for devices::virtio::block::ImageType {
+    fn from(format: DiskImageFormat) -> Self {
+        match format {
+            DiskImageFormat::Raw => devices::virtio::block::ImageType::Raw,
+            DiskImageFormat::Qcow2 => devices::virtio::block::ImageType::Qcow2,
+            DiskImageFormat::Vmdk => devices::virtio::block::ImageType::Vmdk,
+        }
     }
 }

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -39,6 +39,8 @@ pub mod vm;
 pub use builder::VmBuilder;
 #[cfg(feature = "blk")]
 pub use builders::DiskBuilder;
+#[cfg(feature = "blk")]
+pub use builders::DiskImageFormat;
 #[cfg(feature = "net")]
 pub use builders::NetBuilder;
 pub use builders::{ConsoleBuilder, ExecBuilder, FsBuilder, KernelBuilder, MachineBuilder};

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -40,6 +40,8 @@ pub mod backends;
 pub use api::builder::VmBuilder;
 #[cfg(feature = "blk")]
 pub use api::builders::DiskBuilder;
+#[cfg(feature = "blk")]
+pub use api::builders::DiskImageFormat;
 #[cfg(feature = "net")]
 pub use api::builders::NetBuilder;
 pub use api::builders::{ConsoleBuilder, ExecBuilder, FsBuilder, KernelBuilder, MachineBuilder};


### PR DESCRIPTION
## Summary

- Wire up the `blk` feature flag to `devices/blk` and `vmm/blk` dependencies, enabling block device support in krun
- Add `DiskImageFormat` enum supporting Raw, Qcow2, and Vmdk disk image formats
- Add format selection to `DiskBuilder` and integrate block device configuration into `VmBuilder::build()`
- Follows the same pattern established by the net builder in #33

## Changes

- **src/krun/Cargo.toml**: Wire `blk` feature to `devices/blk` and `vmm/blk` dependencies (previously the feature flag was empty)
- **src/krun/src/api/builders.rs**: Add `DiskImageFormat` enum (Raw, Qcow2, Vmdk) with `From<DiskImageFormat> for ImageType` conversion; add `format` field to `DiskConfig` and `current_format` field to `DiskBuilder`; add `format()` builder method; implement explicit `Default` for `DiskBuilder`; propagate format through `path()` and `done()` methods
- **src/krun/src/api/builder.rs**: Import block-related types (`ImageType`, `CacheType`, `BlockDeviceConfig`); add block device configuration loop in `build()` that generates block IDs (vda, vdb, ...), converts format, and calls `vmr.add_block_device()`
- **src/krun/src/api/mod.rs**: Re-export `DiskImageFormat` under `cfg(feature = "blk")`
- **src/krun/src/lib.rs**: Re-export `DiskImageFormat` from the crate root under `cfg(feature = "blk")`

## Test Plan

- Run `cargo build -p krun --features blk` to verify block device support compiles
- Run `cargo build -p krun --features net,blk` to verify both features work together
- Run `cargo build -p krun` to verify default build (without blk) still compiles
- Run `cargo test -p krun` to ensure existing tests pass