### PR TITLE
fix(balloon): throttle guest-stats requests on a periodic timer

### DIFF
--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -4,6 +4,8 @@ use std::io::Write;
 
 use utils::eventfd::EventFd;
 use utils::metrics::MetricsWriter;
+#[cfg(target_os = "linux")]
+use utils::timerfd::TimerFd;
 use vm_memory::{ByteValued, GuestMemory, GuestMemoryMmap};
 
 use super::super::{
@@ -56,6 +58,15 @@ pub struct Balloon {
     pub(crate) device_state: DeviceState,
     config: VirtioBalloonConfig,
     pub(crate) metrics: MetricsWriter,
+    // Index of the stats descriptor the guest has handed us, awaiting return
+    // (add_used + signal) to request the next sample. On Linux that return is
+    // paced by `stats_timer`; elsewhere it happens inline.
+    pub(crate) stats_desc_index: Option<u16>,
+    // Periodic timer that throttles guest-stats requests so the vCPU sleeps
+    // between samples instead of busy-spinning on an unthrottled host<->guest
+    // stats ping-pong. Linux-only (timerfd).
+    #[cfg(target_os = "linux")]
+    pub(crate) stats_timer: TimerFd,
 }
 
 impl Balloon {
@@ -69,6 +80,9 @@ impl Balloon {
             device_state: DeviceState::Inactive,
             config: VirtioBalloonConfig::default(),
             metrics,
+            stats_desc_index: None,
+            #[cfg(target_os = "linux")]
+            stats_timer: TimerFd::new().map_err(|e| BalloonError::Timer(e.into()))?,
         })
     }
 

--- a/src/devices/src/virtio/balloon/event_handler.rs
+++ b/src/devices/src/virtio/balloon/event_handler.rs
@@ -19,6 +19,12 @@ struct BalloonStat {
 
 unsafe impl ByteValued for BalloonStat {}
 
+// How often the host re-requests guest memory stats. One wakeup per second per
+// VM is negligible, versus the ~18k wakeups/second an unthrottled stats queue
+// caused. Linux-only (paired with the stats TimerFd).
+#[cfg(target_os = "linux")]
+const STATS_POLL_INTERVAL_SECS: u64 = 1;
+
 impl Balloon {
     fn queue_event(&self, idx: usize) -> &std::sync::Arc<utils::eventfd::EventFd> {
         &self.queues.as_ref().expect("queues should exist")[idx].event
@@ -63,8 +69,28 @@ impl Balloon {
 
         if let Err(e) = self.queue_event(STQ_INDEX).read() {
             error!("Failed to read balloon stats queue event: {e:?}");
-        } else if self.process_stq() {
-            self.device_state.signal_used_queue();
+            return;
+        }
+
+        // Read the freshly-reported stats and stash the descriptor index.
+        self.process_stats_queue();
+
+        // The buffer must be returned (add_used + signal) to request the next
+        // sample. Doing that *here*, on every guest kick, is exactly what caused
+        // the idle-vCPU busy-spin: the stats queue is host-paced, so returning
+        // the buffer makes the Linux guest's `stats_request` refill and kick
+        // again immediately — an unthrottled host<->guest ping-pong that keeps
+        // the vCPU out of HLT and pins the `fc_vcpu` thread at ~100% on every
+        // running microVM, even idle ones (the 0.1.15 regression). On Linux we
+        // instead return the buffer on a periodic timer (handle_stats_timer_event),
+        // pacing requests to STATS_POLL_INTERVAL_SECS so memory_available_bytes
+        // stays live while the vCPU sleeps between samples. Without a timerfd
+        // (non-Linux) we fall back to returning it inline.
+        #[cfg(not(target_os = "linux"))]
+        {
+            if self.return_stats_buffer() {
+                self.device_state.signal_used_queue();
+            }
         }
     }
 
@@ -98,56 +124,86 @@ impl Balloon {
         }
     }
 
-    fn process_stq(&mut self) -> bool {
+    // Pop the guest's stats descriptor, publish `memory_available_bytes`, and
+    // stash the descriptor index for `return_stats_buffer` to hand back later.
+    // Deliberately does NOT add_used — returning the buffer is the throttled
+    // step that requests the next sample.
+    fn process_stats_queue(&mut self) {
         let mem = match self.device_state {
             crate::virtio::DeviceState::Activated(ref mem, _) => mem,
-            crate::virtio::DeviceState::Inactive => unreachable!(),
+            crate::virtio::DeviceState::Inactive => return,
         };
         let metrics = self.metrics.clone();
         let queues = self
             .queues
             .as_mut()
             .expect("queues should exist when activated");
-        let mut have_used = false;
 
+        let mut latest_index: Option<u16> = None;
         while let Some(head) = queues[STQ_INDEX].queue.pop(mem) {
             let index = head.index;
-            let mut reader = match Reader::new(mem, head) {
-                Ok(reader) => reader,
-                Err(e) => {
-                    error!("balloon: invalid stats descriptor chain: {e:?}");
-                    have_used = true;
-                    if let Err(e) = queues[STQ_INDEX].queue.add_used(mem, index, 0) {
-                        error!("balloon: failed to add used stats element: {e:?}");
-                    }
-                    continue;
-                }
-            };
-
-            while reader.available_bytes() >= std::mem::size_of::<BalloonStat>() {
-                match reader.read_obj::<BalloonStat>() {
-                    Ok(stat) => {
-                        if stat.tag.to_native() == VIRTIO_BALLOON_S_AVAIL {
-                            metrics.set_memory_available_bytes(stat.val.to_native());
+            match Reader::new(mem, head) {
+                Ok(mut reader) => {
+                    while reader.available_bytes() >= std::mem::size_of::<BalloonStat>() {
+                        match reader.read_obj::<BalloonStat>() {
+                            Ok(stat) => {
+                                if stat.tag.to_native() == VIRTIO_BALLOON_S_AVAIL {
+                                    metrics.set_memory_available_bytes(stat.val.to_native());
+                                }
+                            }
+                            Err(e) => {
+                                error!("balloon: failed to read stat: {e:?}");
+                                break;
+                            }
                         }
                     }
-                    Err(e) => {
-                        error!("balloon: failed to read stat: {e:?}");
-                        break;
-                    }
                 }
+                Err(e) => error!("balloon: invalid stats descriptor chain: {e:?}"),
             }
-
-            have_used = true;
-            if let Err(e) = queues[STQ_INDEX].queue.add_used(mem, index, 0) {
-                error!("balloon: failed to add used stats element: {e:?}");
-            }
+            latest_index = Some(index);
         }
 
-        have_used
+        if latest_index.is_some() {
+            self.stats_desc_index = latest_index;
+        }
     }
 
-    fn handle_activate_event(&self, event_manager: &mut EventManager) {
+    // Hand the stashed stats buffer back to the guest (add_used), which requests
+    // a fresh sample. Returns true if the caller should signal the used queue.
+    fn return_stats_buffer(&mut self) -> bool {
+        let index = match self.stats_desc_index.take() {
+            Some(index) => index,
+            None => return false,
+        };
+        let mem = match self.device_state {
+            crate::virtio::DeviceState::Activated(ref mem, _) => mem,
+            crate::virtio::DeviceState::Inactive => return false,
+        };
+        let queues = self
+            .queues
+            .as_mut()
+            .expect("queues should exist when activated");
+        if let Err(e) = queues[STQ_INDEX].queue.add_used(mem, index, 0) {
+            error!("balloon: failed to add used stats element: {e:?}");
+            return false;
+        }
+        true
+    }
+
+    // Timer tick: return the stashed stats buffer to request the next sample.
+    // Throttling the return here — instead of on every guest kick — is what
+    // stops the idle-vCPU busy-spin while keeping `memory_available_bytes` live.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn handle_stats_timer_event(&mut self) {
+        if let Err(e) = self.stats_timer.wait() {
+            error!("balloon: failed to read stats timer: {e:?}");
+        }
+        if self.return_stats_buffer() {
+            self.device_state.signal_used_queue();
+        }
+    }
+
+    fn handle_activate_event(&mut self, event_manager: &mut EventManager) {
         debug!("balloon: activate event");
         if let Err(e) = self.activate_evt.read() {
             error!("Failed to consume balloon activate event: {e:?}");
@@ -209,6 +265,28 @@ impl Balloon {
                 error!("Failed to register balloon frq with event manager: {e:?}");
             });
 
+        // Arm + register the periodic stats timer (Linux only) when the guest
+        // negotiated the stats queue. The timer paces stats requests so the vCPU
+        // sleeps between samples instead of busy-spinning (see handle_stq_event).
+        #[cfg(target_os = "linux")]
+        if self.acked_features & (1u64 << super::defs::uapi::VIRTIO_BALLOON_F_STATS_VQ as u64) != 0
+        {
+            let interval = std::time::Duration::from_secs(STATS_POLL_INTERVAL_SECS);
+            if let Err(e) = self.stats_timer.reset(interval, Some(interval)) {
+                error!("balloon: failed to arm stats timer: {e:?}");
+            }
+            let timer_fd = self.stats_timer.as_raw_fd();
+            event_manager
+                .register(
+                    timer_fd,
+                    EpollEvent::new(EventSet::IN, timer_fd as u64),
+                    self_subscriber.clone(),
+                )
+                .unwrap_or_else(|e| {
+                    error!("Failed to register balloon stats timer with event manager: {e:?}");
+                });
+        }
+
         event_manager
             .unregister(self.activate_evt.as_raw_fd())
             .unwrap_or_else(|e| {
@@ -226,6 +304,8 @@ impl Subscriber for Balloon {
         let phq = self.queue_event(PHQ_INDEX).as_raw_fd();
         let frq = self.queue_event(FRQ_INDEX).as_raw_fd();
         let activate_evt = self.activate_evt.as_raw_fd();
+        #[cfg(target_os = "linux")]
+        let stats_timer = self.stats_timer.as_raw_fd();
 
         if self.is_activated() {
             match source {
@@ -234,6 +314,8 @@ impl Subscriber for Balloon {
                 _ if source == stq => self.handle_stq_event(event),
                 _ if source == phq => self.handle_phq_event(event),
                 _ if source == frq => self.handle_frq_event(event),
+                #[cfg(target_os = "linux")]
+                _ if source == stats_timer => self.handle_stats_timer_event(),
                 _ if source == activate_evt => {
                     self.handle_activate_event(event_manager);
                 }

--- a/src/devices/src/virtio/balloon/mod.rs
+++ b/src/devices/src/virtio/balloon/mod.rs
@@ -25,6 +25,9 @@ mod defs {
 pub enum BalloonError {
     /// Failed to create event fd.
     EventFd(std::io::Error),
+    /// Failed to create the stats-request timer fd.
+    #[cfg(target_os = "linux")]
+    Timer(std::io::Error),
 }
 
 type Result<T> = std::result::Result<T, BalloonError>;

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub use vmm_sys_util::{errno, tempdir, tempfile, terminal};
 #[cfg(target_os = "linux")]
-pub use vmm_sys_util::{eventfd, ioctl};
+pub use vmm_sys_util::{eventfd, ioctl, timerfd};
 
 pub mod byte_order;
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
**Completes the fix from #63** (which was closed + its branch deleted — this is the real fix, not the drain-only band-aid).

## Problem
The virtio-balloon **stats queue** is host-paced: returning the stats buffer to the guest (`add_used` + `signal_used_queue`) makes the Linux guest's `stats_request` callback refill and **kick again immediately** on the used-buffer IRQ. The guest-metrics change (#61, `934ae9738`) returned the buffer on **every guest kick with no throttle** → an unthrottled host↔guest ping-pong that keeps the vCPU out of HLT. Every running microVM — **even idle** — pins its `fc_vcpu` thread at ~100%; a 4-vCPU worker saturates after ~3–4 sandboxes and in-guest commands run 50–100× slower.

## Fix (firecracker-style `stats_timer`)
Split the work so requests are **paced on a periodic timer** instead of fired on every kick:
- **On the guest kick** (`process_stats_queue`): read the stats, publish `memory_available_bytes`, and **stash the descriptor index** — no `add_used`.
- **On a periodic `TimerFd`** (`STATS_POLL_INTERVAL_SECS = 1s`, `handle_stats_timer_event`): return the stashed buffer (`add_used` + signal) to request the next sample.

Result: `memory_available_bytes` stays live (paced to 1/s), the vCPU **sleeps between samples**, and the spin is gone. The timer is armed at activation only when the guest negotiated `VIRTIO_BALLOON_F_STATS_VQ`.

`timerfd` is Linux-only, so non-Linux targets keep returning the buffer **inline** (today's behaviour, unchanged). Re-exported via `utils::timerfd` to match the existing `utils::eventfd`/`ioctl` idiom.

## Verification
- `cargo check -p msb_krun_devices` on **linux/x86_64** (Docker `rust:1-bookworm`): **clean**, 0 warnings (resolves `vmm-sys-util 0.14.0` via the `utils::timerfd` re-export).
- `rustfmt --check` on all 4 changed files: clean.
- Repro + prod evidence for the spin itself are in the earlier write-up (110% vs 3.8% idle CPU, 0.5.6 vs 0.5.5; ~73k vs ~1.2k ctx-sw/s).

Files: `balloon/{device,event_handler,mod}.rs` + `utils/src/lib.rs`.

cc @appcypher — this replaces the closed #63. Happy to tune the 1s interval.
