### PR TITLE
feat(metrics): expose guest VM metrics

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -1041,6 +1041,22 @@ int32_t krun_split_irqchip(uint32_t ctx_id, bool enable);
 int32_t krun_disable_implicit_console(uint32_t ctx_id);
 
 /**
+ * Enables or disables the virtio-balloon device. Enabled by default.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_balloon_device(uint32_t ctx_id, bool enable);
+
+/**
+ * Enables or disables the virtio-rng device. Enabled by default.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_rng_device(uint32_t ctx_id, bool enable);
+
+/**
  * Disable the implicit vsock device.
  *
  * By default, libkrun creates a vsock device automatically. This function

--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 use std::io::Write;
 
 use utils::eventfd::EventFd;
+use utils::metrics::MetricsWriter;
 use vm_memory::{ByteValued, GuestMemory, GuestMemoryMmap};
 
 use super::super::{
@@ -29,6 +30,8 @@ pub(crate) const AVAIL_FEATURES: u64 = (1 << uapi::VIRTIO_F_VERSION_1 as u64)
     | (1 << uapi::VIRTIO_BALLOON_F_FREE_PAGE_HINT as u64)
     | (1 << uapi::VIRTIO_BALLOON_F_REPORTING as u64);
 
+pub(crate) const VIRTIO_BALLOON_S_AVAIL: u16 = 6;
+
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(C, packed)]
 pub struct VirtioBalloonConfig {
@@ -52,10 +55,11 @@ pub struct Balloon {
     pub(crate) activate_evt: EventFd,
     pub(crate) device_state: DeviceState,
     config: VirtioBalloonConfig,
+    pub(crate) metrics: MetricsWriter,
 }
 
 impl Balloon {
-    pub fn new() -> super::Result<Balloon> {
+    pub fn new(metrics: MetricsWriter) -> super::Result<Balloon> {
         Ok(Balloon {
             queues: None,
             avail_features: AVAIL_FEATURES,
@@ -64,6 +68,7 @@ impl Balloon {
                 .map_err(BalloonError::EventFd)?,
             device_state: DeviceState::Inactive,
             config: VirtioBalloonConfig::default(),
+            metrics,
         })
     }
 

--- a/src/devices/src/virtio/balloon/event_handler.rs
+++ b/src/devices/src/virtio/balloon/event_handler.rs
@@ -2,9 +2,22 @@ use std::os::unix::io::AsRawFd;
 
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
+use vm_memory::{ByteValued, Le16, Le64};
 
-use super::device::{Balloon, DFQ_INDEX, FRQ_INDEX, IFQ_INDEX, PHQ_INDEX, STQ_INDEX};
+use super::device::{
+    Balloon, DFQ_INDEX, FRQ_INDEX, IFQ_INDEX, PHQ_INDEX, STQ_INDEX, VIRTIO_BALLOON_S_AVAIL,
+};
+use crate::virtio::descriptor_utils::Reader;
 use crate::virtio::device::VirtioDevice;
+
+#[derive(Clone, Copy, Default)]
+#[repr(C, packed)]
+struct BalloonStat {
+    tag: Le16,
+    val: Le64,
+}
+
+unsafe impl ByteValued for BalloonStat {}
 
 impl Balloon {
     fn queue_event(&self, idx: usize) -> &std::sync::Arc<utils::eventfd::EventFd> {
@@ -40,7 +53,7 @@ impl Balloon {
     }
 
     pub(crate) fn handle_stq_event(&mut self, event: &EpollEvent) {
-        debug!("balloon: stats queue event (ignored)");
+        debug!("balloon: stats queue event");
 
         let event_set = event.event_set();
         if event_set != EventSet::IN {
@@ -50,6 +63,8 @@ impl Balloon {
 
         if let Err(e) = self.queue_event(STQ_INDEX).read() {
             error!("Failed to read balloon stats queue event: {e:?}");
+        } else if self.process_stq() {
+            self.device_state.signal_used_queue();
         }
     }
 
@@ -81,6 +96,56 @@ impl Balloon {
         } else if self.process_frq() {
             self.device_state.signal_used_queue();
         }
+    }
+
+    fn process_stq(&mut self) -> bool {
+        let mem = match self.device_state {
+            crate::virtio::DeviceState::Activated(ref mem, _) => mem,
+            crate::virtio::DeviceState::Inactive => unreachable!(),
+        };
+        let metrics = self.metrics.clone();
+        let queues = self
+            .queues
+            .as_mut()
+            .expect("queues should exist when activated");
+        let mut have_used = false;
+
+        while let Some(head) = queues[STQ_INDEX].queue.pop(mem) {
+            let index = head.index;
+            let mut reader = match Reader::new(mem, head) {
+                Ok(reader) => reader,
+                Err(e) => {
+                    error!("balloon: invalid stats descriptor chain: {e:?}");
+                    have_used = true;
+                    if let Err(e) = queues[STQ_INDEX].queue.add_used(mem, index, 0) {
+                        error!("balloon: failed to add used stats element: {e:?}");
+                    }
+                    continue;
+                }
+            };
+
+            while reader.available_bytes() >= std::mem::size_of::<BalloonStat>() {
+                match reader.read_obj::<BalloonStat>() {
+                    Ok(stat) => match stat.tag.to_native() {
+                        VIRTIO_BALLOON_S_AVAIL => {
+                            metrics.set_memory_available_bytes(stat.val.to_native())
+                        }
+                        _ => {}
+                    },
+                    Err(e) => {
+                        error!("balloon: failed to read stat: {e:?}");
+                        break;
+                    }
+                }
+            }
+
+            have_used = true;
+            if let Err(e) = queues[STQ_INDEX].queue.add_used(mem, index, 0) {
+                error!("balloon: failed to add used stats element: {e:?}");
+            }
+        }
+
+        have_used
     }
 
     fn handle_activate_event(&self, event_manager: &mut EventManager) {

--- a/src/devices/src/virtio/balloon/event_handler.rs
+++ b/src/devices/src/virtio/balloon/event_handler.rs
@@ -126,12 +126,11 @@ impl Balloon {
 
             while reader.available_bytes() >= std::mem::size_of::<BalloonStat>() {
                 match reader.read_obj::<BalloonStat>() {
-                    Ok(stat) => match stat.tag.to_native() {
-                        VIRTIO_BALLOON_S_AVAIL => {
-                            metrics.set_memory_available_bytes(stat.val.to_native())
+                    Ok(stat) => {
+                        if stat.tag.to_native() == VIRTIO_BALLOON_S_AVAIL {
+                            metrics.set_memory_available_bytes(stat.val.to_native());
                         }
-                        _ => {}
-                    },
+                    }
                     Err(e) => {
                         error!("balloon: failed to read stat: {e:?}");
                         break;

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -24,6 +24,7 @@ use imago::{
 };
 use log::{error, warn};
 use utils::eventfd::{EventFd, EFD_NONBLOCK};
+use utils::metrics::BlockMetricsWriter;
 use virtio_bindings::{
     virtio_blk::*, virtio_config::VIRTIO_F_VERSION_1, virtio_ring::VIRTIO_RING_F_EVENT_IDX,
 };
@@ -207,6 +208,7 @@ pub struct Block {
     cache_type: CacheType,
     disk_image: Arc<Mutex<SyncFormatAccess<Box<dyn DynStorage>>>>,
     disk_image_id: Vec<u8>,
+    metrics: BlockMetricsWriter,
     worker_thread: Option<JoinHandle<()>>,
     worker_stopfd: EventFd,
 
@@ -237,6 +239,7 @@ impl Block {
         is_disk_read_only: bool,
         direct_io: bool,
         sync_mode: SyncMode,
+        metrics: BlockMetricsWriter,
     ) -> io::Result<Block> {
         let disk_image = OpenOptions::new()
             .read(true)
@@ -334,6 +337,7 @@ impl Block {
             cache_type,
             disk_image,
             disk_image_id,
+            metrics,
             avail_features,
             acked_features: 0u64,
             device_state: DeviceState::Inactive,
@@ -436,6 +440,7 @@ impl VirtioDevice for Block {
             mem.clone(),
             disk,
             self.worker_stopfd.try_clone().unwrap(),
+            self.metrics.clone(),
         );
         self.worker_thread = Some(worker.run());
 

--- a/src/devices/src/virtio/block/test_utils.rs
+++ b/src/devices/src/virtio/block/test_utils.rs
@@ -3,9 +3,13 @@
 
 use std::os::unix::io::AsRawFd;
 
-use crate::virtio::{Block, CacheType, Queue};
+use crate::virtio::{
+    block::{ImageType, SyncMode},
+    Block, CacheType, Queue,
+};
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
+use utils::metrics::MetricsWriter;
 use utils::tempfile::TempFile;
 
 /// Create a default Block instance to be used in tests.
@@ -21,7 +25,19 @@ pub fn default_block() -> Block {
 pub fn default_block_with_path(path: String) -> Block {
     let id = "test".to_string();
     // The default block device is read-write and non-root.
-    Block::new(id, None, CacheType::Unsafe, path, false, false).unwrap()
+    let metrics = MetricsWriter::default().register_block_device(id.clone());
+    Block::new(
+        id,
+        None,
+        CacheType::Unsafe,
+        path,
+        ImageType::Raw,
+        false,
+        false,
+        SyncMode::None,
+        metrics,
+    )
+    .unwrap()
 }
 
 pub fn invoke_handler_for_queue_event(b: &mut Block) {

--- a/src/devices/src/virtio/block/worker.rs
+++ b/src/devices/src/virtio/block/worker.rs
@@ -10,6 +10,7 @@ use std::result;
 use std::thread;
 use utils::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 use utils::eventfd::EventFd;
+use utils::metrics::BlockMetricsWriter;
 use virtio_bindings::virtio_blk::*;
 use vm_memory::{ByteValued, GuestMemoryMmap};
 
@@ -61,6 +62,7 @@ pub struct BlockWorker {
     mem: GuestMemoryMmap,
     disk: DiskProperties,
     stop_fd: EventFd,
+    metrics: BlockMetricsWriter,
 }
 
 impl BlockWorker {
@@ -70,6 +72,7 @@ impl BlockWorker {
         mem: GuestMemoryMmap,
         disk: DiskProperties,
         stop_fd: EventFd,
+        metrics: BlockMetricsWriter,
     ) -> Self {
         Self {
             device_queue,
@@ -77,6 +80,7 @@ impl BlockWorker {
             mem,
             disk,
             stop_fd,
+            metrics,
         }
     }
 
@@ -105,8 +109,8 @@ impl BlockWorker {
             &EpollEvent::new(EventSet::IN, stop_ev_fd as u64),
         );
 
+        let mut epoll_events = vec![EpollEvent::new(EventSet::empty(), 0); 32];
         loop {
-            let mut epoll_events = vec![EpollEvent::new(EventSet::empty(), 0); 32];
             match epoll.wait(epoll_events.len(), -1, epoll_events.as_mut_slice()) {
                 Ok(ev_cnt) => {
                     for event in &epoll_events[0..ev_cnt] {
@@ -219,13 +223,19 @@ impl BlockWorker {
     ) -> result::Result<usize, RequestError> {
         match request_header.request_type {
             VIRTIO_BLK_T_IN => {
-                let data_len = writer.available_bytes() - 1;
+                let data_len = writer
+                    .available_bytes()
+                    .checked_sub(1)
+                    .ok_or(RequestError::InvalidDataLength)?;
                 if !data_len.is_multiple_of(512) {
                     Err(RequestError::InvalidDataLength)
                 } else {
-                    writer
-                        .write_from_at(&self.disk, data_len, request_header.sector * 512)
-                        .map_err(RequestError::WritingToDescriptor)
+                    let offset = sector_offset(request_header.sector)?;
+                    let len = writer
+                        .write_from_at(&self.disk, data_len, offset)
+                        .map_err(RequestError::WritingToDescriptor)?;
+                    self.metrics.add_read_bytes(len as u64);
+                    Ok(len)
                 }
             }
             VIRTIO_BLK_T_OUT => {
@@ -233,9 +243,12 @@ impl BlockWorker {
                 if !data_len.is_multiple_of(512) {
                     Err(RequestError::InvalidDataLength)
                 } else {
-                    reader
-                        .read_to_at(&self.disk, data_len, request_header.sector * 512)
-                        .map_err(RequestError::ReadingFromDescriptor)
+                    let offset = sector_offset(request_header.sector)?;
+                    let len = reader
+                        .read_to_at(&self.disk, data_len, offset)
+                        .map_err(RequestError::ReadingFromDescriptor)?;
+                    self.metrics.add_write_bytes(len as u64);
+                    Ok(len)
                 }
             }
             VIRTIO_BLK_T_FLUSH => match self.disk.cache_type() {
@@ -268,8 +281,8 @@ impl BlockWorker {
                     .lock()
                     .unwrap()
                     .discard_to_any(
-                        discard_write_data.sector * 512,
-                        discard_write_data.num_sectors as u64 * 512,
+                        sector_offset(discard_write_data.sector)?,
+                        sector_count_bytes(discard_write_data.num_sectors)?,
                     )
                     .map_err(RequestError::Discarding)?;
                 Ok(0)
@@ -285,8 +298,8 @@ impl BlockWorker {
                         .lock()
                         .unwrap()
                         .discard_to_zero(
-                            discard_write_data.sector * 512,
-                            discard_write_data.num_sectors as u64 * 512,
+                            sector_offset(discard_write_data.sector)?,
+                            sector_count_bytes(discard_write_data.num_sectors)?,
                         )
                         .map_err(RequestError::DiscardingToZero)?;
                 } else {
@@ -295,8 +308,8 @@ impl BlockWorker {
                         .lock()
                         .unwrap()
                         .write_zeroes(
-                            discard_write_data.sector * 512,
-                            discard_write_data.num_sectors as u64 * 512,
+                            sector_offset(discard_write_data.sector)?,
+                            sector_count_bytes(discard_write_data.num_sectors)?,
                         )
                         .map_err(RequestError::WritingZeroes)?;
                 }
@@ -304,5 +317,39 @@ impl BlockWorker {
             }
             _ => Err(RequestError::UnknownRequest),
         }
+    }
+}
+
+fn sector_offset(sector: u64) -> result::Result<u64, RequestError> {
+    sector
+        .checked_mul(512)
+        .ok_or(RequestError::InvalidDataLength)
+}
+
+fn sector_count_bytes(sectors: u32) -> result::Result<u64, RequestError> {
+    u64::from(sectors)
+        .checked_mul(512)
+        .ok_or(RequestError::InvalidDataLength)
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sector_offset_rejects_overflow() {
+        assert!(matches!(
+            sector_offset(u64::MAX),
+            Err(RequestError::InvalidDataLength)
+        ));
+    }
+
+    #[test]
+    fn sector_count_bytes_converts_to_bytes() {
+        assert_eq!(sector_count_bytes(8).unwrap(), 4096);
     }
 }

--- a/src/hvf/src/lib.rs
+++ b/src/hvf/src/lib.rs
@@ -477,6 +477,16 @@ impl HvfVcpu<'_> {
         self.vcpuid
     }
 
+    pub fn exec_time_ns(&self) -> Option<u64> {
+        let mut time = 0;
+        let ret = unsafe { hv_vcpu_get_exec_time(self.vcpuid, &mut time) };
+        if ret == HV_SUCCESS {
+            Some(time)
+        } else {
+            None
+        }
+    }
+
     fn read_reg(&self, reg: u32) -> Result<u64, Error> {
         let val: u64 = 0;
         let ret = unsafe { hv_vcpu_get_reg(self.vcpuid, reg, &val as *const _ as *mut _) };

--- a/src/hvf/src/lib.rs
+++ b/src/hvf/src/lib.rs
@@ -26,9 +26,27 @@ use std::time::Duration;
 use arch::aarch64::sysreg::{sys_reg_name, SYSREG_MASK};
 use log::debug;
 
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct MachTimebaseInfo {
+    numer: u32,
+    denom: u32,
+}
+
 extern "C" {
     pub fn mach_absolute_time() -> u64;
+    fn mach_timebase_info(info: *mut MachTimebaseInfo) -> i32;
 }
+
+static MACH_TIMEBASE_INFO: LazyLock<MachTimebaseInfo> = LazyLock::new(|| {
+    let mut info = MachTimebaseInfo { numer: 1, denom: 1 };
+    let ret = unsafe { mach_timebase_info(&mut info) };
+    if ret == 0 && info.denom != 0 {
+        info
+    } else {
+        MachTimebaseInfo { numer: 1, denom: 1 }
+    }
+});
 
 const HV_EXIT_REASON_CANCELED: hv_exit_reason_t = 0;
 const HV_EXIT_REASON_EXCEPTION: hv_exit_reason_t = 1;
@@ -174,6 +192,12 @@ pub fn vcpu_request_exit(vcpuid: u64) -> Result<(), Error> {
     } else {
         Ok(())
     }
+}
+
+fn mach_absolute_time_to_ns(ticks: u64) -> u64 {
+    let timebase = *MACH_TIMEBASE_INFO;
+    let ns = (u128::from(ticks) * u128::from(timebase.numer)) / u128::from(timebase.denom);
+    ns.min(u128::from(u64::MAX)) as u64
 }
 
 pub fn vcpu_set_pending_irq(
@@ -481,7 +505,7 @@ impl HvfVcpu<'_> {
         let mut time = 0;
         let ret = unsafe { hv_vcpu_get_exec_time(self.vcpuid, &mut time) };
         if ret == HV_SUCCESS {
-            Some(time)
+            Some(mach_absolute_time_to_ns(time))
         } else {
             None
         }

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -349,6 +349,8 @@ impl VmBuilder {
         vmr.nested_enabled = self.machine.nested_virt;
         vmr.split_irqchip = self.machine.split_irqchip;
         vmr.request_vsock = self.machine.vsock;
+        vmr.enable_balloon = self.machine.balloon;
+        vmr.enable_rng = self.machine.rng;
 
         // Apply filesystem configuration
         #[cfg(not(feature = "tee"))]

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -44,6 +44,8 @@ pub struct MachineBuilder {
     pub(crate) nested_virt: bool,
     pub(crate) split_irqchip: bool,
     pub(crate) vsock: bool,
+    pub(crate) balloon: bool,
+    pub(crate) rng: bool,
     pub(crate) enable_inet_hijack: bool,
 }
 
@@ -335,6 +337,8 @@ impl MachineBuilder {
             nested_virt: false,
             split_irqchip: false,
             vsock: false,
+            balloon: true,
+            rng: true,
             enable_inet_hijack: false,
         }
     }
@@ -384,6 +388,25 @@ impl MachineBuilder {
     /// its own purposes even though TSI would not otherwise require one.
     pub fn vsock(mut self, enabled: bool) -> Self {
         self.vsock = enabled;
+        self
+    }
+
+    /// Enable or disable the virtio-balloon device.
+    ///
+    /// The device is enabled by default for general-purpose VMs. Latency-sensitive
+    /// guests that never resize memory can disable it to avoid one virtio-mmio
+    /// device and its guest-side probe.
+    pub fn balloon(mut self, enabled: bool) -> Self {
+        self.balloon = enabled;
+        self
+    }
+
+    /// Enable or disable the virtio-rng device.
+    ///
+    /// The device is enabled by default. Guests with a known nonblocking boot
+    /// path can disable it to remove one virtio-mmio device from cold start.
+    pub fn rng(mut self, enabled: bool) -> Self {
+        self.rng = enabled;
         self
     }
 

--- a/src/krun/src/api/metrics.rs
+++ b/src/krun/src/api/metrics.rs
@@ -1,0 +1,9 @@
+//! VM metrics API.
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+pub use utils::metrics::{
+    BlockDeviceMetrics, BlockMetrics, CpuMetrics, MemoryMetrics, MetricsHandle, VmMetrics,
+};

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -31,6 +31,7 @@ pub mod builder;
 pub mod builders;
 pub mod error;
 pub mod exit_handle;
+pub mod metrics;
 pub mod vm;
 
 //--------------------------------------------------------------------------------------------------
@@ -47,4 +48,7 @@ pub use builders::NetBuilder;
 pub use builders::{ConsoleBuilder, ExecBuilder, FsBuilder, KernelBuilder, MachineBuilder};
 pub use error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use exit_handle::ExitHandle;
+pub use metrics::{
+    BlockDeviceMetrics, BlockMetrics, CpuMetrics, MemoryMetrics, MetricsHandle, VmMetrics,
+};
 pub use vm::Vm;

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -4,7 +4,7 @@ use std::convert::Infallible;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicI32;
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{Instant, SystemTime};
 
 #[cfg(target_os = "linux")]
 use std::env;
@@ -22,6 +22,7 @@ use vmm::vmm_config::vsock::VsockDeviceConfig;
 
 use super::error::{BuildError, Error, Result, RuntimeError};
 use super::exit_handle::ExitHandle;
+use super::metrics::MetricsHandle;
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -120,11 +121,23 @@ impl Vm {
         Arc::clone(&self.exit_code)
     }
 
+    /// Get a cloneable handle for VM metrics.
+    ///
+    /// Must be called before [`enter()`](Self::enter) if the caller needs to
+    /// sample metrics while the VM is running, because `enter()` never returns
+    /// on a successful boot.
+    pub fn metrics_handle(&self) -> MetricsHandle {
+        self.vmr.metrics.handle()
+    }
+
     /// Start the VM. This call never returns on success — the VMM calls
     /// `_exit()` when the guest shuts down, killing the entire process.
     ///
     /// Only returns `Err` if something fails before the VMM takes over.
     pub fn enter(mut self) -> Result<Infallible> {
+        let mut trace = BootTrace::new("api");
+        trace.mark("enter.start");
+
         // Set process name on Linux
         #[cfg(target_os = "linux")]
         {
@@ -138,6 +151,7 @@ impl Vm {
         // Create event manager
         let mut event_manager = EventManager::new()
             .map_err(|e| Error::Build(BuildError::Start(format!("EventManager: {e:?}"))))?;
+        trace.mark("event_manager.ready");
 
         // Load kernel from libkrunfw if not already configured
         if self.vmr.external_kernel.is_none()
@@ -147,6 +161,7 @@ impl Vm {
         {
             self.load_krunfw()?;
         }
+        trace.mark("kernel.ready");
 
         // Capture boot start timestamp (epoch nanoseconds) for guest-side timing.
         let boot_start_ns = SystemTime::now()
@@ -160,9 +175,11 @@ impl Vm {
         self.vmr
             .set_kernel_cmdline(kernel_cmdline)
             .map_err(|e| Error::Build(BuildError::Start(format!("kernel cmdline: {e:?}"))))?;
+        trace.mark("kernel_cmdline.ready");
 
         // Configure vsock
         self.configure_vsock()?;
+        trace.mark("vsock.configured");
 
         // Create shutdown EventFd on macOS aarch64 (needed for GPIO shutdown device)
         let shutdown_efd = if cfg!(target_arch = "aarch64") && cfg!(target_os = "macos") {
@@ -186,6 +203,7 @@ impl Vm {
             self.exit_code,
         )
         .map_err(|e| Error::Build(BuildError::Start(format!("build_microvm: {e:?}"))))?;
+        trace.mark("build_microvm.ready");
 
         // Register user exit observers
         {
@@ -194,6 +212,7 @@ impl Vm {
                 vmm.add_exit_observer(observer);
             }
         }
+        trace.mark("observers.ready");
 
         // Start worker threads if needed
         #[cfg(target_os = "macos")]
@@ -211,6 +230,7 @@ impl Vm {
         #[cfg(any(feature = "amd-sev", feature = "tdx"))]
         vmm::worker::start_worker_thread(_vmm.clone(), _receiver.clone())
             .map_err(|e| Error::Runtime(RuntimeError::EventLoop(format!("{e:?}"))))?;
+        trace.mark("event_loop.start");
 
         // Run the event loop. On normal guest exit, the VMM calls _exit() directly.
         loop {
@@ -399,6 +419,41 @@ impl Vm {
         }
 
         tsi_flags
+    }
+}
+
+struct BootTrace {
+    enabled: bool,
+    scope: &'static str,
+    start: Instant,
+    last: Instant,
+}
+
+impl BootTrace {
+    fn new(scope: &'static str) -> Self {
+        let now = Instant::now();
+        Self {
+            enabled: std::env::var_os("MSB_KRUN_BOOT_TRACE").is_some(),
+            scope,
+            start: now,
+            last: now,
+        }
+    }
+
+    fn mark(&mut self, label: &'static str) {
+        if !self.enabled {
+            return;
+        }
+
+        let now = Instant::now();
+        eprintln!(
+            "krun.boot scope={} label={} elapsed_us={} delta_us={}",
+            self.scope,
+            label,
+            now.duration_since(self.start).as_micros(),
+            now.duration_since(self.last).as_micros(),
+        );
+        self.last = now;
     }
 }
 

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -51,6 +51,9 @@ pub use api::builders::SyncMode;
 pub use api::builders::{ConsoleBuilder, ExecBuilder, FsBuilder, KernelBuilder, MachineBuilder};
 pub use api::error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use api::exit_handle::ExitHandle;
+pub use api::metrics::{
+    BlockDeviceMetrics, BlockMetrics, CpuMetrics, MemoryMetrics, MetricsHandle, VmMetrics,
+};
 pub use api::vm::Vm;
 
 pub use backends::console::ConsolePortBackend;

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -2317,6 +2317,32 @@ pub extern "C" fn krun_disable_implicit_console(ctx_id: u32) -> i32 {
 }
 
 #[no_mangle]
+pub extern "C" fn krun_set_balloon_device(ctx_id: u32, enable: bool) -> i32 {
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => {
+            let cfg = ctx_cfg.get_mut();
+            cfg.vmr.enable_balloon = enable;
+        }
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+
+    KRUN_SUCCESS
+}
+
+#[no_mangle]
+pub extern "C" fn krun_set_rng_device(ctx_id: u32, enable: bool) -> i32 {
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => {
+            let cfg = ctx_cfg.get_mut();
+            cfg.vmr.enable_rng = enable;
+        }
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+
+    KRUN_SUCCESS
+}
+
+#[no_mangle]
 pub extern "C" fn krun_disable_implicit_vsock(ctx_id: u32) -> i32 {
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => {

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -16,6 +16,7 @@ pub mod macos;
 pub use macos::epoll;
 #[cfg(target_os = "macos")]
 pub use macos::eventfd;
+pub mod metrics;
 pub mod pollable_channel;
 #[cfg(target_arch = "x86_64")]
 pub mod rand;

--- a/src/utils/src/metrics.rs
+++ b/src/utils/src/metrics.rs
@@ -1,0 +1,465 @@
+// Copyright 2026 Super Rad Company
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::sync::Mutex;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+type HostResidentMemorySampler = dyn Fn() -> Option<u64> + Send + Sync + 'static;
+
+/// Cloneable handle for point-in-time VM metrics.
+#[derive(Clone, Debug, Default)]
+pub struct MetricsHandle {
+    state: Arc<MetricsState>,
+}
+
+/// Cloneable writer for VMM and device metrics.
+#[derive(Clone, Debug, Default)]
+pub struct MetricsWriter {
+    state: Arc<MetricsState>,
+}
+
+/// Cloneable writer for one block device's metrics.
+#[derive(Clone, Debug)]
+pub struct BlockMetricsWriter {
+    state: Arc<MetricsState>,
+    device: Arc<BlockDeviceState>,
+}
+
+/// Point-in-time VM metrics.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct VmMetrics {
+    /// CPU metrics.
+    pub cpu: CpuMetrics,
+    /// Memory metrics.
+    pub memory: MemoryMetrics,
+    /// Block device metrics.
+    pub block: BlockMetrics,
+}
+
+/// CPU metrics.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CpuMetrics {
+    /// Cumulative guest vCPU execution time across all vCPUs when available.
+    pub vcpu_time_ns: Option<u64>,
+}
+
+/// Memory metrics.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct MemoryMetrics {
+    /// Configured guest physical memory.
+    pub total_bytes: u64,
+    /// Guest-available memory when reported by virtio-balloon stats.
+    pub available_bytes: Option<u64>,
+    /// Derived guest-used memory when available.
+    pub used_bytes: Option<u64>,
+    /// Host-resident guest memory pages when the VMM can report them.
+    pub host_resident_bytes: Option<u64>,
+}
+
+/// Aggregate block metrics.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct BlockMetrics {
+    /// Successful guest logical bytes read from block devices.
+    pub read_bytes: u64,
+    /// Successful guest logical bytes written to block devices.
+    pub write_bytes: u64,
+    /// Per-device block metrics.
+    pub devices: Vec<BlockDeviceMetrics>,
+}
+
+/// Per-device block metrics.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BlockDeviceMetrics {
+    /// VMM block device id.
+    pub id: String,
+    /// Successful guest logical bytes read from this block device.
+    pub read_bytes: u64,
+    /// Successful guest logical bytes written to this block device.
+    pub write_bytes: u64,
+}
+
+struct MetricsState {
+    vcpu_time_ns: AtomicU64,
+    vcpu_time_valid: AtomicU64,
+    memory_total_bytes: AtomicU64,
+    memory_available_bytes: AtomicU64,
+    memory_available_valid: AtomicU64,
+    memory_host_resident_bytes: AtomicU64,
+    memory_host_resident_valid: AtomicU64,
+    memory_host_resident_sampler: Mutex<Option<Arc<HostResidentMemorySampler>>>,
+    block_read_bytes: AtomicU64,
+    block_write_bytes: AtomicU64,
+    block_devices: Mutex<Vec<Arc<BlockDeviceState>>>,
+}
+
+#[derive(Debug)]
+struct BlockDeviceState {
+    id: String,
+    read_bytes: AtomicU64,
+    write_bytes: AtomicU64,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl MetricsHandle {
+    /// Return a coherent-enough snapshot of current VM metrics.
+    ///
+    /// Counters are monotonic atomics. Callers that need rates should compute
+    /// deltas between snapshots.
+    pub fn snapshot(&self) -> VmMetrics {
+        self.snapshot_inner(true)
+    }
+
+    /// Return aggregate VM metrics without per-device block details.
+    ///
+    /// This avoids cloning the per-device vector for high-frequency samplers
+    /// that only publish aggregate counters.
+    pub fn aggregate_snapshot(&self) -> VmMetrics {
+        self.snapshot_inner(false)
+    }
+
+    fn snapshot_inner(&self, include_block_devices: bool) -> VmMetrics {
+        let total_bytes = self.state.memory_total_bytes.load(Ordering::Relaxed);
+        let available_bytes = valid_value(
+            &self.state.memory_available_valid,
+            &self.state.memory_available_bytes,
+        );
+        let host_resident_bytes = self.host_resident_bytes();
+        VmMetrics {
+            cpu: CpuMetrics {
+                vcpu_time_ns: valid_value(&self.state.vcpu_time_valid, &self.state.vcpu_time_ns),
+            },
+            memory: MemoryMetrics {
+                total_bytes,
+                available_bytes,
+                used_bytes: available_bytes
+                    .and_then(|available| total_bytes.checked_sub(available)),
+                host_resident_bytes,
+            },
+            block: BlockMetrics {
+                read_bytes: self.state.block_read_bytes.load(Ordering::Relaxed),
+                write_bytes: self.state.block_write_bytes.load(Ordering::Relaxed),
+                devices: if include_block_devices {
+                    self.state
+                        .block_devices
+                        .lock()
+                        .unwrap()
+                        .iter()
+                        .map(|device| BlockDeviceMetrics {
+                            id: device.id.clone(),
+                            read_bytes: device.read_bytes.load(Ordering::Relaxed),
+                            write_bytes: device.write_bytes.load(Ordering::Relaxed),
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                },
+            },
+        }
+    }
+
+    fn host_resident_bytes(&self) -> Option<u64> {
+        let sampler = self
+            .state
+            .memory_host_resident_sampler
+            .lock()
+            .unwrap()
+            .clone();
+        if let Some(sampler) = sampler {
+            match sampler() {
+                Some(bytes) => {
+                    self.state
+                        .memory_host_resident_bytes
+                        .store(bytes, Ordering::Relaxed);
+                    self.state
+                        .memory_host_resident_valid
+                        .store(1, Ordering::Release);
+                }
+                None => {
+                    self.state
+                        .memory_host_resident_valid
+                        .store(0, Ordering::Release);
+                    return None;
+                }
+            }
+        }
+
+        valid_value(
+            &self.state.memory_host_resident_valid,
+            &self.state.memory_host_resident_bytes,
+        )
+    }
+}
+
+impl MetricsWriter {
+    /// Return a public read handle for this metrics state.
+    pub fn handle(&self) -> MetricsHandle {
+        MetricsHandle {
+            state: Arc::clone(&self.state),
+        }
+    }
+
+    /// Set configured guest memory.
+    pub fn set_memory_total_bytes(&self, bytes: u64) {
+        self.state
+            .memory_total_bytes
+            .store(bytes, Ordering::Relaxed);
+    }
+
+    /// Set guest-available memory.
+    pub fn set_memory_available_bytes(&self, bytes: u64) {
+        self.state
+            .memory_available_bytes
+            .store(bytes, Ordering::Relaxed);
+        self.state
+            .memory_available_valid
+            .store(1, Ordering::Release);
+    }
+
+    /// Set host-resident guest memory.
+    pub fn set_memory_host_resident_bytes(&self, bytes: u64) {
+        self.state
+            .memory_host_resident_bytes
+            .store(bytes, Ordering::Relaxed);
+        self.state
+            .memory_host_resident_valid
+            .store(1, Ordering::Release);
+    }
+
+    /// Register a sampler that refreshes host-resident guest memory during snapshots.
+    pub fn set_memory_host_resident_sampler<F>(&self, sampler: F)
+    where
+        F: Fn() -> Option<u64> + Send + Sync + 'static,
+    {
+        *self.state.memory_host_resident_sampler.lock().unwrap() = Some(Arc::new(sampler));
+    }
+
+    /// Add guest vCPU execution time.
+    pub fn add_vcpu_time_ns(&self, ns: u64) {
+        self.state.vcpu_time_ns.fetch_add(ns, Ordering::Relaxed);
+        self.state.vcpu_time_valid.store(1, Ordering::Release);
+    }
+
+    /// Register one block device and return a device-scoped metrics writer.
+    pub fn register_block_device(&self, id: String) -> BlockMetricsWriter {
+        let device = Arc::new(BlockDeviceState {
+            id,
+            read_bytes: AtomicU64::new(0),
+            write_bytes: AtomicU64::new(0),
+        });
+        self.state
+            .block_devices
+            .lock()
+            .unwrap()
+            .push(Arc::clone(&device));
+        BlockMetricsWriter {
+            state: Arc::clone(&self.state),
+            device,
+        }
+    }
+}
+
+impl BlockMetricsWriter {
+    /// Add successful guest logical block read bytes.
+    pub fn add_read_bytes(&self, bytes: u64) {
+        self.state
+            .block_read_bytes
+            .fetch_add(bytes, Ordering::Relaxed);
+        self.device.read_bytes.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Add successful guest logical block write bytes.
+    pub fn add_write_bytes(&self, bytes: u64) {
+        self.state
+            .block_write_bytes
+            .fetch_add(bytes, Ordering::Relaxed);
+        self.device.write_bytes.fetch_add(bytes, Ordering::Relaxed);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for MetricsState {
+    fn default() -> Self {
+        Self {
+            vcpu_time_ns: AtomicU64::new(0),
+            vcpu_time_valid: AtomicU64::new(0),
+            memory_total_bytes: AtomicU64::new(0),
+            memory_available_bytes: AtomicU64::new(0),
+            memory_available_valid: AtomicU64::new(0),
+            memory_host_resident_bytes: AtomicU64::new(0),
+            memory_host_resident_valid: AtomicU64::new(0),
+            memory_host_resident_sampler: Mutex::new(None),
+            block_read_bytes: AtomicU64::new(0),
+            block_write_bytes: AtomicU64::new(0),
+            block_devices: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl fmt::Debug for MetricsState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MetricsState").finish_non_exhaustive()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn valid_value(valid: &AtomicU64, value: &AtomicU64) -> Option<u64> {
+    if valid.load(Ordering::Acquire) == 0 {
+        None
+    } else {
+        Some(value.load(Ordering::Relaxed))
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpu_time_is_unavailable_until_written() {
+        let writer = MetricsWriter::default();
+
+        assert_eq!(writer.handle().snapshot().cpu.vcpu_time_ns, None);
+
+        writer.add_vcpu_time_ns(12);
+
+        assert_eq!(writer.handle().snapshot().cpu.vcpu_time_ns, Some(12));
+    }
+
+    #[test]
+    fn memory_used_is_derived_from_configured_total_and_available() {
+        let writer = MetricsWriter::default();
+
+        writer.set_memory_total_bytes(1024);
+
+        let snapshot = writer.handle().snapshot();
+        assert_eq!(snapshot.memory.total_bytes, 1024);
+        assert_eq!(snapshot.memory.available_bytes, None);
+        assert_eq!(snapshot.memory.used_bytes, None);
+
+        writer.set_memory_available_bytes(256);
+
+        let snapshot = writer.handle().snapshot();
+        assert_eq!(snapshot.memory.available_bytes, Some(256));
+        assert_eq!(snapshot.memory.used_bytes, Some(768));
+    }
+
+    #[test]
+    fn memory_used_is_unavailable_when_available_exceeds_total() {
+        let writer = MetricsWriter::default();
+
+        writer.set_memory_total_bytes(1024);
+        writer.set_memory_available_bytes(2048);
+
+        let snapshot = writer.handle().snapshot();
+        assert_eq!(snapshot.memory.available_bytes, Some(2048));
+        assert_eq!(snapshot.memory.used_bytes, None);
+    }
+
+    #[test]
+    fn host_resident_sampler_refreshes_snapshot() {
+        let writer = MetricsWriter::default();
+        let value = Arc::new(AtomicU64::new(4096));
+        let sampler_value = Arc::clone(&value);
+
+        writer
+            .set_memory_host_resident_sampler(move || Some(sampler_value.load(Ordering::Relaxed)));
+
+        assert_eq!(
+            writer.handle().snapshot().memory.host_resident_bytes,
+            Some(4096)
+        );
+
+        value.store(8192, Ordering::Relaxed);
+
+        assert_eq!(
+            writer.handle().snapshot().memory.host_resident_bytes,
+            Some(8192)
+        );
+    }
+
+    #[test]
+    fn host_resident_sampler_failure_clears_previous_value() {
+        let writer = MetricsWriter::default();
+        let value = Arc::new(AtomicU64::new(4096));
+        let sampler_value = Arc::clone(&value);
+
+        writer.set_memory_host_resident_sampler(move || {
+            match sampler_value.load(Ordering::Relaxed) {
+                0 => None,
+                bytes => Some(bytes),
+            }
+        });
+
+        assert_eq!(
+            writer.handle().snapshot().memory.host_resident_bytes,
+            Some(4096)
+        );
+
+        value.store(0, Ordering::Relaxed);
+
+        assert_eq!(writer.handle().snapshot().memory.host_resident_bytes, None);
+    }
+
+    #[test]
+    fn block_metrics_include_aggregate_and_per_device_counters() {
+        let writer = MetricsWriter::default();
+        let root = writer.register_block_device("root".to_string());
+        let data = writer.register_block_device("data".to_string());
+
+        root.add_read_bytes(128);
+        root.add_write_bytes(256);
+        data.add_read_bytes(512);
+
+        let snapshot = writer.handle().snapshot();
+        assert_eq!(snapshot.block.read_bytes, 640);
+        assert_eq!(snapshot.block.write_bytes, 256);
+        assert_eq!(
+            snapshot.block.devices,
+            vec![
+                BlockDeviceMetrics {
+                    id: "root".to_string(),
+                    read_bytes: 128,
+                    write_bytes: 256,
+                },
+                BlockDeviceMetrics {
+                    id: "data".to_string(),
+                    read_bytes: 512,
+                    write_bytes: 0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn aggregate_snapshot_omits_per_device_block_counters() {
+        let writer = MetricsWriter::default();
+        let root = writer.register_block_device("root".to_string());
+
+        root.add_read_bytes(128);
+        root.add_write_bytes(256);
+
+        let snapshot = writer.handle().aggregate_snapshot();
+        assert_eq!(snapshot.block.read_bytes, 128);
+        assert_eq!(snapshot.block.write_bytes, 256);
+        assert!(snapshot.block.devices.is_empty());
+    }
+}

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -17,6 +17,7 @@ use std::os::fd::{BorrowedFd, FromRawFd};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicI32;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use super::{Error, Vmm};
 
@@ -567,6 +568,9 @@ pub fn build_microvm(
     exit_evt: EventFd,
     exit_code: Arc<AtomicI32>,
 ) -> std::result::Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
+    let mut trace = BootTrace::new("vmm");
+    trace.mark("build_microvm.start");
+
     let payload = choose_payload(vm_resources)?;
 
     let (guest_memory, arch_memory_info, mut _shm_manager, payload_config) = create_guest_memory(
@@ -577,6 +581,7 @@ pub fn build_microvm(
         vm_resources,
         &payload,
     )?;
+    trace.mark("guest_memory.ready");
 
     let vcpu_config = vm_resources.vcpu_config();
 
@@ -594,6 +599,7 @@ pub fn build_microvm(
     if let Some(cmdline) = &vm_resources.kernel_cmdline.krun_env {
         kernel_cmdline.insert_str(cmdline.as_str()).unwrap();
     }
+    trace.mark("kernel_cmdline.ready");
 
     if let Some(kernel_console) = &vm_resources.kernel_console {
         let cmdline = kernel_cmdline.as_str();
@@ -613,6 +619,7 @@ pub fn build_microvm(
     #[cfg(not(feature = "tee"))]
     #[allow(unused_mut)]
     let mut vm = setup_vm(&guest_memory, vm_resources.nested_enabled)?;
+    trace.mark("vm.ready");
 
     #[cfg(feature = "tee")]
     let (_kvm, vm) = {
@@ -855,6 +862,7 @@ pub fn build_microvm(
             &pio_device_manager.io_bus,
             &exit_evt,
             kernel_boot,
+            vm_resources.metrics.clone(),
             #[cfg(feature = "tee")]
             _sender,
         )
@@ -881,6 +889,7 @@ pub fn build_microvm(
             &arch_memory_info,
             payload_config.entry_addr,
             &exit_evt,
+            vm_resources.metrics.clone(),
         )
         .map_err(StartMicrovmError::Internal)?;
 
@@ -929,6 +938,7 @@ pub fn build_microvm(
             &exit_evt,
             vcpu_list.clone(),
             vm_resources.nested_enabled,
+            vm_resources.metrics.clone(),
         )
         .map_err(StartMicrovmError::Internal)?;
 
@@ -951,6 +961,7 @@ pub fn build_microvm(
             &guest_memory,
             payload_config.entry_addr,
             &exit_evt,
+            vm_resources.metrics.clone(),
         )
         .map_err(StartMicrovmError::Internal)?;
 
@@ -965,6 +976,8 @@ pub fn build_microvm(
             serial_device,
         )?;
     }
+
+    trace.mark("arch_devices.ready");
 
     // exit_code is pre-created and shared with callers via Vm::exit_code().
 
@@ -988,9 +1001,24 @@ pub fn build_microvm(
     }
 
     #[cfg(not(feature = "tee"))]
-    attach_balloon_device(&mut vmm, event_manager, intc.clone())?;
+    if vm_resources.enable_balloon {
+        attach_balloon_device(
+            &mut vmm,
+            event_manager,
+            intc.clone(),
+            vm_resources.metrics.clone(),
+        )?;
+        trace.mark("balloon.attached");
+    } else {
+        trace.mark("balloon.skipped");
+    }
     #[cfg(not(feature = "tee"))]
-    attach_rng_device(&mut vmm, event_manager, intc.clone())?;
+    if vm_resources.enable_rng {
+        attach_rng_device(&mut vmm, event_manager, intc.clone())?;
+        trace.mark("rng.attached");
+    } else {
+        trace.mark("rng.skipped");
+    }
     let mut console_id = 0;
     if !vm_resources.disable_implicit_console {
         attach_console_devices(
@@ -1002,6 +1030,9 @@ pub fn build_microvm(
             console_id,
         )?;
         console_id += 1;
+        trace.mark("implicit_console.attached");
+    } else {
+        trace.mark("implicit_console.skipped");
     }
 
     for console_cfg in std::mem::take(&mut vm_resources.virtio_consoles) {
@@ -1015,6 +1046,7 @@ pub fn build_microvm(
         )?;
         console_id += 1;
     }
+    trace.mark("virtio_consoles.ready");
 
     #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
     let export_table: Option<ExportTable> = if cfg!(feature = "gpu") {
@@ -1060,6 +1092,7 @@ pub fn build_microvm(
         #[cfg(target_os = "macos")]
         _sender.clone(),
     )?;
+    trace.mark("fs.ready");
     #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
     attach_custom_fs_devices(
         &mut vmm,
@@ -1071,8 +1104,11 @@ pub fn build_microvm(
         #[cfg(target_os = "macos")]
         _sender,
     )?;
+    trace.mark("custom_fs.ready");
     #[cfg(feature = "blk")]
     attach_block_devices(&mut vmm, &vm_resources.block, intc.clone())?;
+    #[cfg(feature = "blk")]
+    trace.mark("block.ready");
 
     if let Some(vsock) = vm_resources.vsock.get() {
         attach_unixsock_vsock_device(&mut vmm, vsock, event_manager, intc.clone())?;
@@ -1083,10 +1119,15 @@ pub fn build_microvm(
         if tsi_flags.contains(TsiFlags::HIJACK_UNIX) {
             vmm.kernel_cmdline.insert_str("tsi_hijack_unix")?;
         }
+        trace.mark("vsock.ready");
+    } else {
+        trace.mark("vsock.skipped");
     }
 
     #[cfg(feature = "net")]
     attach_net_devices(&mut vmm, &vm_resources.net, intc.clone())?;
+    #[cfg(feature = "net")]
+    trace.mark("net.ready");
     #[cfg(feature = "snd")]
     if vm_resources.snd_device {
         attach_snd_device(&mut vmm, intc.clone())?;
@@ -1108,6 +1149,7 @@ pub fn build_microvm(
         &vm_resources.smbios_oem_strings,
     )
     .map_err(StartMicrovmError::Internal)?;
+    trace.mark("system.configured");
 
     #[cfg(feature = "tee")]
     {
@@ -1145,6 +1187,7 @@ pub fn build_microvm(
 
     vmm.start_vcpus(vcpus)
         .map_err(StartMicrovmError::Internal)?;
+    trace.mark("vcpus.started");
 
     // Clippy thinks we don't need Arc<Mutex<...
     // but we don't want to change the event_manager interface
@@ -1153,8 +1196,44 @@ pub fn build_microvm(
     event_manager
         .add_subscriber(vmm.clone())
         .map_err(StartMicrovmError::RegisterEvent)?;
+    trace.mark("build_microvm.done");
 
     Ok(vmm)
+}
+
+struct BootTrace {
+    enabled: bool,
+    scope: &'static str,
+    start: Instant,
+    last: Instant,
+}
+
+impl BootTrace {
+    fn new(scope: &'static str) -> Self {
+        let now = Instant::now();
+        Self {
+            enabled: std::env::var_os("MSB_KRUN_BOOT_TRACE").is_some(),
+            scope,
+            start: now,
+            last: now,
+        }
+    }
+
+    fn mark(&mut self, label: &'static str) {
+        if !self.enabled {
+            return;
+        }
+
+        let now = Instant::now();
+        eprintln!(
+            "krun.boot scope={} label={} elapsed_us={} delta_us={}",
+            self.scope,
+            label,
+            now.duration_since(self.start).as_micros(),
+            now.duration_since(self.last).as_micros(),
+        );
+        self.last = now;
+    }
 }
 
 fn load_external_kernel(
@@ -1555,6 +1634,12 @@ pub fn create_guest_memory(
         }
     }
 
+    crate::metrics::install_host_resident_memory_sampler(
+        &vm_resources.metrics,
+        &guest_mem,
+        &arch_mem_info,
+    );
+
     let payload_config = PayloadConfig {
         entry_addr,
         initrd_config,
@@ -1765,6 +1850,7 @@ fn create_vcpus_x86_64(
     io_bus: &devices::Bus,
     exit_evt: &EventFd,
     kernel_boot: bool,
+    metrics: utils::metrics::MetricsWriter,
     #[cfg(feature = "tee")] pm_sender: Sender<WorkerMessage>,
 ) -> super::Result<Vec<Vcpu>> {
     let mut vcpus = Vec::with_capacity(vcpu_config.vcpu_count as usize);
@@ -1776,6 +1862,7 @@ fn create_vcpus_x86_64(
             vm.supported_msrs().clone(),
             io_bus.clone(),
             exit_evt.try_clone().map_err(Error::EventFd)?,
+            metrics.clone(),
             #[cfg(feature = "tee")]
             pm_sender.clone(),
         )
@@ -1796,6 +1883,7 @@ fn create_vcpus_aarch64(
     mem_info: &ArchMemoryInfo,
     entry_addr: GuestAddress,
     exit_evt: &EventFd,
+    metrics: utils::metrics::MetricsWriter,
 ) -> super::Result<Vec<Vcpu>> {
     let mut vcpus = Vec::with_capacity(vcpu_config.vcpu_count as usize);
     for cpu_index in 0..vcpu_config.vcpu_count {
@@ -1803,6 +1891,7 @@ fn create_vcpus_aarch64(
             cpu_index,
             vm.fd(),
             exit_evt.try_clone().map_err(Error::EventFd)?,
+            metrics.clone(),
         )
         .map_err(Error::Vcpu)?;
 
@@ -1823,6 +1912,7 @@ fn create_vcpus_aarch64(
     exit_evt: &EventFd,
     vcpu_list: Arc<VcpuList>,
     nested_enabled: bool,
+    metrics: utils::metrics::MetricsWriter,
 ) -> super::Result<Vec<Vcpu>> {
     let mut vcpus = Vec::with_capacity(vcpu_config.vcpu_count as usize);
     let mut boot_senders: HashMap<u64, Sender<u64>> = HashMap::new();
@@ -1842,6 +1932,7 @@ fn create_vcpus_aarch64(
             exit_evt.try_clone().map_err(Error::EventFd)?,
             vcpu_list.clone(),
             nested_enabled,
+            metrics.clone(),
         )
         .map_err(Error::Vcpu)?;
 
@@ -1866,6 +1957,7 @@ fn create_vcpus_riscv64(
     guest_mem: &GuestMemoryMmap,
     entry_addr: GuestAddress,
     exit_evt: &EventFd,
+    metrics: utils::metrics::MetricsWriter,
 ) -> super::Result<Vec<Vcpu>> {
     let mut vcpus = Vec::with_capacity(vcpu_config.vcpu_count as usize);
     for cpu_index in 0..vcpu_config.vcpu_count {
@@ -1873,6 +1965,7 @@ fn create_vcpus_riscv64(
             cpu_index,
             vm.fd(),
             exit_evt.try_clone().map_err(Error::EventFd)?,
+            metrics.clone(),
         )
         .map_err(Error::Vcpu)?;
 
@@ -2289,10 +2382,11 @@ fn attach_balloon_device(
     vmm: &mut Vmm,
     event_manager: &mut EventManager,
     intc: IrqChip,
+    metrics: utils::metrics::MetricsWriter,
 ) -> std::result::Result<(), StartMicrovmError> {
     use self::StartMicrovmError::*;
 
-    let balloon = Arc::new(Mutex::new(devices::virtio::Balloon::new().unwrap()));
+    let balloon = Arc::new(Mutex::new(devices::virtio::Balloon::new(metrics).unwrap()));
 
     event_manager
         .add_subscriber(balloon.clone())
@@ -2480,6 +2574,7 @@ pub mod tests {
             &bus,
             &EventFd::new(utils::eventfd::EFD_NONBLOCK).unwrap(),
             true,
+            utils::metrics::MetricsWriter::default(),
         )
         .unwrap();
         assert_eq!(vcpu_vec.len(), vcpu_count as usize);
@@ -2507,6 +2602,7 @@ pub mod tests {
             &arch_memory_info,
             entry_addr,
             &EventFd::new(utils::eventfd::EFD_NONBLOCK).unwrap(),
+            utils::metrics::MetricsWriter::default(),
         )
         .unwrap();
         assert_eq!(vcpu_vec.len(), vcpu_count as usize);

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1904,6 +1904,7 @@ fn create_vcpus_aarch64(
 }
 
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[allow(clippy::too_many_arguments)]
 fn create_vcpus_aarch64(
     _vm: &Vm,
     vcpu_config: &VcpuConfig,

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -32,6 +32,7 @@ mod linux;
 use crate::linux::vstate;
 #[cfg(target_os = "macos")]
 mod macos;
+mod metrics;
 mod terminal;
 pub mod worker;
 

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -1049,6 +1049,7 @@ impl Vcpu {
     /// * `io_bus` - The io-bus used to access port-io devices.
     /// * `exit_evt` - An `EventFd` that will be written into when this vcpu exits.
     #[cfg(target_arch = "x86_64")]
+    #[allow(clippy::too_many_arguments)]
     pub fn new_x86_64(
         id: u8,
         vm_fd: &VmFd,

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -59,8 +59,10 @@ use kvm_bindings::{kvm_enable_cap, KVM_CAP_EXIT_HYPERCALL, KVM_MEMORY_EXIT_FLAG_
 use kvm_bindings::{kvm_memory_attributes, KVM_MEMORY_ATTRIBUTE_PRIVATE};
 use kvm_ioctls::{Cap::*, *};
 use utils::eventfd::EventFd;
+use utils::metrics::MetricsWriter;
 use utils::signal::{register_signal_handler, sigrtmin, Killable};
 use utils::sm::StateMachine;
+use utils::time::{get_time, ClockType};
 #[cfg(feature = "tee")]
 use utils::worker_message::{MemoryProperties, WorkerMessage};
 use vm_memory::{
@@ -947,6 +949,8 @@ pub struct Vcpu {
     // The transmitting end of the responses channel owned by the vcpu side.
     response_sender: Sender<VcpuResponse>,
 
+    metrics: MetricsWriter,
+
     #[cfg(feature = "tee")]
     pm_sender: Sender<WorkerMessage>,
 }
@@ -1052,6 +1056,7 @@ impl Vcpu {
         msr_list: MsrList,
         io_bus: devices::Bus,
         exit_evt: EventFd,
+        metrics: MetricsWriter,
         #[cfg(feature = "tee")] pm_sender: Sender<WorkerMessage>,
     ) -> Result<Self> {
         let kvm_vcpu = vm_fd.create_vcpu(id as u64).map_err(Error::VcpuFd)?;
@@ -1079,6 +1084,7 @@ impl Vcpu {
             event_sender: Some(event_sender),
             response_receiver: Some(response_receiver),
             response_sender,
+            metrics,
             #[cfg(feature = "tee")]
             pm_sender,
         })
@@ -1093,7 +1099,12 @@ impl Vcpu {
     /// * `exit_evt` - An `EventFd` that will be written into when this vcpu exits.
     /// * `create_ts` - A timestamp used by the vcpu to calculate its lifetime.
     #[cfg(target_arch = "aarch64")]
-    pub fn new_aarch64(id: u8, vm_fd: &VmFd, exit_evt: EventFd) -> Result<Self> {
+    pub fn new_aarch64(
+        id: u8,
+        vm_fd: &VmFd,
+        exit_evt: EventFd,
+        metrics: MetricsWriter,
+    ) -> Result<Self> {
         let kvm_vcpu = vm_fd.create_vcpu(id as u64).map_err(Error::VcpuFd)?;
         let (event_sender, event_receiver) = unbounded();
         let (response_sender, response_receiver) = unbounded();
@@ -1108,6 +1119,7 @@ impl Vcpu {
             event_sender: Some(event_sender),
             response_receiver: Some(response_receiver),
             response_sender,
+            metrics,
         })
     }
 
@@ -1120,7 +1132,12 @@ impl Vcpu {
     /// * `exit_evt` - An `EventFd` that will be written into when this vcpu exits.
     /// * `create_ts` - A timestamp used by the vcpu to calculate its lifetime.
     #[cfg(target_arch = "riscv64")]
-    pub fn new_riscv64(id: u8, vm_fd: &VmFd, exit_evt: EventFd) -> Result<Self> {
+    pub fn new_riscv64(
+        id: u8,
+        vm_fd: &VmFd,
+        exit_evt: EventFd,
+        metrics: MetricsWriter,
+    ) -> Result<Self> {
         let kvm_vcpu = vm_fd.create_vcpu(id as u64).map_err(Error::VcpuFd)?;
         let (event_sender, event_receiver) = unbounded();
         let (response_sender, response_receiver) = unbounded();
@@ -1134,6 +1151,7 @@ impl Vcpu {
             event_sender: Some(event_sender),
             response_receiver: Some(response_receiver),
             response_sender,
+            metrics,
         })
     }
 
@@ -1570,8 +1588,15 @@ impl Vcpu {
     fn running(&mut self) -> StateMachine<Self> {
         // This loop is here just for optimizing the emulation path.
         // No point in ticking the state machine if there are no external events.
+        let mut last_thread_cpu_ns = get_time(ClockType::ThreadCpu);
         loop {
-            match self.run_emulation() {
+            let emulation = self.run_emulation();
+            let thread_cpu_ns = get_time(ClockType::ThreadCpu);
+            self.metrics
+                .add_vcpu_time_ns(thread_cpu_ns.saturating_sub(last_thread_cpu_ns));
+            last_thread_cpu_ns = thread_cpu_ns;
+
+            match emulation {
                 // Emulation ran successfully, continue.
                 Ok(VcpuEmulation::Handled) => (),
                 // Emulation was interrupted, check external events.
@@ -1832,12 +1857,13 @@ mod tests {
                 vm.supported_msrs().clone(),
                 devices::Bus::new(),
                 exit_evt,
+                MetricsWriter::default(),
             )
             .unwrap();
         }
         #[cfg(target_arch = "aarch64")]
         {
-            vcpu = Vcpu::new_aarch64(1, vm.fd(), exit_evt).unwrap();
+            vcpu = Vcpu::new_aarch64(1, vm.fd(), exit_evt, MetricsWriter::default()).unwrap();
         }
 
         (vm, vcpu, gm)
@@ -1927,6 +1953,7 @@ mod tests {
             0,
             vm.fd(),
             EventFd::new(utils::eventfd::EFD_NONBLOCK).unwrap(),
+            MetricsWriter::default(),
         )
         .unwrap();
 
@@ -1939,6 +1966,7 @@ mod tests {
             1,
             vm.fd(),
             EventFd::new(utils::eventfd::EFD_NONBLOCK).unwrap(),
+            MetricsWriter::default(),
         )
         .unwrap();
 

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -23,6 +23,7 @@ use crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender};
 use devices::legacy::VcpuList;
 use hvf::{HvfVcpu, HvfVm, VcpuExit, Vcpus};
 use utils::eventfd::EventFd;
+use utils::metrics::MetricsWriter;
 use vm_memory::{
     Address, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion,
 };
@@ -201,6 +202,7 @@ pub struct Vcpu {
 
     vcpu_list: Arc<VcpuList>,
     nested_enabled: bool,
+    metrics: MetricsWriter,
 }
 
 impl Vcpu {
@@ -275,6 +277,7 @@ impl Vcpu {
         exit_evt: EventFd,
         vcpu_list: Arc<VcpuList>,
         nested_enabled: bool,
+        metrics: MetricsWriter,
     ) -> Result<Self> {
         let (event_sender, event_receiver) = unbounded();
         let (response_sender, response_receiver) = unbounded();
@@ -294,6 +297,7 @@ impl Vcpu {
             response_sender,
             vcpu_list,
             nested_enabled,
+            metrics,
         })
     }
 
@@ -458,8 +462,16 @@ impl Vcpu {
             .set_initial_state(entry_addr, self.fdt_addr)
             .unwrap_or_else(|_| panic!("Can't set HVF vCPU {hvf_vcpuid} initial state"));
 
+        let mut last_exec_time_ns = hvf_vcpu.exec_time_ns().unwrap_or(0);
         loop {
-            match self.run_emulation(&mut hvf_vcpu) {
+            let emulation = self.run_emulation(&mut hvf_vcpu);
+            if let Some(exec_time_ns) = hvf_vcpu.exec_time_ns() {
+                self.metrics
+                    .add_vcpu_time_ns(exec_time_ns.saturating_sub(last_exec_time_ns));
+                last_exec_time_ns = exec_time_ns;
+            }
+
+            match emulation {
                 // Emulation ran successfully, continue.
                 Ok(VcpuEmulation::Handled) => (),
                 // Emulation was interrupted by a breakpoint.

--- a/src/vmm/src/metrics.rs
+++ b/src/vmm/src/metrics.rs
@@ -1,0 +1,262 @@
+// Copyright 2026 Super Rad Company
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io;
+use std::sync::Mutex;
+
+use arch::ArchMemoryInfo;
+use utils::metrics::MetricsWriter;
+use vm_memory::{Address, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct GuestMemoryRange {
+    start: u64,
+    end: u64,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) fn install_host_resident_memory_sampler(
+    metrics: &MetricsWriter,
+    guest_memory: &GuestMemoryMmap,
+    arch_memory_info: &ArchMemoryInfo,
+) {
+    let guest_memory = guest_memory.clone();
+    let ranges = guest_memory_ranges(arch_memory_info);
+    let page_size = page_size();
+    let residency = Mutex::new(Vec::new());
+
+    metrics.set_memory_host_resident_sampler(move || {
+        match host_resident_memory_bytes(&guest_memory, &ranges, page_size, &residency) {
+            Ok(bytes) => Some(bytes),
+            Err(err) => {
+                debug!("failed to sample host-resident guest memory: {err}");
+                None
+            }
+        }
+    });
+}
+
+fn host_resident_memory_bytes(
+    guest_memory: &GuestMemoryMmap,
+    ranges: &[GuestMemoryRange],
+    page_size: usize,
+    residency: &Mutex<Vec<u8>>,
+) -> io::Result<u64> {
+    let mut total = 0u64;
+    let mut residency = residency.lock().unwrap();
+    for region in guest_memory.iter() {
+        for range in ranges {
+            let Some((offset, len)) =
+                inspect_region_range(region.start_addr().raw_value(), region.len(), *range)
+            else {
+                continue;
+            };
+            total = total.saturating_add(region_resident_bytes(
+                region.as_ptr().wrapping_add(offset),
+                len,
+                page_size,
+                &mut residency,
+            )?);
+        }
+    }
+    Ok(total)
+}
+
+fn guest_memory_ranges(info: &ArchMemoryInfo) -> Vec<GuestMemoryRange> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        let mut ranges = Vec::new();
+        if info.ram_below_gap > 0 {
+            ranges.push(GuestMemoryRange {
+                start: 0,
+                end: info.ram_below_gap,
+            });
+        }
+        if info.ram_above_gap > 0 {
+            ranges.push(GuestMemoryRange {
+                start: info.ram_last_addr.saturating_sub(info.ram_above_gap),
+                end: info.ram_last_addr,
+            });
+        }
+        ranges
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        vec![GuestMemoryRange {
+            start: info.ram_start_addr,
+            end: info.ram_last_addr,
+        }]
+    }
+
+    #[cfg(target_arch = "riscv64")]
+    {
+        vec![GuestMemoryRange {
+            start: 0,
+            end: info.ram_last_addr,
+        }]
+    }
+}
+
+fn inspect_region_range(
+    region_start: u64,
+    region_len: u64,
+    range: GuestMemoryRange,
+) -> Option<(usize, usize)> {
+    if region_len == 0 || range.start >= range.end {
+        return None;
+    }
+
+    let region_end = region_start.saturating_add(region_len);
+    let overlap_start = region_start.max(range.start);
+    let overlap_end = region_end.min(range.end);
+    if overlap_start >= overlap_end {
+        return None;
+    }
+
+    Some((
+        usize::try_from(overlap_start - region_start).ok()?,
+        usize::try_from(overlap_end - overlap_start).ok()?,
+    ))
+}
+
+fn region_resident_bytes(
+    host_addr: *mut u8,
+    len: usize,
+    page_size: usize,
+    residency: &mut Vec<u8>,
+) -> io::Result<u64> {
+    if len == 0 {
+        return Ok(0);
+    }
+
+    let start = host_addr as usize;
+    let aligned_start = start - (start % page_size);
+    let page_offset = start - aligned_start;
+    let inspected_len = len
+        .checked_add(page_offset)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "mincore range overflow"))?;
+    let page_count = inspected_len.div_ceil(page_size);
+    residency.resize(page_count, 0);
+
+    mincore(aligned_start as *mut u8, inspected_len, residency)?;
+
+    Ok(resident_bytes_from_mincore(
+        residency,
+        page_offset,
+        len,
+        page_size,
+    ))
+}
+
+fn resident_bytes_from_mincore(
+    residency: &[u8],
+    page_offset: usize,
+    len: usize,
+    page_size: usize,
+) -> u64 {
+    let region_start = page_offset;
+    let region_end = page_offset + len;
+    let mut bytes = 0usize;
+
+    for (idx, entry) in residency.iter().enumerate() {
+        if entry & 1 == 0 {
+            continue;
+        }
+
+        let page_start = idx * page_size;
+        let page_end = page_start + page_size;
+        let overlap_start = page_start.max(region_start);
+        let overlap_end = page_end.min(region_end);
+        bytes = bytes.saturating_add(overlap_end.saturating_sub(overlap_start));
+    }
+
+    bytes as u64
+}
+
+#[cfg(target_os = "linux")]
+fn mincore(addr: *mut u8, len: usize, residency: &mut [u8]) -> io::Result<()> {
+    let rc = unsafe {
+        libc::mincore(
+            addr.cast::<libc::c_void>(),
+            len,
+            residency.as_mut_ptr().cast::<libc::c_uchar>(),
+        )
+    };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn mincore(addr: *mut u8, len: usize, residency: &mut [u8]) -> io::Result<()> {
+    let rc = unsafe {
+        libc::mincore(
+            addr.cast::<libc::c_void>(),
+            len,
+            residency.as_mut_ptr().cast::<libc::c_char>(),
+        )
+    };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+fn page_size() -> usize {
+    let value = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    usize::try_from(value)
+        .ok()
+        .filter(|value| *value > 0)
+        .unwrap_or(4096)
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inspect_region_range_skips_non_overlapping_regions() {
+        let range = GuestMemoryRange {
+            start: 4096,
+            end: 8192,
+        };
+
+        assert_eq!(inspect_region_range(0, 4096, range), None);
+        assert_eq!(inspect_region_range(8192, 4096, range), None);
+    }
+
+    #[test]
+    fn inspect_region_range_clamps_to_range_overlap() {
+        let range = GuestMemoryRange {
+            start: 4096,
+            end: 8192,
+        };
+
+        assert_eq!(inspect_region_range(0, 8192, range), Some((4096, 4096)));
+        assert_eq!(inspect_region_range(6144, 4096, range), Some((0, 2048)));
+    }
+
+    #[test]
+    fn resident_bytes_accounts_for_partial_pages() {
+        assert_eq!(
+            resident_bytes_from_mincore(&[1, 0, 1], 1024, 6144, 4096),
+            4096
+        );
+        assert_eq!(resident_bytes_from_mincore(&[1, 1], 1024, 2048, 4096), 2048);
+    }
+}

--- a/src/vmm/src/metrics.rs
+++ b/src/vmm/src/metrics.rs
@@ -255,7 +255,7 @@ mod tests {
     fn resident_bytes_accounts_for_partial_pages() {
         assert_eq!(
             resident_bytes_from_mincore(&[1, 0, 1], 1024, 6144, 4096),
-            4096
+            3072
         );
         assert_eq!(resident_bytes_from_mincore(&[1, 1], 1024, 2048, 4096), 2048);
     }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -34,6 +34,7 @@ use devices::virtio::display::DisplayInfo;
 use kbs_types::Tee;
 #[cfg(feature = "gpu")]
 use krun_display::DisplayBackend;
+use utils::metrics::MetricsWriter;
 
 type Result<E> = std::result::Result<(), E>;
 
@@ -131,7 +132,6 @@ pub enum VsockConfig {
 
 /// A data structure that encapsulates the device configurations
 /// held in the Vmm.
-#[derive(Default)]
 pub struct VmResources {
     /// The vCpu and memory configuration for this microVM.
     vm_config: VmConfig,
@@ -189,11 +189,17 @@ pub struct VmResources {
     pub nested_enabled: bool,
     /// Whether to enable split irqchip
     pub split_irqchip: bool,
+    /// Shared metrics state for VMM and device counters.
+    pub metrics: MetricsWriter,
     /// Force-enable the virtio-vsock device even when no TSI transport is
     /// required. When `false`, vsock is only attached if `configure_vsock`
     /// determines it is needed (HIJACK_INET when there's no virtio-net, or
     /// HIJACK_UNIX when there's a single root virtio-fs on Linux).
     pub request_vsock: bool,
+    /// Whether to attach the virtio-balloon device.
+    pub enable_balloon: bool,
+    /// Whether to attach the virtio-rng device.
+    pub enable_rng: bool,
     /// Do not create an implicit console device in the guest
     pub disable_implicit_console: bool,
     /// The console id to use for console= in the kernel cmdline
@@ -202,6 +208,55 @@ pub struct VmResources {
     pub serial_consoles: Vec<SerialConsoleConfig>,
     /// Virtio consoles to attach to the guest
     pub virtio_consoles: Vec<VirtioConsoleConfigMode>,
+}
+
+impl Default for VmResources {
+    fn default() -> Self {
+        Self {
+            vm_config: VmConfig::default(),
+            firmware_config: None,
+            kernel_cmdline: KernelCmdlineConfig::default(),
+            kernel_bundle: None,
+            external_kernel: None,
+            #[cfg(feature = "tee")]
+            qboot_bundle: None,
+            #[cfg(feature = "tee")]
+            initrd_bundle: None,
+            #[cfg(not(feature = "tee"))]
+            fs: Vec::new(),
+            #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
+            custom_fs: Vec::new(),
+            vsock: VsockBuilder::default(),
+            #[cfg(feature = "blk")]
+            block: BlockBuilder::default(),
+            #[cfg(feature = "net")]
+            net: NetBuilder::default(),
+            #[cfg(feature = "tee")]
+            tee_config: TeeConfig::default(),
+            gpu_virgl_flags: None,
+            gpu_shm_size: None,
+            #[cfg(feature = "gpu")]
+            display_backend: None,
+            #[cfg(feature = "gpu")]
+            displays: Vec::new(),
+            #[cfg(feature = "input")]
+            input_backends: Vec::new(),
+            #[cfg(feature = "snd")]
+            snd_device: false,
+            console_output: None,
+            smbios_oem_strings: None,
+            nested_enabled: false,
+            split_irqchip: false,
+            metrics: MetricsWriter::default(),
+            request_vsock: false,
+            enable_balloon: true,
+            enable_rng: true,
+            disable_implicit_console: false,
+            kernel_console: None,
+            serial_consoles: Vec::new(),
+            virtio_consoles: Vec::new(),
+        }
+    }
 }
 
 impl VmResources {
@@ -252,6 +307,13 @@ impl VmResources {
         if machine_config.mem_size_mib.is_some() {
             self.vm_config.mem_size_mib = machine_config.mem_size_mib;
         }
+        let memory_total_bytes = self
+            .vm_config
+            .mem_size_mib
+            .unwrap_or(128)
+            .saturating_mul(1024)
+            .saturating_mul(1024) as u64;
+        self.metrics.set_memory_total_bytes(memory_total_bytes);
 
         if machine_config.cpu_template.is_some() {
             self.vm_config.cpu_template = machine_config.cpu_template;
@@ -335,7 +397,7 @@ impl VmResources {
 
     #[cfg(feature = "blk")]
     pub fn add_block_device(&mut self, config: BlockDeviceConfig) -> Result<BlockConfigError> {
-        self.block.insert(config)
+        self.block.insert(config, self.metrics.clone())
     }
 
     /// Sets a vsock device to be attached when the VM starts.
@@ -405,6 +467,7 @@ mod tests {
     use crate::vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig, VmConfigError};
     use crate::vmm_config::vsock::tests::{default_config, TempSockFile};
     use crate::vstate::VcpuConfig;
+    use utils::metrics::MetricsWriter;
     use utils::tempfile::TempFile;
 
     fn default_kernel_cmdline() -> KernelCmdlineConfig {
@@ -442,7 +505,10 @@ mod tests {
             smbios_oem_strings: None,
             nested_enabled: false,
             split_irqchip: false,
+            metrics: MetricsWriter::default(),
             request_vsock: false,
+            enable_balloon: true,
+            enable_rng: true,
             disable_implicit_console: false,
             serial_consoles: Vec::new(),
             virtio_consoles: Vec::new(),

--- a/src/vmm/src/vmm_config/block.rs
+++ b/src/vmm/src/vmm_config/block.rs
@@ -6,6 +6,7 @@ use devices::virtio::{
     block::{ImageType, SyncMode},
     Block, CacheType,
 };
+use utils::metrics::MetricsWriter;
 
 #[derive(Debug)]
 pub enum BlockConfigError {
@@ -54,13 +55,14 @@ impl BlockBuilder {
         }
     }
 
-    pub fn insert(&mut self, config: BlockDeviceConfig) -> Result<()> {
-        let block_dev = Arc::new(Mutex::new(Self::create_block(config)?));
+    pub fn insert(&mut self, config: BlockDeviceConfig, metrics: MetricsWriter) -> Result<()> {
+        let block_dev = Arc::new(Mutex::new(Self::create_block(config, metrics)?));
         self.list.push_back(block_dev);
         Ok(())
     }
 
-    pub fn create_block(config: BlockDeviceConfig) -> Result<Block> {
+    pub fn create_block(config: BlockDeviceConfig, metrics: MetricsWriter) -> Result<Block> {
+        let device_metrics = metrics.register_block_device(config.block_id.clone());
         devices::virtio::Block::new(
             config.block_id,
             None,
@@ -70,6 +72,7 @@ impl BlockBuilder {
             config.is_disk_read_only,
             config.direct_io,
             config.sync_mode,
+            device_metrics,
         )
         .map_err(BlockConfigError::CreateBlockDevice)
     }


### PR DESCRIPTION
## TL;DR
Expose guest-focused VM metrics from libkrun so hosts can sample CPU time, memory, host residency, and block I/O while a VM is running.

## Description
- Add a cloneable metrics handle to the Rust API, with aggregate snapshots for vCPU time, guest memory, host-resident memory, and block I/O counters.
- Wire metrics through VMM construction, HVF execution, virtio-balloon stats, and virtio-blk completion paths.
- Track block byte counts from completed I/O lengths instead of requested descriptor lengths.
- Add C API toggles for balloon and rng devices so callers can keep memory stats available by default.
- Keep host-resident memory sampling inside the VMM so callers do not need to infer guest residency from host process totals.

## Examples

`Vm::enter()` does not return after a successful boot, so callers should clone the metrics handle before entering the VM and sample it from another host thread.

```rust
use std::thread;
use std::time::{Duration, Instant};

use msb_krun::{Result, VmBuilder};

fn main() -> Result<()> {
    let vm = VmBuilder::new()
        .machine(|m| m.vcpus(2).memory_mib(1024))
        .fs(|fs| fs.root("/path/to/rootfs"))
        .exec(|e| {
            e.path("/bin/sh")
                .args(["-c", "dd if=/dev/zero of=/tmp/io bs=1M count=64"])
                .env("HOME", "/root")
        })
        .build()?;

    let metrics = vm.metrics_handle();

    thread::spawn(move || {
        let mut previous = metrics.aggregate_snapshot();
        let mut previous_at = Instant::now();

        loop {
            thread::sleep(Duration::from_secs(1));

            let now = Instant::now();
            let current = metrics.aggregate_snapshot();
            let elapsed_ns = now.duration_since(previous_at).as_nanos() as u64;

            let cpu_percent = match (previous.cpu.vcpu_time_ns, current.cpu.vcpu_time_ns) {
                (Some(prev), Some(curr)) if elapsed_ns > 0 => {
                    100.0 * curr.saturating_sub(prev) as f64 / elapsed_ns as f64
                }
                _ => 0.0,
            };

            eprintln!(
                "cpu={cpu_percent:.1}% mem_used={:?} host_resident={:?} block_read={} block_write={}",
                current.memory.used_bytes,
                current.memory.host_resident_bytes,
                current.block.read_bytes,
                current.block.write_bytes,
            );

            previous = current;
            previous_at = now;
        }
    });

    vm.enter()?;
    unreachable!()
}
```

Use `aggregate_snapshot()` for high-frequency polling when aggregate counters are enough. Use `snapshot()` when the caller also needs per-device block counters:

```rust
let snapshot = metrics.snapshot();

for device in snapshot.block.devices {
    eprintln!(
        "block id={} read_bytes={} write_bytes={}",
        device.id,
        device.read_bytes,
        device.write_bytes,
    );
}
```

The CPU value is cumulative guest vCPU execution time. Consumers should compute deltas between snapshots to derive utilization. Memory availability comes from virtio-balloon stats, so `available_bytes` and derived `used_bytes` remain `None` until the guest reports balloon statistics. `host_resident_bytes` is sampled by the VMM and reflects host-resident guest memory, not total host process RSS.

The C API additions in this PR only control whether virtio-balloon and virtio-rng are present:

```c
krun_set_balloon_device(ctx_id, true);
krun_set_rng_device(ctx_id, true);
```

The metrics snapshot API is exposed through the Rust `msb_krun` API.

## Test Plan
- [x] `cargo fmt --all`
- [x] `BINDGEN_EXTRA_CLANG_ARGS="--sysroot $(xcrun --show-sdk-path)" cargo clippy --locked -- -D warnings`
- [x] `cargo test -p msb_krun_hvf`
- [x] GitHub Actions: all PR checks passing
