### PR TITLE
fix(balloon): stop idle vCPU busy-spin from unthrottled stats queue

### DIFF
--- a/src/devices/src/virtio/balloon/event_handler.rs
+++ b/src/devices/src/virtio/balloon/event_handler.rs
@@ -61,10 +61,23 @@ impl Balloon {
             return;
         }
 
+        // HOTFIX (idle vCPU busy-spin): drain the kick ONLY. Do not call
+        // process_stq() (which add_used()s the stats buffer back to the guest)
+        // or signal_used_queue() here.
+        //
+        // The virtio-balloon stats queue is host-paced: returning the buffer and
+        // signalling makes the Linux guest's `stats_request` callback refill and
+        // kick again *immediately*, so on the next kick we signal again — an
+        // unthrottled host<->guest ping-pong that keeps the vCPU out of HLT and
+        // pins the `fc_vcpu` thread at ~100% on every running microVM, even idle
+        // ones. This restores the pre-0.1.15 behaviour (microsandbox <= 0.5.5).
+        //
+        // Proper follow-up: re-request stats on a periodic TimerFd — mirror
+        // firecracker's `stats_timer` / `process_stats_timer_event` — so
+        // `memory_available_bytes` stays live without spinning. process_stq() is
+        // retained below for that change.
         if let Err(e) = self.queue_event(STQ_INDEX).read() {
             error!("Failed to read balloon stats queue event: {e:?}");
-        } else if self.process_stq() {
-            self.device_state.signal_used_queue();
         }
     }
 
@@ -98,6 +111,10 @@ impl Balloon {
         }
     }
 
+    // Retained for the follow-up timer-throttled stats fix (see handle_stq_event).
+    // Not called by the hotfix, which drains the stats kick without re-driving
+    // the queue to stop the idle-vCPU busy-spin.
+    #[allow(dead_code)]
     fn process_stq(&mut self) -> bool {
         let mem = match self.device_state {
             crate::virtio::DeviceState::Activated(ref mem, _) => mem,


### PR DESCRIPTION
**Draft / hotfix.** cc @appcypher (this is in the path added by #61).

## TL;DR
The virtio-balloon **stats queue** is driven by the host with **no throttle**, so an **idle** microVM busy-spins its vCPU. `handle_stq_event` returns the stats buffer (`add_used`) and `signal_used_queue()`s the guest on **every** kick. The stats queue is host-paced — the Linux guest's `stats_request` refills + kicks again *immediately* on the used-buffer IRQ — so this is an unthrottled host↔guest ping-pong that keeps the vCPU out of HLT. The `fc_vcpu` thread pins at **~100% on every running sandbox, even idle ones**.

## Impact
- Each running microVM (idle or not) burns ~1 host core. On a 4-vCPU worker, ~3–4 sandboxes saturate it (vs ~30 by memory) — ~8× capacity loss.
- In-guest commands (`apt update`, etc.) run **50–100× slower**: the single guest vCPU is consumed servicing the balloon ping-pong (~18k IRQs/s).
- Host signature: 0% idle, high `gu`/`sy`, ~73k context-switches/s with a few sandboxes.

## Root cause
`src/devices/src/virtio/balloon/event_handler.rs` — `handle_stq_event` → `process_stq()` (`add_used`) + `signal_used_queue()` fire on every guest kick, with **no timer**. Introduced by **#61** (`934ae9738`, "expose guest VM metrics") to read `VIRTIO_BALLOON_S_AVAIL` into `memory_available_bytes`; before #61 the stats queue was inert (`"stats queue event (ignored)"`) so the vCPU could sleep. Firecracker — this device's origin — paces stats with a `stats_timer` (`process_stats_timer_event`); that throttle is absent here. Guest kernel (`libkrunfw`) is unchanged, consistent with a host-VMM regression.

## This change (hotfix)
Drain the stats kick **without** re-driving the queue — no `process_stq()`/`signal_used_queue()`. Restores the pre-#61 behaviour and stops the spin immediately. **Trade-off:** `memory_available_bytes` stops updating. `process_stq()` is retained (`#[allow(dead_code)]`) for the proper fix.

## Proper follow-up (keeps the metric)
Re-request stats on a periodic `TimerFd`, mirroring firecracker's `stats_timer` / `process_stats_timer_event`: on the guest kick, *parse* + stash the descriptor index (no `add_used`/`signal`); on a ~1s timer, `add_used` + `signal` to request the next sample. The vCPU sleeps between ticks; the metric stays live at 1/s. Happy to push this as a follow-up commit if you'd prefer it over the drain-only hotfix.

## Repro (~1 min, any Linux+KVM host — no extra infra)
Boots a fresh **idle** sandbox on 0.5.6 (affected) vs 0.5.5 (baseline) and prints idle vCPU cost. Run nothing inside it.
```bash
base=https://github.com/superradcompany/microsandbox/releases/download
run() { v=$1 h=$2; rm -rf "$h"; mkdir -p "$h/bin" "$h/lib"
  curl -fsSL "$base/$v/msb-linux-x86_64"          -o "$h/bin/msb"
  curl -fsSL "$base/$v/agentd-x86_64"             -o "$h/bin/agentd"
  curl -fsSL "$base/$v/libkrunfw-linux-x86_64.so" -o "$h/lib/libkrunfw.so.5.2.1"
  ln -sf libkrunfw.so.5.2.1 "$h/lib/libkrunfw.so.5"; ln -sf libkrunfw.so.5 "$h/lib/libkrunfw.so"
  chmod +x "$h/bin/msb" "$h/bin/agentd"
  MSB_HOME="$h" "$h/bin/msb" create --name "s-$v" --replace --memory 512M \
      --pull if-missing mirror.gcr.io/library/debian:stable-slim >/dev/null 2>&1
  sleep 15; pid=$(pgrep -f "name s-$v" | head -1)
  echo "$v: msb sandbox %CPU = $(ps -o %cpu= -p "$pid")"
  top -bHn1 -p "$pid" 2>/dev/null | awk '/fc_vcpu/{print "   fc_vcpu %CPU =",$9; exit}'
  MSB_HOME="$h" "$h/bin/msb" stop "s-$v" >/dev/null 2>&1; MSB_HOME="$h" "$h/bin/msb" remove "s-$v" >/dev/null 2>&1; rm -rf "$h"; }
run v0.5.6 /tmp/s056   # expect ~100% (fc_vcpu hot) — SPIN
run v0.5.5 /tmp/s055   # expect ~0-4% (fc_vcpu asleep) — correct
```
Measured on prod (GCP `n2-standard-4`, Intel): 0.5.6 idle = ~110% / ~73k ctx-sw/s; 0.5.5 idle = ~3.8% / ~1.2k. Reproduced both in an isolated `MSB_HOME` and via a clean `~/.microsandbox` reinstall (0.5.6→0.5.5: 110%→3.2%).

> Not built/CI'd locally (no libkrun toolchain here) — draft pending your build/CI. The diff is a comment + removing the re-drive of the stats queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)