### PR TITLE
feat(krun): add on_exit observer API for VM shutdown callbacks

### DIFF
--- a/examples/rust_vm/src/main.rs
+++ b/examples/rust_vm/src/main.rs
@@ -36,6 +36,9 @@ fn main() -> Result<()> {
                 .args(["Hello from libkrun VM!"])
                 .env("HOME", "/root")
         })
+        .on_exit(|| {
+            eprintln!("[on_exit] VM is shutting down — cleanup complete");
+        })
         .build()?
         .enter()?;
 

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -68,6 +68,7 @@ pub struct VmBuilder {
     net: NetBuilder,
     #[cfg(feature = "blk")]
     disk: DiskBuilder,
+    exit_observers: Vec<Box<dyn Fn() + Send + 'static>>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -93,6 +94,7 @@ impl VmBuilder {
             net: NetBuilder::new(),
             #[cfg(feature = "blk")]
             disk: DiskBuilder::new(),
+            exit_observers: Vec::new(),
         }
     }
 
@@ -243,6 +245,25 @@ impl VmBuilder {
     /// ```
     pub fn console(mut self, f: impl FnOnce(ConsoleBuilder) -> ConsoleBuilder) -> Self {
         self.console = f(self.console);
+        self
+    }
+
+    /// Register a callback that runs synchronously on graceful guest-initiated shutdown.
+    ///
+    /// Multiple observers are supported and are called in registration order.
+    /// User callbacks execute after internal device cleanup (console reset, terminal restore).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use msb_krun::VmBuilder;
+    /// VmBuilder::new()
+    ///     .on_exit(|| {
+    ///         // flush logs, write final status, etc.
+    ///     });
+    /// ```
+    pub fn on_exit(mut self, f: impl Fn() + Send + 'static) -> Self {
+        self.exit_observers.push(Box::new(f));
         self
     }
 
@@ -477,6 +498,7 @@ impl VmBuilder {
             rlimits,
             self.kernel.krunfw_path,
             self.kernel.init_path,
+            self.exit_observers,
         ))
     }
 }

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -43,6 +43,7 @@ pub struct Vm {
     rlimits: Option<String>,
     krunfw_path: Option<PathBuf>,
     init_path: Option<String>,
+    exit_observers: Vec<Box<dyn Fn() + Send + 'static>>,
     /// Keeps the libkrunfw library loaded so kernel memory pointers remain valid.
     _krunfw_library: Option<libloading::Library>,
 }
@@ -64,6 +65,7 @@ impl Vm {
         rlimits: Option<String>,
         krunfw_path: Option<PathBuf>,
         init_path: Option<String>,
+        exit_observers: Vec<Box<dyn Fn() + Send + 'static>>,
     ) -> Self {
         Self {
             vmr,
@@ -75,6 +77,7 @@ impl Vm {
             rlimits,
             krunfw_path,
             init_path,
+            exit_observers,
             _krunfw_library: None,
         }
     }
@@ -139,6 +142,14 @@ impl Vm {
         let _vmm = vmm::builder::build_microvm(&self.vmr, &mut event_manager, shutdown_efd, sender)
             .map_err(|e| Error::Build(BuildError::Start(format!("build_microvm: {e:?}"))))?;
 
+        // Register user exit observers
+        {
+            let mut vmm = _vmm.lock().expect("Poisoned VMM mutex");
+            for observer in self.exit_observers {
+                vmm.add_exit_observer(observer);
+            }
+        }
+
         // Start worker threads if needed
         #[cfg(target_os = "macos")]
         if self.vmr.gpu_virgl_flags.is_some() {
@@ -162,6 +173,11 @@ impl Vm {
                 Ok(_) => {}
                 Err(e) => {
                     error!("Error in EventManager loop: {e:?}");
+                    // Run exit observers before returning so cleanup (terminal
+                    // restore, console reset, user callbacks) still fires.
+                    _vmm.lock()
+                        .expect("Poisoned VMM mutex")
+                        .notify_exit_observers();
                     return Err(Error::Runtime(RuntimeError::EventLoop(format!("{e:?}"))));
                 }
             }
@@ -384,6 +400,7 @@ mod tests {
             None,
             None,
             None,
+            Vec::new(),
         )
     }
 

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -342,6 +342,11 @@ impl Vmm {
         &self.guest_memory
     }
 
+    /// Adds an exit observer that will be called on graceful guest-initiated shutdown.
+    pub fn add_exit_observer(&mut self, observer: impl VmmExitObserver + 'static) {
+        self.exit_observers.push(Arc::new(Mutex::new(observer)));
+    }
+
     /// Injects CTRL+ALT+DEL keystroke combo in the i8042 device.
     #[cfg(target_arch = "x86_64")]
     pub fn send_ctrl_alt_del(&mut self) -> Result<()> {
@@ -353,16 +358,28 @@ impl Vmm {
             .map_err(Error::I8042Error)
     }
 
-    /// Waits for all vCPUs to exit and terminates the Firecracker process.
+    /// Invokes all registered exit observers.
+    ///
+    /// Each observer is wrapped in `catch_unwind` so that a panic in one
+    /// observer does not prevent subsequent observers from running.
+    pub fn notify_exit_observers(&mut self) {
+        for observer in &self.exit_observers {
+            let obs = Arc::clone(observer);
+            if let Err(e) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                obs.lock()
+                    .expect("Poisoned mutex for exit observer")
+                    .on_vmm_exit();
+            })) {
+                error!("Exit observer panicked: {e:?}");
+            }
+        }
+    }
+
+    /// Invokes exit observers and terminates the process.
     pub fn stop(&mut self, exit_code: i32) {
         info!("Vmm is stopping.");
 
-        for observer in &self.exit_observers {
-            observer
-                .lock()
-                .expect("Poisoned mutex for exit observer")
-                .on_vmm_exit();
-        }
+        self.notify_exit_observers();
 
         // Exit from Firecracker using the provided exit code. Safe because we're terminating
         // the process anyway.


### PR DESCRIPTION
## Summary

- Add `VmBuilder::on_exit()` API to register callbacks that run synchronously on graceful guest-initiated shutdown
- Extract `Vmm::notify_exit_observers()` with panic isolation so one failing observer doesn't prevent others from running
- Ensure exit observers fire on EventManager error path, not just the normal `stop()` path
- User callbacks execute after internal device cleanup (console reset, terminal restore) in registration order

## Changes

- `src/krun/src/api/builder.rs`: Add `exit_observers` field to `VmBuilder` and `on_exit()` method that accepts `impl Fn() + Send + 'static` callbacks, forwarded through to `Vm::new()`
- `src/krun/src/api/vm.rs`: Add `exit_observers` field to `Vm`, register observers with `Vmm::add_exit_observer()` during `enter()` using a single mutex lock, and call `notify_exit_observers()` on EventManager error path before returning the error
- `src/vmm/src/lib.rs`: Add `Vmm::add_exit_observer()` public method and extract `notify_exit_observers()` from `stop()`, wrapping each observer call in `std::panic::catch_unwind` to isolate panics between observers
- `examples/rust_vm/src/main.rs`: Demonstrate `on_exit` usage with a shutdown message

## Test Plan

- Run `cargo check --workspace` to verify compilation across all crates
- Run `cargo test --package msb_krun` to verify all krun tests pass (19 tests)
- Build and run the rust_vm example with codesigning to verify end-to-end: `KRUNFW_PATH=~/.microsandbox/lib/libkrunfw.5.dylib target/debug/rust_vm` — should print "Hello from libkrun VM!" followed by "[on_exit] VM is shutting down - cleanup complete"
- Verify observer isolation: a panicking callback should not prevent subsequent observers from running (catch_unwind in notify_exit_observers)