### PR TITLE
msb_krun_cpuid: fix compilation on Rust 1.93 by wrapping CPUID calls in unsafe blocks

### DIFF
--- a/src/cpuid/src/brand_string.rs
+++ b/src/cpuid/src/brand_string.rs
@@ -104,7 +104,7 @@ impl BrandString {
     /// of the host CPU.
     pub fn from_host_cpuid() -> Result<Self, Error> {
         let mut this = Self::new();
-        let mut cpuid_regs = host_cpuid(0x8000_0000);
+        let mut cpuid_regs = unsafe { host_cpuid(0x8000_0000) };
 
         if cpuid_regs.eax < 0x8000_0004 {
             // Brand string not supported by the host CPU
@@ -112,7 +112,7 @@ impl BrandString {
         }
 
         for leaf in 0x8000_0002..=0x8000_0004 {
-            cpuid_regs = host_cpuid(leaf);
+            cpuid_regs = unsafe { host_cpuid(leaf) };
             this.set_reg_for_leaf(leaf, Reg::EAX, cpuid_regs.eax);
             this.set_reg_for_leaf(leaf, Reg::EBX, cpuid_regs.ebx);
             this.set_reg_for_leaf(leaf, Reg::ECX, cpuid_regs.ecx);

--- a/src/cpuid/src/brand_string.rs
+++ b/src/cpuid/src/brand_string.rs
@@ -102,6 +102,7 @@ impl BrandString {
 
     /// Creates a brand string, initialized from the CPUID leaves 0x80000002 through 0x80000004
     /// of the host CPU.
+    #[allow(unused_unsafe)]
     pub fn from_host_cpuid() -> Result<Self, Error> {
         let mut this = Self::new();
         let mut cpuid_regs = unsafe { host_cpuid(0x8000_0000) };
@@ -388,7 +389,7 @@ mod tests {
         match BrandString::from_host_cpuid() {
             Ok(bstr) => {
                 for leaf in 0x8000_0002..=0x8000_0004_u32 {
-                    let host_regs = host_cpuid(leaf);
+                    let host_regs = unsafe { host_cpuid(leaf) };
                     assert_eq!(bstr.get_reg_for_leaf(leaf, Reg::EAX), host_regs.eax);
                     assert_eq!(bstr.get_reg_for_leaf(leaf, Reg::EBX), host_regs.ebx);
                     assert_eq!(bstr.get_reg_for_leaf(leaf, Reg::ECX), host_regs.ecx);
@@ -398,7 +399,7 @@ mod tests {
             Err(Error::NotSupported) => {
                 // from_host_cpuid() should only fail if the host CPU doesn't support
                 // CPUID leaves up to 0x80000004, so let's make sure that's what happened.
-                let host_regs = host_cpuid(0x8000_0000);
+                let host_regs = unsafe { host_cpuid(0x8000_0000) };
                 assert!(host_regs.eax < 0x8000_0004);
             }
             _ => panic!("This function should not return another type of error"),

--- a/src/cpuid/src/common.rs
+++ b/src/cpuid/src/common.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(target_arch = "x86")]
-use std::arch::x86::{__cpuid_count, __get_cpuid_max, CpuidResult};
+use std::arch::x86::{CpuidResult, __cpuid_count, __get_cpuid_max};
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::{__cpuid_count, __get_cpuid_max, CpuidResult};
+use std::arch::x86_64::{CpuidResult, __cpuid_count, __get_cpuid_max};
 
 use crate::cpu_leaf::*;
 
@@ -34,14 +34,14 @@ pub fn get_cpuid(function: u32, count: u32) -> Result<CpuidResult, Error> {
         }
     }
 
-    let max_function = __get_cpuid_max(function & leaf_0x80000000::LEAF_NUM).0;
+    let max_function = unsafe { __get_cpuid_max(function & leaf_0x80000000::LEAF_NUM).0 };
     if function > max_function {
         return Err(Error::InvalidParameters(format!(
             "Function not supported: 0x{function:x}"
         )));
     }
 
-    let entry = __cpuid_count(function, count);
+    let entry = unsafe { __cpuid_count(function, count) };
     if entry.eax == 0 && entry.ebx == 0 && entry.ecx == 0 && entry.edx == 0 {
         return Err(Error::InvalidParameters(format!("Invalid count: {count}")));
     }

--- a/src/cpuid/src/common.rs
+++ b/src/cpuid/src/common.rs
@@ -4,7 +4,7 @@
 #[cfg(target_arch = "x86")]
 use std::arch::x86::{__cpuid_count, __get_cpuid_max, CpuidResult};
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86::{__cpuid_count, __get_cpuid_max, CpuidResult};
+use std::arch::x86_64::{__cpuid_count, __get_cpuid_max, CpuidResult};
 
 use crate::cpu_leaf::*;
 
@@ -18,6 +18,7 @@ pub enum Error {
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[allow(unused_unsafe)]
 pub fn get_cpuid(function: u32, count: u32) -> Result<CpuidResult, Error> {
     // TODO: replace with validation based on `has_cpuid()` when it becomes stable:
     //  https://doc.rust-lang.org/core/arch/x86/fn.has_cpuid.html
@@ -34,6 +35,7 @@ pub fn get_cpuid(function: u32, count: u32) -> Result<CpuidResult, Error> {
         }
     }
 
+    // this is safe because the host supports the `cpuid` instruction
     let max_function = unsafe { __get_cpuid_max(function & leaf_0x80000000::LEAF_NUM).0 };
     if function > max_function {
         return Err(Error::InvalidParameters(format!(
@@ -41,6 +43,7 @@ pub fn get_cpuid(function: u32, count: u32) -> Result<CpuidResult, Error> {
         )));
     }
 
+    // this is safe because the host supports the `cpuid` instruction
     let entry = unsafe { __cpuid_count(function, count) };
     if entry.eax == 0 && entry.ebx == 0 && entry.ecx == 0 && entry.edx == 0 {
         return Err(Error::InvalidParameters(format!("Invalid count: {count}")));

--- a/src/cpuid/src/common.rs
+++ b/src/cpuid/src/common.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(target_arch = "x86")]
-use std::arch::x86::{CpuidResult, __cpuid_count, __get_cpuid_max};
+use std::arch::x86::{__cpuid_count, __get_cpuid_max, CpuidResult};
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::{CpuidResult, __cpuid_count, __get_cpuid_max};
+use std::arch::x86::{__cpuid_count, __get_cpuid_max, CpuidResult};
 
 use crate::cpu_leaf::*;
 


### PR DESCRIPTION
Recent Rust versions (e.g., 1.93.0) require explicit `unsafe` blocks when calling low-level CPU intrinsics such as `__cpuid`, `__cpuid_count`, and `__get_cpuid_max`.

This crate was invoking these functions without `unsafe` blocks, which results in compilation errors:

    error[E0133]: call to unsafe function is unsafe and requires unsafe function or block

Wrap all such calls in explicit `unsafe {}` blocks to satisfy the compiler and maintain correctness.

No functional changes intended—this aligns the code with Rust’s safety requirements for intrinsic operations.