### PR TITLE
feat(krun): make virtio-vsock opt-in when TSI does not need it

### DIFF
--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -333,6 +333,7 @@ impl VmBuilder {
             .map_err(|err| map_vm_config_error(&self.machine, err))?;
         vmr.nested_enabled = self.machine.nested_virt;
         vmr.split_irqchip = self.machine.split_irqchip;
+        vmr.request_vsock = self.machine.vsock;
 
         // Apply filesystem configuration
         #[cfg(not(feature = "tee"))]

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -43,6 +43,7 @@ pub struct MachineBuilder {
     pub(crate) hyperthreading: bool,
     pub(crate) nested_virt: bool,
     pub(crate) split_irqchip: bool,
+    pub(crate) vsock: bool,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -298,6 +299,7 @@ impl MachineBuilder {
             hyperthreading: false,
             nested_virt: false,
             split_irqchip: false,
+            vsock: false,
         }
     }
 
@@ -335,6 +337,17 @@ impl MachineBuilder {
     /// aarch64 or riscv64.
     pub fn split_irqchip(mut self, enabled: bool) -> Self {
         self.split_irqchip = enabled;
+        self
+    }
+
+    /// Force-attach a virtio-vsock device to the guest.
+    ///
+    /// By default, vsock is only attached when needed as a TSI transport
+    /// (no virtio-net → HIJACK_INET, or single root virtio-fs on Linux →
+    /// HIJACK_UNIX). Set this to `true` when the guest needs a vsock for
+    /// its own purposes even though TSI would not otherwise require one.
+    pub fn vsock(mut self, enabled: bool) -> Self {
+        self.vsock = enabled;
         self
     }
 }

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -256,7 +256,13 @@ impl Vm {
         Ok(())
     }
 
-    /// Configure vsock device.
+    /// Configure the vsock device.
+    ///
+    /// The device is only attached when actually needed — either because the
+    /// caller explicitly requested it (`VmBuilder::vsock(true)`), or because
+    /// TSI needs it as a transport (no virtio-net → HIJACK_INET; single root
+    /// virtio-fs on Linux → HIJACK_UNIX). This keeps the per-VM IRQ/MMIO
+    /// budget free when nothing actually uses vsock.
     fn configure_vsock(&mut self) -> Result<()> {
         use devices::virtio::TsiFlags;
 
@@ -277,6 +283,10 @@ impl Vm {
         #[cfg(not(feature = "tee"))]
         {
             tsi_flags = self.maybe_enable_hijack_unix(tsi_flags);
+        }
+
+        if !self.vmr.request_vsock && tsi_flags.is_empty() {
+            return Ok(());
         }
 
         let vsock_config = VsockDeviceConfig {

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -189,6 +189,11 @@ pub struct VmResources {
     pub nested_enabled: bool,
     /// Whether to enable split irqchip
     pub split_irqchip: bool,
+    /// Force-enable the virtio-vsock device even when no TSI transport is
+    /// required. When `false`, vsock is only attached if `configure_vsock`
+    /// determines it is needed (HIJACK_INET when there's no virtio-net, or
+    /// HIJACK_UNIX when there's a single root virtio-fs on Linux).
+    pub request_vsock: bool,
     /// Do not create an implicit console device in the guest
     pub disable_implicit_console: bool,
     /// The console id to use for console= in the kernel cmdline
@@ -437,6 +442,7 @@ mod tests {
             smbios_oem_strings: None,
             nested_enabled: false,
             split_irqchip: false,
+            request_vsock: false,
             disable_implicit_console: false,
             serial_consoles: Vec::new(),
             virtio_consoles: Vec::new(),


### PR DESCRIPTION
## Summary

- Stop unconditionally attaching a virtio-vsock device in `Vm::build()`. `configure_vsock` now only attaches it when the TSI transport needs it (no virtio-net in guest → `HIJACK_INET`, or single root virtio-fs on Linux → `HIJACK_UNIX`) or when the caller explicitly opts in.
- Add `MachineBuilder::vsock(bool)` for callers that want a guest-visible vsock device even when TSI wouldn't otherwise require one, backed by a new `VmResources::request_vsock` flag.
- Reclaim one IRQ + one MMIO slot per VM for the common case where vsock had no work to do (virtio-net present and multiple virtio-fs tags, so neither TSI hijack applies). For microsandbox's default configuration this drops the x86_64 baseline from 8 IRQs to 7, giving one extra slot for user mounts before the in-kernel-IOAPIC ceiling is hit.
- Guest remains safe with the device absent: the `krun-init` shipped in libkrunfw is built without `__TIMESYNC__` and therefore has no `AF_VSOCK` callers; Linux's built-in `CONFIG_VIRTIO_VSOCKETS` driver sits dormant when no matching device is enumerated. The VMM-side `tsi_hijack*` kernel-cmdline injection in `builder.rs` already lives inside `if let Some(vsock) = vm_resources.vsock.get()`, so the guest is never told to expect a transport that isn't there.

## Test Plan

- [x] `cargo build -p msb_krun` — clean
- [x] `cargo fmt --check`
- [x] End-to-end: microsandbox patched against this branch, `just build && just install`, `msb run alpine` boots and exits cleanly
- [x] Verify a TSI-using configuration (no virtio-net) still attaches vsock implicitly — `tsi_hijack` should appear in the guest kernel cmdline
- [ ] Verify explicit `.vsock(true)` forces the device on even when both TSI flags would be empty (virtio-net configured plus multiple fs tags)