### PR TITLE
fix(arch): align boot cmdline limits with firmware

### DIFF
--- a/src/arch/src/aarch64/layout.rs
+++ b/src/arch/src/aarch64/layout.rs
@@ -59,8 +59,8 @@ pub const DRAM_MEM_END: u64 = 0x00FF_8000_0000; // 1024 - 2 = 1022 GB.
 pub const DRAM_MEM_MAX_SIZE: u64 = DRAM_MEM_END - DRAM_MEM_START_KERNEL;
 
 /// Kernel command line maximum size.
-/// As per `arch/arm64/include/uapi/asm/setup.h`.
-pub const CMDLINE_MAX_SIZE: usize = 2048;
+/// Matches msb-krunfw's `arch/arm64/include/uapi/asm/setup.h`.
+pub const CMDLINE_MAX_SIZE: usize = 16 * 1024;
 
 /// Maximum size of the device tree blob as specified in https://www.kernel.org/doc/Documentation/arm64/booting.txt.
 pub const FDT_MAX_SIZE: usize = 0x20_0000;

--- a/src/arch/src/riscv64/layout.rs
+++ b/src/arch/src/riscv64/layout.rs
@@ -9,8 +9,8 @@ pub const DRAM_MEM_END: u64 = 0x00FF_8000_0000; // 1024 - 2 = 1022 GB.
 pub const DRAM_MEM_MAX_SIZE: u64 = DRAM_MEM_END - DRAM_MEM_START;
 
 /// Kernel command line maximum size.
-/// As per `arch/riscv/include/uapi/asm/setup.h`.
-pub const CMDLINE_MAX_SIZE: usize = 1024;
+/// Matches msb-krunfw's `arch/riscv/include/uapi/asm/setup.h`.
+pub const CMDLINE_MAX_SIZE: usize = 16 * 1024;
 
 pub const FDT_MAX_SIZE: usize = 0x1_0000;
 

--- a/src/arch/src/x86_64/layout.rs
+++ b/src/arch/src/x86_64/layout.rs
@@ -13,7 +13,8 @@ pub const BOOT_STACK_POINTER: u64 = 0x8ff0;
 /// Kernel command line start address.
 pub const CMDLINE_START: u64 = 0x20000;
 /// Kernel command line start address maximum size.
-pub const CMDLINE_MAX_SIZE: usize = 0x10000;
+/// Matches msb-krunfw's `arch/x86/include/asm/setup.h`.
+pub const CMDLINE_MAX_SIZE: usize = 16 * 1024;
 /// Kernel command line static size on SEV.
 pub const CMDLINE_SEV_SIZE: usize = 0x200;
 /// Initrd start address on SEV.


### PR DESCRIPTION
## TL;DR
Align libkrun's VMM command-line guard with the msb-krunfw 16 KiB guest kernel command line.

## Description
- Raise `CMDLINE_MAX_SIZE` to 16 KiB for aarch64, riscv64, and x86_64.
- Document that the VMM guard matches the patched msb-krunfw kernel headers.
- Keep the VMM-side byte limit consistent with the firmware-side boot argument limit.

## Test Plan
- [x] `cargo fmt --manifest-path src/arch/Cargo.toml -- --check`
- [x] `cargo check --manifest-path src/arch/Cargo.toml`
- [x] `cargo check -p msb_krun --features blk,net`
