### PR TITLE
feat(krun): add exit signal handlers, exit handle, and custom console backends

### DIFF
--- a/examples/rust_vm/src/main.rs
+++ b/examples/rust_vm/src/main.rs
@@ -36,8 +36,8 @@ fn main() -> Result<()> {
                 .args(["Hello from libkrun VM!"])
                 .env("HOME", "/root")
         })
-        .on_exit(|| {
-            eprintln!("[on_exit] VM is shutting down — cleanup complete");
+        .on_exit(|exit_code| {
+            eprintln!("[on_exit] VM exiting with code {exit_code}");
         })
         .build()?
         .enter()?;

--- a/src/devices/src/virtio/console/device.rs
+++ b/src/devices/src/virtio/console/device.rs
@@ -362,7 +362,7 @@ impl VirtioDevice for Console {
 }
 
 impl VmmExitObserver for Console {
-    fn on_vmm_exit(&mut self) {
+    fn on_vmm_exit(&mut self, _exit_code: i32) {
         self.reset();
         log::trace!("Console on_vmm_exit finished");
     }

--- a/src/devices/src/virtio/console/port_io.rs
+++ b/src/devices/src/virtio/console/port_io.rs
@@ -159,6 +159,118 @@ impl PortOutput for PortOutputFd {
     }
 }
 
+//--------------------------------------------------------------------------------------------------
+// Types: Custom Console Port Backend Adapters
+//--------------------------------------------------------------------------------------------------
+
+use std::sync::Arc;
+
+/// Trait for custom virtio-console port backends.
+///
+/// Implementors provide bidirectional byte I/O between the host and guest
+/// without going through file descriptors on the data path. The console
+/// device's RX thread calls [`read`](Self::read) and the TX thread calls
+/// [`write`](Self::write) — both via `&self`, so the implementation must
+/// use interior mutability (e.g. lock-free ring buffers).
+///
+/// [`read_wake_fd`](Self::read_wake_fd) returns a file descriptor that
+/// becomes readable when [`read`](Self::read) would return data. The
+/// console RX thread uses this fd in a `poll()` call to block efficiently.
+pub trait ConsolePortBackend: Send + Sync {
+    /// Read bytes destined for the guest (host → guest direction).
+    ///
+    /// Copies up to `buf.len()` bytes into `buf`. Returns the number of
+    /// bytes written, or `WouldBlock` if no data is available.
+    fn read(&self, buf: &mut [u8]) -> io::Result<usize>;
+
+    /// Write bytes from the guest (guest → host direction).
+    ///
+    /// Accepts up to `buf.len()` bytes. Returns the number of bytes
+    /// consumed, or `WouldBlock` if the backend cannot accept data.
+    fn write(&self, buf: &[u8]) -> io::Result<usize>;
+
+    /// File descriptor that becomes readable when [`read`](Self::read) has data.
+    ///
+    /// Used by the console RX thread for `poll()`-based blocking. Typically
+    /// the read end of a wake pipe.
+    fn read_wake_fd(&self) -> RawFd;
+}
+
+/// Adapter that wraps a [`ConsolePortBackend`] as a [`PortInput`].
+///
+/// Used by the console RX thread to read data from the backend into guest
+/// memory via VolatileSlice.
+pub struct ConsolePortBackendInputAdapter {
+    backend: Arc<dyn ConsolePortBackend>,
+}
+
+impl ConsolePortBackendInputAdapter {
+    pub fn new(backend: Arc<dyn ConsolePortBackend>) -> Self {
+        Self { backend }
+    }
+}
+
+impl PortInput for ConsolePortBackendInputAdapter {
+    fn read_volatile(&mut self, buf: &mut VolatileSlice) -> io::Result<usize> {
+        let guard = buf.ptr_guard_mut();
+
+        // SAFETY: The VolatileSlice invariant guarantees the memory region is
+        // valid for writes of `buf.len()` bytes for the lifetime of the guard.
+        let dst = unsafe { std::slice::from_raw_parts_mut(guard.as_ptr(), buf.len()) };
+
+        let n = self.backend.read(dst)?;
+
+        if n > 0 {
+            buf.bitmap().mark_dirty(0, n);
+        }
+
+        Ok(n)
+    }
+
+    fn wait_until_readable(&self, stopfd: Option<&EventFd>) {
+        let wake_fd = self.backend.read_wake_fd();
+        let mut poll_fds = Vec::with_capacity(2);
+        let wake_bfd = unsafe { BorrowedFd::borrow_raw(wake_fd) };
+        poll_fds.push(PollFd::new(wake_bfd, PollFlags::POLLIN));
+        if let Some(stopfd) = stopfd {
+            let stop_bfd = unsafe { BorrowedFd::borrow_raw(stopfd.as_raw_fd()) };
+            poll_fds.push(PollFd::new(stop_bfd, PollFlags::POLLIN));
+        }
+        poll(&mut poll_fds, PollTimeout::NONE).expect("Failed to poll");
+    }
+}
+
+/// Adapter that wraps a [`ConsolePortBackend`] as a [`PortOutput`].
+///
+/// Used by the console TX thread to write guest data to the backend.
+pub struct ConsolePortBackendOutputAdapter {
+    backend: Arc<dyn ConsolePortBackend>,
+}
+
+impl ConsolePortBackendOutputAdapter {
+    pub fn new(backend: Arc<dyn ConsolePortBackend>) -> Self {
+        Self { backend }
+    }
+}
+
+impl PortOutput for ConsolePortBackendOutputAdapter {
+    fn write_volatile(&mut self, buf: &VolatileSlice) -> io::Result<usize> {
+        let guard = buf.ptr_guard();
+
+        // SAFETY: The VolatileSlice invariant guarantees the memory region is
+        // valid for reads of `buf.len()` bytes for the lifetime of the guard.
+        let src = unsafe { std::slice::from_raw_parts(guard.as_ptr(), buf.len()) };
+
+        self.backend.write(src)
+    }
+
+    fn wait_until_writable(&self) {
+        // Ring buffer push is lock-free and practically instant. If the ring
+        // is full, write() returns WouldBlock and the console TX thread's
+        // existing retry loop handles backpressure.
+    }
+}
+
 fn dup_raw_fd_into_owned(raw_fd: RawFd) -> Result<OwnedFd, nix::Error> {
     // SAFETY: if raw_fd is invalid the `dup` call below will fail
     let borrowed_fd = unsafe { BorrowedFd::borrow_raw(raw_fd) };

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -167,13 +167,16 @@ pub trait VirtioDevice: AsAny + Send {
 }
 
 pub trait VmmExitObserver: Send {
-    /// Callback to finish processing or cleanup the device resources
-    fn on_vmm_exit(&mut self) {}
+    /// Callback to finish processing or cleanup the device resources.
+    ///
+    /// `exit_code` is the final exit code chosen by the VMM (from guest
+    /// vCPU or the shared `exit_code` Arc).
+    fn on_vmm_exit(&mut self, _exit_code: i32) {}
 }
 
-impl<F: Fn() + Send> VmmExitObserver for F {
-    fn on_vmm_exit(&mut self) {
-        self()
+impl<F: Fn(i32) + Send> VmmExitObserver for F {
+    fn on_vmm_exit(&mut self, exit_code: i32) {
+        self(exit_code)
     }
 }
 

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -1,8 +1,12 @@
 //! VM Builder for creating and configuring microVMs using nested builders.
 
+use std::sync::atomic::AtomicI32;
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 use std::sync::Arc;
+#[cfg(any(feature = "tee", feature = "aws-nitro"))]
+use std::sync::Arc;
 
+use utils::eventfd::{EventFd, EFD_NONBLOCK};
 use vmm::resources::{VirtioConsoleConfigMode, VmResources};
 use vmm::vmm_config::machine_config::VmConfig;
 use vmm::vmm_config::machine_config::VmConfigError;
@@ -20,7 +24,7 @@ use super::builders::{ConsoleBuilder, ExecBuilder, FsBuilder, KernelBuilder, Mac
 #[cfg(feature = "net")]
 use super::builders::{NetBuilder, NetConfig};
 
-use super::error::{ConfigError, Error, Result};
+use super::error::{BuildError, ConfigError, Error, Result};
 use super::vm::Vm;
 
 #[cfg(feature = "blk")]
@@ -68,7 +72,7 @@ pub struct VmBuilder {
     net: NetBuilder,
     #[cfg(feature = "blk")]
     disk: DiskBuilder,
-    exit_observers: Vec<Box<dyn Fn() + Send + 'static>>,
+    exit_observers: Vec<Box<dyn Fn(i32) + Send + 'static>>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -258,11 +262,12 @@ impl VmBuilder {
     /// ```rust,no_run
     /// # use msb_krun::VmBuilder;
     /// VmBuilder::new()
-    ///     .on_exit(|| {
+    ///     .on_exit(|exit_code| {
     ///         // flush logs, write final status, etc.
+    ///         eprintln!("VM exited with code {exit_code}");
     ///     });
     /// ```
-    pub fn on_exit(mut self, f: impl Fn() + Send + 'static) -> Self {
+    pub fn on_exit(mut self, f: impl Fn(i32) + Send + 'static) -> Self {
         self.exit_observers.push(Box::new(f));
         self
     }
@@ -488,6 +493,10 @@ impl VmBuilder {
             )
         };
 
+        let exit_evt = EventFd::new(EFD_NONBLOCK)
+            .map_err(|e| Error::Build(BuildError::Start(format!("exit EventFd: {e:?}"))))?;
+        let exit_code = Arc::new(AtomicI32::new(i32::MAX));
+
         Ok(Vm::new(
             vmr,
             self.kernel.cmdline,
@@ -499,6 +508,8 @@ impl VmBuilder {
             self.kernel.krunfw_path,
             self.kernel.init_path,
             self.exit_observers,
+            exit_evt,
+            exit_code,
         ))
     }
 }

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -2,7 +2,11 @@
 
 use std::os::fd::RawFd;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
+use devices::virtio::console::port_io::{
+    ConsolePortBackend, ConsolePortBackendInputAdapter, ConsolePortBackendOutputAdapter,
+};
 use vmm::resources::PortConfig;
 
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
@@ -185,7 +189,7 @@ pub enum NetConfig {
 ///             .gpu_shm_size(1 << 28)
 ///     });
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Default)]
 pub struct ConsoleBuilder {
     pub(crate) output: Option<PathBuf>,
     pub(crate) ports: Vec<PortConfig>,
@@ -591,6 +595,31 @@ impl ConsoleBuilder {
     /// Call this to suppress that console when using only explicit ports.
     pub fn disable_implicit(mut self) -> Self {
         self.disable_implicit = true;
+        self
+    }
+
+    /// Add a custom console port backend.
+    ///
+    /// The backend provides bidirectional byte I/O without file descriptors
+    /// on the data path, matching the pattern of
+    /// [`NetBuilder::custom()`](NetBuilder::custom) and
+    /// [`FsBuilder::custom()`](FsBuilder::custom).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// VmBuilder::new()
+    ///     .console(|c| c.custom("agent", Box::new(my_backend)))
+    /// ```
+    pub fn custom(mut self, name: &str, backend: Box<dyn ConsolePortBackend>) -> Self {
+        let backend: Arc<dyn ConsolePortBackend> = Arc::from(backend);
+        let input = Box::new(ConsolePortBackendInputAdapter::new(Arc::clone(&backend)));
+        let output = Box::new(ConsolePortBackendOutputAdapter::new(backend));
+        self.ports.push(PortConfig::Custom {
+            name: name.to_string(),
+            input,
+            output,
+        });
         self
     }
 }

--- a/src/krun/src/api/exit_handle.rs
+++ b/src/krun/src/api/exit_handle.rs
@@ -1,0 +1,86 @@
+//! Handle for triggering VM exit from any thread.
+
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::{io, result};
+
+use utils::eventfd::EventFd;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// A thread-safe, cloneable handle that triggers VM exit when fired.
+///
+/// Obtained via [`Vm::exit_handle()`](super::vm::Vm::exit_handle) before
+/// calling [`Vm::enter()`](super::vm::Vm::enter). Background tasks (idle
+/// timeout, max-duration timer, relay drain) use this to shut down the VMM
+/// cleanly — the exit event fd fires, exit observers run, and the process
+/// terminates.
+///
+/// Multiple triggers are idempotent: the VMM reads the event once and calls
+/// `_exit()`.
+pub struct ExitHandle {
+    write_fd: OwnedFd,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl ExitHandle {
+    /// Create an `ExitHandle` from an [`EventFd`].
+    ///
+    /// Dups the write end so the handle is independent of the original fd
+    /// lifetime.
+    pub(crate) fn from_event_fd(evt: &EventFd) -> result::Result<Self, io::Error> {
+        // On Linux, EventFd is a single fd (read/write on the same fd).
+        // On macOS, EventFd is a pipe pair — we need the write end.
+        #[cfg(target_os = "linux")]
+        let raw_fd = evt.as_raw_fd();
+        #[cfg(target_os = "macos")]
+        let raw_fd = evt.get_write_fd();
+
+        let fd = unsafe { libc::dup(raw_fd) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let write_fd = unsafe { OwnedFd::from_raw_fd(fd) };
+        Ok(Self { write_fd })
+    }
+
+    /// Trigger VM exit.
+    ///
+    /// Writes to the exit event fd, causing the VMM event loop to invoke
+    /// exit observers and call `_exit()`. Safe to call from any thread.
+    /// Async-signal-safe.
+    pub fn trigger(&self) {
+        let val: u64 = 1;
+        // SAFETY: write_fd is a valid, owned file descriptor. Writing 8 bytes
+        // (a u64) matches the EventFd/pipe protocol used by the VMM.
+        let _ = unsafe {
+            libc::write(
+                self.write_fd.as_raw_fd(),
+                &val as *const u64 as *const libc::c_void,
+                std::mem::size_of::<u64>(),
+            )
+        };
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Clone for ExitHandle {
+    fn clone(&self) -> Self {
+        let fd = unsafe { libc::dup(self.write_fd.as_raw_fd()) };
+        assert!(fd >= 0, "Failed to dup ExitHandle fd");
+        let write_fd = unsafe { OwnedFd::from_raw_fd(fd) };
+        Self { write_fd }
+    }
+}
+
+// SAFETY: OwnedFd is Send. The write operation is atomic for 8-byte writes
+// on both eventfd (Linux) and pipes (macOS, when ≤ PIPE_BUF).
+unsafe impl Send for ExitHandle {}
+unsafe impl Sync for ExitHandle {}

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -30,6 +30,7 @@
 pub mod builder;
 pub mod builders;
 pub mod error;
+pub mod exit_handle;
 pub mod vm;
 
 //--------------------------------------------------------------------------------------------------
@@ -45,4 +46,5 @@ pub use builders::DiskImageFormat;
 pub use builders::NetBuilder;
 pub use builders::{ConsoleBuilder, ExecBuilder, FsBuilder, KernelBuilder, MachineBuilder};
 pub use error::{BuildError, ConfigError, Error, Result, RuntimeError};
+pub use exit_handle::ExitHandle;
 pub use vm::Vm;

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -2,6 +2,8 @@
 
 use std::convert::Infallible;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicI32;
+use std::sync::Arc;
 use std::time::SystemTime;
 
 #[cfg(target_os = "linux")]
@@ -19,6 +21,7 @@ use vmm::vmm_config::kernel_cmdline::KernelCmdlineConfig;
 use vmm::vmm_config::vsock::VsockDeviceConfig;
 
 use super::error::{BuildError, Error, Result, RuntimeError};
+use super::exit_handle::ExitHandle;
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -43,7 +46,11 @@ pub struct Vm {
     rlimits: Option<String>,
     krunfw_path: Option<PathBuf>,
     init_path: Option<String>,
-    exit_observers: Vec<Box<dyn Fn() + Send + 'static>>,
+    exit_observers: Vec<Box<dyn Fn(i32) + Send + 'static>>,
+    /// Pre-created exit event fd for triggering VM shutdown.
+    exit_evt: EventFd,
+    /// Shared exit code — written by the VMM, readable by exit observers.
+    exit_code: Arc<AtomicI32>,
     /// Keeps the libkrunfw library loaded so kernel memory pointers remain valid.
     _krunfw_library: Option<libloading::Library>,
 }
@@ -65,7 +72,9 @@ impl Vm {
         rlimits: Option<String>,
         krunfw_path: Option<PathBuf>,
         init_path: Option<String>,
-        exit_observers: Vec<Box<dyn Fn() + Send + 'static>>,
+        exit_observers: Vec<Box<dyn Fn(i32) + Send + 'static>>,
+        exit_evt: EventFd,
+        exit_code: Arc<AtomicI32>,
     ) -> Self {
         Self {
             vmr,
@@ -78,8 +87,30 @@ impl Vm {
             krunfw_path,
             init_path,
             exit_observers,
+            exit_evt,
+            exit_code,
             _krunfw_library: None,
         }
+    }
+
+    /// Get a cloneable handle that triggers VM exit from any thread.
+    ///
+    /// Must be called **before** [`enter()`](Self::enter). Background tasks
+    /// use this to shut down the VMM (e.g. idle timeout, max duration).
+    pub fn exit_handle(&self) -> ExitHandle {
+        ExitHandle::from_event_fd(&self.exit_evt)
+            .expect("Failed to create ExitHandle from exit EventFd")
+    }
+
+    /// Get a shared reference to the VM exit code.
+    ///
+    /// The VMM writes the guest exit code here before invoking exit
+    /// observers. Read it inside an [`on_exit`](super::builder::VmBuilder::on_exit)
+    /// closure to record the exit status.
+    ///
+    /// Sentinel value `i32::MAX` means "not yet set".
+    pub fn exit_code(&self) -> Arc<AtomicI32> {
+        Arc::clone(&self.exit_code)
     }
 
     /// Start the VM. This call never returns on success — the VMM calls
@@ -139,8 +170,15 @@ impl Vm {
         // Build the microVM
         let (sender, _receiver) = unbounded();
 
-        let _vmm = vmm::builder::build_microvm(&self.vmr, &mut event_manager, shutdown_efd, sender)
-            .map_err(|e| Error::Build(BuildError::Start(format!("build_microvm: {e:?}"))))?;
+        let _vmm = vmm::builder::build_microvm(
+            &mut self.vmr,
+            &mut event_manager,
+            shutdown_efd,
+            sender,
+            self.exit_evt,
+            self.exit_code,
+        )
+        .map_err(|e| Error::Build(BuildError::Start(format!("build_microvm: {e:?}"))))?;
 
         // Register user exit observers
         {
@@ -177,7 +215,7 @@ impl Vm {
                     // restore, console reset, user callbacks) still fires.
                     _vmm.lock()
                         .expect("Poisoned VMM mutex")
-                        .notify_exit_observers();
+                        .notify_exit_observers(1);
                     return Err(Error::Runtime(RuntimeError::EventLoop(format!("{e:?}"))));
                 }
             }
@@ -386,6 +424,7 @@ fn load_krunfw_library(path: Option<&std::path::Path>) -> Result<KrunfwBindings>
 mod tests {
     use super::*;
     use devices::virtio::TsiFlags;
+    use utils::eventfd::EFD_NONBLOCK;
     #[cfg(not(feature = "tee"))]
     use vmm::vmm_config::fs::FsDeviceConfig;
 
@@ -401,6 +440,8 @@ mod tests {
             None,
             None,
             Vec::new(),
+            EventFd::new(EFD_NONBLOCK).unwrap(),
+            Arc::new(AtomicI32::new(i32::MAX)),
         )
     }
 

--- a/src/krun/src/backends/console.rs
+++ b/src/krun/src/backends/console.rs
@@ -1,0 +1,7 @@
+//! Custom console port backend support.
+//!
+//! Re-exports [`ConsolePortBackend`] from the devices crate, following the
+//! same pattern as [`NetBackend`](super::net::NetBackend) and
+//! [`DynFileSystem`](super::fs::DynFileSystem).
+
+pub use devices::virtio::console::port_io::ConsolePortBackend;

--- a/src/krun/src/backends/mod.rs
+++ b/src/krun/src/backends/mod.rs
@@ -3,6 +3,12 @@
 //! This module provides traits and types for implementing custom backends
 //! for libkrun's virtio devices.
 //!
+//! # Console Backends
+//!
+//! The `console` module provides the [`ConsolePortBackend`] trait for
+//! in-process virtio-console port backends. See [`console::ConsolePortBackend`]
+//! for details.
+//!
 //! # Network Backends
 //!
 //! The `net` module re-exports the `NetBackend` trait which allows custom
@@ -17,6 +23,8 @@
 // Modules
 //--------------------------------------------------------------------------------------------------
 
+pub mod console;
+
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 pub mod fs;
 
@@ -26,6 +34,8 @@ pub mod net;
 //--------------------------------------------------------------------------------------------------
 // Re-Exports
 //--------------------------------------------------------------------------------------------------
+
+pub use console::ConsolePortBackend;
 
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 pub use fs::DynFileSystem;

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -42,11 +42,11 @@ pub use api::builder::VmBuilder;
 pub use api::builders::DiskBuilder;
 #[cfg(feature = "blk")]
 pub use api::builders::DiskImageFormat;
-pub use api::exit_handle::ExitHandle;
 #[cfg(feature = "net")]
 pub use api::builders::NetBuilder;
 pub use api::builders::{ConsoleBuilder, ExecBuilder, FsBuilder, KernelBuilder, MachineBuilder};
 pub use api::error::{BuildError, ConfigError, Error, Result, RuntimeError};
+pub use api::exit_handle::ExitHandle;
 pub use api::vm::Vm;
 
 pub use backends::console::ConsolePortBackend;

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -42,11 +42,14 @@ pub use api::builder::VmBuilder;
 pub use api::builders::DiskBuilder;
 #[cfg(feature = "blk")]
 pub use api::builders::DiskImageFormat;
+pub use api::exit_handle::ExitHandle;
 #[cfg(feature = "net")]
 pub use api::builders::NetBuilder;
 pub use api::builders::{ConsoleBuilder, ExecBuilder, FsBuilder, KernelBuilder, MachineBuilder};
 pub use api::error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use api::vm::Vm;
+
+pub use backends::console::ConsolePortBackend;
 
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 pub use backends::fs::DynFileSystem;

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -34,8 +34,7 @@ use std::os::fd::{BorrowedFd, FromRawFd, RawFd};
 use std::path::PathBuf;
 use std::slice;
 use std::sync::atomic::{AtomicI32, Ordering};
-use std::sync::LazyLock;
-use std::sync::Mutex;
+use std::sync::{Arc, LazyLock, Mutex};
 use utils::eventfd::EventFd;
 use vmm::resources::{
     DefaultVirtioConsoleConfig, PortConfig, SerialConsoleConfig, TsiFlags, VirtioConsoleConfigMode,
@@ -2696,11 +2695,22 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
 
     let (sender, _receiver) = unbounded();
 
+    let exit_evt = match utils::eventfd::EventFd::new(utils::eventfd::EFD_NONBLOCK) {
+        Ok(evt) => evt,
+        Err(e) => {
+            error!("Failed to create exit EventFd: {e:?}");
+            return -libc::EINVAL;
+        }
+    };
+    let exit_code = Arc::new(AtomicI32::new(i32::MAX));
+
     let _vmm = match vmm::builder::build_microvm(
-        &ctx_cfg.vmr,
+        &mut ctx_cfg.vmr,
         &mut event_manager,
         ctx_cfg.shutdown_efd,
         sender,
+        exit_evt,
+        exit_code,
     ) {
         Ok(vmm) => vmm,
         Err(e) => {

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -51,6 +51,7 @@ use devices::virtio::{port_io, MmioTransport, PortDescription, VirtioDevice, Vso
 use kbs_types::Tee;
 
 use crate::device_manager;
+use crate::exit_signal::register_exit_signal_handlers;
 #[cfg(target_os = "linux")]
 use crate::signal_handler::register_sigint_handler;
 #[cfg(target_os = "linux")]
@@ -561,10 +562,12 @@ fn choose_payload(vm_resources: &VmResources) -> Result<Payload, StartMicrovmErr
 /// An `Arc` reference of the built `Vmm` is also plugged in the `EventManager`, while another
 /// is returned.
 pub fn build_microvm(
-    vm_resources: &super::resources::VmResources,
+    vm_resources: &mut super::resources::VmResources,
     event_manager: &mut EventManager,
     _shutdown_efd: Option<EventFd>,
     _sender: Sender<WorkerMessage>,
+    exit_evt: EventFd,
+    exit_code: Arc<AtomicI32>,
 ) -> std::result::Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
     let payload = choose_payload(vm_resources)?;
 
@@ -766,7 +769,15 @@ pub fn build_microvm(
         serial_devices.push(setup_serial_device(event_manager, input, output)?);
     }
 
-    let exit_evt = EventFd::new(utils::eventfd::EFD_NONBLOCK)
+    // Register signal handlers with the pre-created exit EventFd.
+    // On Linux eventfd is a single fd (read/write on the same fd).
+    // On macOS EventFd is a pipe pair — we need the write end.
+    #[cfg(target_os = "linux")]
+    let exit_write_fd = exit_evt.as_raw_fd();
+    #[cfg(target_os = "macos")]
+    let exit_write_fd = exit_evt.get_write_fd();
+
+    register_exit_signal_handlers(exit_write_fd)
         .map_err(Error::EventFd)
         .map_err(StartMicrovmError::Internal)?;
 
@@ -947,8 +958,7 @@ pub fn build_microvm(
         )?;
     }
 
-    // We use this atomic to record the exit code set by init/init.c in the VM.
-    let exit_code = Arc::new(AtomicI32::new(i32::MAX));
+    // exit_code is pre-created and shared with callers via Vm::exit_code().
 
     let mut vmm = Vmm {
         guest_memory,
@@ -986,7 +996,7 @@ pub fn build_microvm(
         console_id += 1;
     }
 
-    for console_cfg in vm_resources.virtio_consoles.iter() {
+    for console_cfg in std::mem::take(&mut vm_resources.virtio_consoles) {
         attach_console_devices(
             &mut vmm,
             event_manager,
@@ -2118,7 +2128,7 @@ fn setup_terminal_raw_mode(
         match term_set_raw_mode(term_fd, handle_signals_by_terminal) {
             Ok(old_mode) => {
                 let raw_fd = term_fd.as_raw_fd();
-                vmm.exit_observers.push(Arc::new(Mutex::new(move || {
+                vmm.exit_observers.push(Arc::new(Mutex::new(move |_: i32| {
                     if let Err(e) =
                         term_restore_mode(unsafe { BorrowedFd::borrow_raw(raw_fd) }, &old_mode)
                     {
@@ -2135,22 +2145,22 @@ fn setup_terminal_raw_mode(
 
 fn create_explicit_ports(
     vmm: &mut Vmm,
-    port_configs: &[PortConfig],
+    port_configs: Vec<PortConfig>,
 ) -> std::result::Result<Vec<PortDescription>, StartMicrovmError> {
     let mut ports = Vec::with_capacity(port_configs.len());
 
     for port_cfg in port_configs {
         let port_desc = match port_cfg {
             PortConfig::Tty { name, tty_fd } => {
-                assert!(*tty_fd > 0, "PortConfig::Tty must have a valid tty_fd");
-                let term_fd = unsafe { BorrowedFd::borrow_raw(*tty_fd) };
+                assert!(tty_fd > 0, "PortConfig::Tty must have a valid tty_fd");
+                let term_fd = unsafe { BorrowedFd::borrow_raw(tty_fd) };
                 setup_terminal_raw_mode(vmm, Some(term_fd), false);
 
                 PortDescription {
-                    name: name.clone().into(),
-                    input: Some(port_io::input_to_raw_fd_dup(*tty_fd).unwrap()),
-                    output: Some(port_io::output_to_raw_fd_dup(*tty_fd).unwrap()),
-                    terminal: Some(port_io::term_fd(*tty_fd).unwrap()),
+                    name: name.into(),
+                    input: Some(port_io::input_to_raw_fd_dup(tty_fd).unwrap()),
+                    output: Some(port_io::output_to_raw_fd_dup(tty_fd).unwrap()),
+                    terminal: Some(port_io::term_fd(tty_fd).unwrap()),
                 }
             }
             PortConfig::InOut {
@@ -2158,17 +2168,27 @@ fn create_explicit_ports(
                 input_fd,
                 output_fd,
             } => PortDescription {
-                name: name.clone().into(),
-                input: if *input_fd < 0 {
+                name: name.into(),
+                input: if input_fd < 0 {
                     None
                 } else {
-                    Some(port_io::input_to_raw_fd_dup(*input_fd).unwrap())
+                    Some(port_io::input_to_raw_fd_dup(input_fd).unwrap())
                 },
-                output: if *output_fd < 0 {
+                output: if output_fd < 0 {
                     None
                 } else {
-                    Some(port_io::output_to_raw_fd_dup(*output_fd).unwrap())
+                    Some(port_io::output_to_raw_fd_dup(output_fd).unwrap())
                 },
+                terminal: None,
+            },
+            PortConfig::Custom {
+                name,
+                input,
+                output,
+            } => PortDescription {
+                name: name.into(),
+                input: Some(input),
+                output: Some(output),
                 terminal: None,
             },
         };
@@ -2184,7 +2204,7 @@ fn attach_console_devices(
     event_manager: &mut EventManager,
     intc: IrqChip,
     vm_resources: &VmResources,
-    cfg: Option<&VirtioConsoleConfigMode>,
+    cfg: Option<VirtioConsoleConfigMode>,
     id_number: u32,
 ) -> std::result::Result<(), StartMicrovmError> {
     use self::StartMicrovmError::*;
@@ -2196,7 +2216,7 @@ fn attach_console_devices(
         Some(VirtioConsoleConfigMode::Autoconfigure(autocfg)) => autoconfigure_console_ports(
             vmm,
             vm_resources,
-            Some(autocfg),
+            Some(&autocfg),
             creating_implicit_console,
         )?,
         Some(VirtioConsoleConfigMode::Explicit(ports)) => create_explicit_ports(vmm, ports)?,

--- a/src/vmm/src/exit_signal.rs
+++ b/src/vmm/src/exit_signal.rs
@@ -56,7 +56,7 @@ pub fn register_exit_signal_handlers(exit_write_fd: RawFd) -> io::Result<()> {
 
     unsafe {
         let mut sa: libc::sigaction = mem::zeroed();
-        sa.sa_sigaction = exit_signal_handler as usize;
+        sa.sa_sigaction = exit_signal_handler as *const () as usize;
         sa.sa_flags = libc::SA_SIGINFO;
 
         if libc::sigaction(libc::SIGTERM, &sa, ptr::null_mut()) != 0 {

--- a/src/vmm/src/exit_signal.rs
+++ b/src/vmm/src/exit_signal.rs
@@ -1,0 +1,71 @@
+//! Cross-platform signal handlers for graceful VMM shutdown.
+//!
+//! Registers `SIGTERM` and `SIGUSR1` handlers that write to the VMM's exit
+//! event fd, causing the event loop to trigger a graceful shutdown with exit
+//! observer invocation.
+//!
+//! Uses `libc::sigaction` directly (POSIX) instead of `vmm_sys_util::signal`
+//! so it works on both Linux and macOS.
+
+use std::os::unix::io::RawFd;
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::{io, mem, ptr};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+static EXIT_EVT_FD: AtomicI32 = AtomicI32::new(-1);
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Signal handler for `SIGTERM` and `SIGUSR1`.
+///
+/// Writes to the VMM exit event fd so that the event loop triggers a graceful
+/// shutdown (exit observers run before `_exit`). All operations are
+/// async-signal-safe.
+extern "C" fn exit_signal_handler(
+    num: libc::c_int,
+    info: *mut libc::siginfo_t,
+    _unused: *mut libc::c_void,
+) {
+    let si_signo = unsafe { (*info).si_signo };
+
+    if num != si_signo || (num != libc::SIGTERM && num != libc::SIGUSR1) {
+        unsafe { libc::_exit(i32::from(super::FC_EXIT_CODE_UNEXPECTED_ERROR)) };
+    }
+
+    let val: u64 = 1;
+    let exit_fd = EXIT_EVT_FD.load(Ordering::Relaxed);
+    let _ = unsafe { libc::write(exit_fd, &val as *const _ as *const libc::c_void, 8) };
+}
+
+/// Registers `SIGTERM` and `SIGUSR1` handlers that write to the given fd,
+/// causing a graceful VMM shutdown with exit observer invocation.
+///
+/// # Arguments
+///
+/// * `exit_write_fd` - The file descriptor to write to when a signal arrives.
+///   On Linux this is the eventfd itself (`as_raw_fd()`). On macOS, where
+///   `EventFd` is backed by a pipe, this must be the **write** end
+///   (`get_write_fd()`).
+pub fn register_exit_signal_handlers(exit_write_fd: RawFd) -> io::Result<()> {
+    EXIT_EVT_FD.store(exit_write_fd, Ordering::Relaxed);
+
+    unsafe {
+        let mut sa: libc::sigaction = mem::zeroed();
+        sa.sa_sigaction = exit_signal_handler as usize;
+        sa.sa_flags = libc::SA_SIGINFO;
+
+        if libc::sigaction(libc::SIGTERM, &sa, ptr::null_mut()) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if libc::sigaction(libc::SIGUSR1, &sa, ptr::null_mut()) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+
+    Ok(())
+}

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -18,6 +18,8 @@ pub mod builder;
 pub(crate) mod device_manager;
 /// Resource store for configured microVM resources.
 pub mod resources;
+/// Cross-platform exit signal handlers (SIGTERM, SIGUSR1).
+pub mod exit_signal;
 /// Signal handling utilities.
 #[cfg(target_os = "linux")]
 pub mod signal_handler;
@@ -362,13 +364,13 @@ impl Vmm {
     ///
     /// Each observer is wrapped in `catch_unwind` so that a panic in one
     /// observer does not prevent subsequent observers from running.
-    pub fn notify_exit_observers(&mut self) {
+    pub fn notify_exit_observers(&mut self, exit_code: i32) {
         for observer in &self.exit_observers {
             let obs = Arc::clone(observer);
             if let Err(e) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 obs.lock()
                     .expect("Poisoned mutex for exit observer")
-                    .on_vmm_exit();
+                    .on_vmm_exit(exit_code);
             })) {
                 error!("Exit observer panicked: {e:?}");
             }
@@ -379,7 +381,7 @@ impl Vmm {
     pub fn stop(&mut self, exit_code: i32) {
         info!("Vmm is stopping.");
 
-        self.notify_exit_observers();
+        self.notify_exit_observers(exit_code);
 
         // Exit from Firecracker using the provided exit code. Safe because we're terminating
         // the process anyway.

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -16,10 +16,10 @@ extern crate log;
 /// Handles setup and initialization a `Vmm` object.
 pub mod builder;
 pub(crate) mod device_manager;
-/// Resource store for configured microVM resources.
-pub mod resources;
 /// Cross-platform exit signal handlers (SIGTERM, SIGUSR1).
 pub mod exit_signal;
+/// Resource store for configured microVM resources.
+pub mod resources;
 /// Signal handling utilities.
 #[cfg(target_os = "linux")]
 pub mod signal_handler;

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -100,7 +100,6 @@ pub enum VirtioConsoleConfigMode {
     Explicit(Vec<PortConfig>),
 }
 
-#[derive(Debug, Clone)]
 pub enum PortConfig {
     Tty {
         name: String,
@@ -110,6 +109,11 @@ pub enum PortConfig {
         name: String,
         input_fd: RawFd,
         output_fd: RawFd,
+    },
+    Custom {
+        name: String,
+        input: Box<dyn devices::virtio::port_io::PortInput + Send>,
+        output: Box<dyn devices::virtio::port_io::PortOutput + Send>,
     },
 }
 


### PR DESCRIPTION
## Summary

- Add cross-platform SIGTERM/SIGUSR1 signal handlers that trigger graceful VMM shutdown through the exit event fd, ensuring exit observers run before process termination
- Add `ExitHandle` type for triggering VM exit programmatically from any thread (cloneable, thread-safe, async-signal-safe)
- Propagate the VM exit code through the observer chain so `on_exit` callbacks receive the `i32` exit code, and expose `Vm::exit_code()` as a shared `Arc<AtomicI32>`
- Add `ConsolePortBackend` trait and `PortConfig::Custom` variant for custom in-process console port I/O without file descriptors on the data path

## Changes

- New `src/vmm/src/exit_signal.rs`: POSIX `sigaction`-based handlers for SIGTERM and SIGUSR1 that write to the VMM exit event fd, working on both Linux and macOS
- New `src/krun/src/api/exit_handle.rs`: `ExitHandle` struct that dups the exit event fd write end and exposes a `trigger()` method, with `Clone`/`Send`/`Sync` implementations
- New `src/krun/src/backends/console.rs`: Re-exports `ConsolePortBackend` from the devices crate
- Modified `src/devices/src/virtio/console/port_io.rs`: Added `ConsolePortBackend` trait with `read`/`write`/`read_wake_fd` methods, plus `ConsolePortBackendInputAdapter` and `ConsolePortBackendOutputAdapter` that bridge the trait to `PortInput`/`PortOutput`
- Modified `src/devices/src/virtio/device.rs`: Changed `VmmExitObserver::on_vmm_exit()` and its blanket `Fn` impl to accept `exit_code: i32`
- Modified `src/krun/src/api/builder.rs`: `on_exit` callback signature changed from `Fn()` to `Fn(i32)`, pre-creates `exit_evt` and `exit_code` and passes them to `Vm::new()`
- Modified `src/krun/src/api/builders.rs`: Added `ConsoleBuilder::custom()` method that wraps a `ConsolePortBackend` into `PortConfig::Custom`
- Modified `src/krun/src/api/vm.rs`: Added `Vm::exit_handle()` and `Vm::exit_code()` public methods; updated `enter()` to pass `exit_evt` and `exit_code` to `build_microvm`
- Modified `src/vmm/src/builder.rs`: `build_microvm` now accepts pre-created `exit_evt: EventFd` and `exit_code: Arc<AtomicI32>` instead of creating them internally; registers exit signal handlers; added `PortConfig::Custom` arm in `create_explicit_ports`; `attach_console_devices` takes owned `VirtioConsoleConfigMode` instead of a reference
- Modified `src/vmm/src/lib.rs`: `notify_exit_observers` and `stop` propagate `exit_code: i32`
- Modified `src/vmm/src/resources.rs`: Added `PortConfig::Custom` variant with boxed `PortInput`/`PortOutput`; removed `Debug`/`Clone` derives from `PortConfig`
- Modified `src/libkrun/src/lib.rs`: Updated `krun_start_enter` to create and pass `exit_evt`/`exit_code` to `build_microvm`
- Updated `examples/rust_vm/src/main.rs`: `on_exit` callback now receives and prints the exit code

## Test Plan

- Run `cargo build` to verify compilation succeeds across all crates
- Run `cargo test` to verify existing unit tests pass (including updated `Vm::new()` signatures in `vm.rs` tests)
- Verify the `rust_vm` example compiles: `cargo build -p rust_vm`
- Test graceful shutdown by sending SIGTERM to a running VM and confirming exit observers fire
- Test `ExitHandle::trigger()` from a background thread to verify programmatic shutdown works