### PR TITLE
fix(balloon): pace guest stats with a timer

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -21,12 +21,15 @@ runs:
 
     - name: Set up Homebrew (macOS)
       if: runner.os == 'macOS'
-      uses: Homebrew/actions/setup-homebrew@master
+      uses: Homebrew/actions/setup-homebrew@main
 
     - name: Install packages (macOS)
       if: runner.os == 'macOS'
       shell: bash
-      run: brew tap slp/krun && brew install virglrenderer llvm
+      run: |
+        brew tap slp/krun
+        brew trust slp/krun
+        brew install virglrenderer llvm
 
     - name: Install packages (Linux)
       if: runner.os == 'Linux'

--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -1,9 +1,11 @@
 use std::cmp;
 use std::convert::TryInto;
 use std::io::Write;
+use std::time::Duration;
 
 use utils::eventfd::EventFd;
 use utils::metrics::MetricsWriter;
+use utils::timerfd::TimerFd;
 use vm_memory::{ByteValued, GuestMemory, GuestMemoryMmap};
 
 use super::super::{
@@ -25,12 +27,15 @@ pub(crate) const PHQ_INDEX: usize = 3;
 pub(crate) const FRQ_INDEX: usize = 4;
 
 // Supported features.
-pub(crate) const AVAIL_FEATURES: u64 = (1 << uapi::VIRTIO_F_VERSION_1 as u64)
+pub(crate) const BASE_AVAIL_FEATURES: u64 = (1 << uapi::VIRTIO_F_VERSION_1 as u64)
     | (1 << uapi::VIRTIO_BALLOON_F_STATS_VQ as u64)
     | (1 << uapi::VIRTIO_BALLOON_F_FREE_PAGE_HINT as u64)
     | (1 << uapi::VIRTIO_BALLOON_F_REPORTING as u64);
 
 pub(crate) const VIRTIO_BALLOON_S_AVAIL: u16 = 6;
+pub(crate) const MAX_STATS_TAGS: u32 = 256;
+pub(crate) const MAX_STATS_DESC_LEN: u32 =
+    MAX_STATS_TAGS * std::mem::size_of::<BalloonStat>() as u32;
 
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(C, packed)]
@@ -48,6 +53,15 @@ pub struct VirtioBalloonConfig {
 // Safe because it only has data and has no implicit padding.
 unsafe impl ByteValued for VirtioBalloonConfig {}
 
+#[derive(Clone, Copy, Default)]
+#[repr(C, packed)]
+pub(crate) struct BalloonStat {
+    pub(crate) tag: vm_memory::Le16,
+    pub(crate) val: vm_memory::Le64,
+}
+
+unsafe impl ByteValued for BalloonStat {}
+
 pub struct Balloon {
     pub(crate) queues: Option<Vec<DeviceQueue>>,
     pub(crate) avail_features: u64,
@@ -56,24 +70,37 @@ pub struct Balloon {
     pub(crate) device_state: DeviceState,
     config: VirtioBalloonConfig,
     pub(crate) metrics: MetricsWriter,
+    pub(crate) stats_polling_interval: Option<Duration>,
+    pub(crate) stats_timer: TimerFd,
+    pub(crate) stats_desc_index: Option<u16>,
 }
 
 impl Balloon {
-    pub fn new(metrics: MetricsWriter) -> super::Result<Balloon> {
+    pub fn new(
+        metrics: MetricsWriter,
+        stats_polling_interval: Option<Duration>,
+    ) -> super::Result<Balloon> {
         Ok(Balloon {
             queues: None,
-            avail_features: AVAIL_FEATURES,
+            avail_features: BASE_AVAIL_FEATURES,
             acked_features: 0,
             activate_evt: EventFd::new(utils::eventfd::EFD_NONBLOCK)
                 .map_err(BalloonError::EventFd)?,
             device_state: DeviceState::Inactive,
             config: VirtioBalloonConfig::default(),
             metrics,
+            stats_polling_interval,
+            stats_timer: TimerFd::new().map_err(BalloonError::TimerFd)?,
+            stats_desc_index: None,
         })
     }
 
     pub fn id(&self) -> &str {
         defs::BALLOON_DEV_ID
+    }
+
+    pub(crate) fn stats_enabled(&self) -> bool {
+        self.stats_polling_interval.is_some()
     }
 
     pub fn process_frq(&mut self) -> bool {

--- a/src/devices/src/virtio/balloon/event_handler.rs
+++ b/src/devices/src/virtio/balloon/event_handler.rs
@@ -2,22 +2,13 @@ use std::os::unix::io::AsRawFd;
 
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
-use vm_memory::{ByteValued, Le16, Le64};
 
 use super::device::{
-    Balloon, DFQ_INDEX, FRQ_INDEX, IFQ_INDEX, PHQ_INDEX, STQ_INDEX, VIRTIO_BALLOON_S_AVAIL,
+    Balloon, BalloonStat, DFQ_INDEX, FRQ_INDEX, IFQ_INDEX, MAX_STATS_DESC_LEN, PHQ_INDEX,
+    STQ_INDEX, VIRTIO_BALLOON_S_AVAIL,
 };
 use crate::virtio::descriptor_utils::Reader;
 use crate::virtio::device::VirtioDevice;
-
-#[derive(Clone, Copy, Default)]
-#[repr(C, packed)]
-struct BalloonStat {
-    tag: Le16,
-    val: Le64,
-}
-
-unsafe impl ByteValued for BalloonStat {}
 
 impl Balloon {
     fn queue_event(&self, idx: usize) -> &std::sync::Arc<utils::eventfd::EventFd> {
@@ -63,8 +54,24 @@ impl Balloon {
 
         if let Err(e) = self.queue_event(STQ_INDEX).read() {
             error!("Failed to read balloon stats queue event: {e:?}");
-        } else if self.process_stq() {
-            self.device_state.signal_used_queue();
+        } else {
+            self.process_stq();
+        }
+    }
+
+    pub(crate) fn handle_stats_timer_event(&mut self, event: &EpollEvent) {
+        debug!("balloon: stats timer event");
+
+        let event_set = event.event_set();
+        if event_set != EventSet::IN {
+            warn!("balloon: stats timer unexpected event {event_set:?}");
+            return;
+        }
+
+        if let Err(e) = self.stats_timer.read() {
+            error!("Failed to read balloon stats timer event: {e:?}");
+        } else {
+            self.trigger_stats_update();
         }
     }
 
@@ -98,28 +105,62 @@ impl Balloon {
         }
     }
 
-    fn process_stq(&mut self) -> bool {
+    fn process_stq(&mut self) {
         let mem = match self.device_state {
             crate::virtio::DeviceState::Activated(ref mem, _) => mem,
             crate::virtio::DeviceState::Inactive => unreachable!(),
         };
         let metrics = self.metrics.clone();
-        let queues = self
-            .queues
-            .as_mut()
-            .expect("queues should exist when activated");
-        let mut have_used = false;
-
-        while let Some(head) = queues[STQ_INDEX].queue.pop(mem) {
+        while let Some(head) = {
+            let queues = self
+                .queues
+                .as_mut()
+                .expect("queues should exist when activated");
+            queues[STQ_INDEX].queue.pop(mem)
+        } {
             let index = head.index;
+
+            if let Some(prev_index) = self.stats_desc_index.take() {
+                error!("balloon: driver is not compliant, more than one stats buffer received");
+                let add_result = {
+                    let queues = self
+                        .queues
+                        .as_mut()
+                        .expect("queues should exist when activated");
+                    queues[STQ_INDEX].queue.add_used(mem, prev_index, 0)
+                };
+                if let Err(e) = add_result {
+                    error!("balloon: failed to add stale used stats element: {e:?}");
+                } else {
+                    self.device_state.signal_used_queue();
+                }
+            }
+
+            match stats_descriptor_len(&head) {
+                Some(len) if len <= MAX_STATS_DESC_LEN => {}
+                Some(len) => {
+                    warn!(
+                        "balloon: stats descriptor too large: {} > {}, skipping",
+                        len, MAX_STATS_DESC_LEN
+                    );
+                    self.stats_desc_index = Some(index);
+                    self.arm_stats_timer();
+                    continue;
+                }
+                None => {
+                    error!("balloon: stats descriptor length overflow");
+                    self.stats_desc_index = Some(index);
+                    self.arm_stats_timer();
+                    continue;
+                }
+            }
+
             let mut reader = match Reader::new(mem, head) {
                 Ok(reader) => reader,
                 Err(e) => {
                     error!("balloon: invalid stats descriptor chain: {e:?}");
-                    have_used = true;
-                    if let Err(e) = queues[STQ_INDEX].queue.add_used(mem, index, 0) {
-                        error!("balloon: failed to add used stats element: {e:?}");
-                    }
+                    self.stats_desc_index = Some(index);
+                    self.arm_stats_timer();
                     continue;
                 }
             };
@@ -138,16 +179,44 @@ impl Balloon {
                 }
             }
 
-            have_used = true;
-            if let Err(e) = queues[STQ_INDEX].queue.add_used(mem, index, 0) {
-                error!("balloon: failed to add used stats element: {e:?}");
-            }
+            self.stats_desc_index = Some(index);
+            self.arm_stats_timer();
         }
-
-        have_used
     }
 
-    fn handle_activate_event(&self, event_manager: &mut EventManager) {
+    fn arm_stats_timer(&self) {
+        let Some(interval) = self.stats_polling_interval else {
+            return;
+        };
+
+        if let Err(e) = self.stats_timer.arm_oneshot(interval) {
+            error!("balloon: failed to arm stats timer: {e:?}");
+        }
+    }
+
+    fn trigger_stats_update(&mut self) {
+        let Some(index) = self.stats_desc_index.take() else {
+            debug!("balloon: stats timer fired without a retained descriptor");
+            return;
+        };
+
+        let mem = match self.device_state {
+            crate::virtio::DeviceState::Activated(ref mem, _) => mem,
+            crate::virtio::DeviceState::Inactive => unreachable!(),
+        };
+        let queues = self
+            .queues
+            .as_mut()
+            .expect("queues should exist when activated");
+
+        if let Err(e) = queues[STQ_INDEX].queue.add_used(mem, index, 0) {
+            error!("balloon: failed to add used stats element: {e:?}");
+        } else {
+            self.device_state.signal_used_queue();
+        }
+    }
+
+    fn handle_activate_event(&mut self, event_manager: &mut EventManager) {
         debug!("balloon: activate event");
         if let Err(e) = self.activate_evt.read() {
             error!("Failed to consume balloon activate event: {e:?}");
@@ -179,15 +248,27 @@ impl Balloon {
                 error!("Failed to register balloon dfq with event manager: {e:?}");
             });
 
-        event_manager
-            .register(
-                self.queue_event(STQ_INDEX).as_raw_fd(),
-                EpollEvent::new(EventSet::IN, self.queue_event(STQ_INDEX).as_raw_fd() as u64),
-                self_subscriber.clone(),
-            )
-            .unwrap_or_else(|e| {
-                error!("Failed to register balloon stq with event manager: {e:?}");
-            });
+        if self.stats_enabled() {
+            event_manager
+                .register(
+                    self.queue_event(STQ_INDEX).as_raw_fd(),
+                    EpollEvent::new(EventSet::IN, self.queue_event(STQ_INDEX).as_raw_fd() as u64),
+                    self_subscriber.clone(),
+                )
+                .unwrap_or_else(|e| {
+                    error!("Failed to register balloon stq with event manager: {e:?}");
+                });
+
+            event_manager
+                .register(
+                    self.stats_timer.as_raw_fd(),
+                    EpollEvent::new(EventSet::IN, self.stats_timer.as_raw_fd() as u64),
+                    self_subscriber.clone(),
+                )
+                .unwrap_or_else(|e| {
+                    error!("Failed to register balloon stats timer with event manager: {e:?}");
+                });
+        }
 
         event_manager
             .register(
@@ -226,12 +307,16 @@ impl Subscriber for Balloon {
         let phq = self.queue_event(PHQ_INDEX).as_raw_fd();
         let frq = self.queue_event(FRQ_INDEX).as_raw_fd();
         let activate_evt = self.activate_evt.as_raw_fd();
+        let stats_timer = self.stats_timer.as_raw_fd();
 
         if self.is_activated() {
             match source {
                 _ if source == ifq => self.handle_ifq_event(event),
                 _ if source == dfq => self.handle_dfq_event(event),
                 _ if source == stq => self.handle_stq_event(event),
+                _ if self.stats_enabled() && source == stats_timer => {
+                    self.handle_stats_timer_event(event)
+                }
                 _ if source == phq => self.handle_phq_event(event),
                 _ if source == frq => self.handle_frq_event(event),
                 _ if source == activate_evt => {
@@ -250,4 +335,12 @@ impl Subscriber for Balloon {
             self.activate_evt.as_raw_fd() as u64,
         )]
     }
+}
+
+fn stats_descriptor_len(head: &crate::virtio::DescriptorChain<'_>) -> Option<u32> {
+    let mut len = 0u32;
+    for desc in head.clone().into_iter().readable() {
+        len = len.checked_add(desc.len)?;
+    }
+    Some(len)
 }

--- a/src/devices/src/virtio/balloon/mod.rs
+++ b/src/devices/src/virtio/balloon/mod.rs
@@ -25,6 +25,8 @@ mod defs {
 pub enum BalloonError {
     /// Failed to create event fd.
     EventFd(std::io::Error),
+    /// Failed to create or configure timer fd.
+    TimerFd(std::io::Error),
 }
 
 type Result<T> = std::result::Result<T, BalloonError>;

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -350,6 +350,7 @@ impl VmBuilder {
         vmr.split_irqchip = self.machine.split_irqchip;
         vmr.request_vsock = self.machine.vsock;
         vmr.enable_balloon = self.machine.balloon;
+        vmr.balloon_stats_interval = self.machine.balloon_stats_interval;
         vmr.enable_rng = self.machine.rng;
 
         // Apply filesystem configuration

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -3,6 +3,7 @@
 use std::os::fd::RawFd;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use devices::virtio::console::port_io::{
     ConsolePortBackend, ConsolePortBackendInputAdapter, ConsolePortBackendOutputAdapter,
@@ -45,6 +46,7 @@ pub struct MachineBuilder {
     pub(crate) split_irqchip: bool,
     pub(crate) vsock: bool,
     pub(crate) balloon: bool,
+    pub(crate) balloon_stats_interval: Option<Duration>,
     pub(crate) rng: bool,
     pub(crate) enable_inet_hijack: bool,
 }
@@ -338,6 +340,7 @@ impl MachineBuilder {
             split_irqchip: false,
             vsock: false,
             balloon: true,
+            balloon_stats_interval: Some(Duration::from_secs(1)),
             rng: true,
             enable_inet_hijack: false,
         }
@@ -398,6 +401,16 @@ impl MachineBuilder {
     /// device and its guest-side probe.
     pub fn balloon(mut self, enabled: bool) -> Self {
         self.balloon = enabled;
+        self
+    }
+
+    /// Set the virtio-balloon guest memory statistics polling interval.
+    ///
+    /// `Some(interval)` advertises and drives the stats queue at the requested
+    /// cadence. `None` disables balloon stats polling while still allowing the
+    /// balloon device itself to be attached.
+    pub fn balloon_stats_interval(mut self, interval: Option<Duration>) -> Self {
+        self.balloon_stats_interval = interval;
         self
     }
 

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -26,4 +26,5 @@ pub mod sized_vec;
 pub mod sm;
 pub mod syscall;
 pub mod time;
+pub mod timerfd;
 pub mod worker_message;

--- a/src/utils/src/timerfd.rs
+++ b/src/utils/src/timerfd.rs
@@ -1,0 +1,218 @@
+use std::io;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::time::Duration;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Pollable timer used by event-loop driven devices.
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+pub struct TimerFd {
+    fd: RawFd,
+}
+
+/// Pollable timer used by event-loop driven devices.
+#[cfg(target_os = "macos")]
+#[derive(Debug)]
+pub struct TimerFd {
+    event: crate::eventfd::EventFd,
+    worker: std::sync::Mutex<Option<TimerWorker>>,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug)]
+struct TimerWorker {
+    stop: std::sync::mpsc::Sender<()>,
+    handle: std::thread::JoinHandle<()>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(target_os = "linux")]
+impl TimerFd {
+    /// Create a nonblocking timer file descriptor.
+    pub fn new() -> io::Result<Self> {
+        let fd = unsafe {
+            libc::timerfd_create(
+                libc::CLOCK_MONOTONIC,
+                libc::TFD_NONBLOCK | libc::TFD_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(Self { fd })
+        }
+    }
+
+    /// Arm the timer to fire once after `duration`.
+    pub fn arm_oneshot(&self, duration: Duration) -> io::Result<()> {
+        validate_duration(duration)?;
+        self.set_time(duration, Duration::ZERO)
+    }
+
+    /// Disarm the timer.
+    pub fn disarm(&self) -> io::Result<()> {
+        self.set_time(Duration::ZERO, Duration::ZERO)
+    }
+
+    /// Read and return the number of expirations.
+    pub fn read(&self) -> io::Result<u64> {
+        let mut value = 0u64;
+        let ret = unsafe {
+            libc::read(
+                self.fd,
+                &mut value as *mut u64 as *mut libc::c_void,
+                std::mem::size_of::<u64>(),
+            )
+        };
+        if ret < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(value)
+        }
+    }
+
+    fn set_time(&self, value: Duration, interval: Duration) -> io::Result<()> {
+        let spec = libc::itimerspec {
+            it_interval: duration_to_timespec(interval),
+            it_value: duration_to_timespec(value),
+        };
+        let ret = unsafe { libc::timerfd_settime(self.fd, 0, &spec, std::ptr::null_mut()) };
+        if ret < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl TimerFd {
+    /// Create a nonblocking pollable timer.
+    pub fn new() -> io::Result<Self> {
+        Ok(Self {
+            event: crate::eventfd::EventFd::new(crate::eventfd::EFD_NONBLOCK)?,
+            worker: std::sync::Mutex::new(None),
+        })
+    }
+
+    /// Arm the timer to fire once after `duration`.
+    pub fn arm_oneshot(&self, duration: Duration) -> io::Result<()> {
+        validate_duration(duration)?;
+        self.disarm()?;
+
+        let event = self.event.try_clone()?;
+        let (stop, rx) = std::sync::mpsc::channel();
+        let handle = std::thread::Builder::new()
+            .name("msb_krun_timer".to_string())
+            .spawn(move || {
+                if let Err(std::sync::mpsc::RecvTimeoutError::Timeout) = rx.recv_timeout(duration) {
+                    let _ = event.write(1);
+                }
+            })?;
+
+        *self.worker.lock().unwrap() = Some(TimerWorker { stop, handle });
+        Ok(())
+    }
+
+    /// Disarm the timer.
+    pub fn disarm(&self) -> io::Result<()> {
+        if let Some(worker) = self.worker.lock().unwrap().take() {
+            let _ = worker.stop.send(());
+            let _ = worker.handle.join();
+        }
+        Ok(())
+    }
+
+    /// Read and return the number of expirations.
+    pub fn read(&self) -> io::Result<u64> {
+        self.event.read()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(target_os = "linux")]
+impl AsRawFd for TimerFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl AsRawFd for TimerFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.event.as_raw_fd()
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for TimerFd {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.fd);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for TimerFd {
+    fn drop(&mut self) {
+        let _ = self.disarm();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn validate_duration(duration: Duration) -> io::Result<()> {
+    if duration.is_zero() {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "timer duration must be nonzero",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn duration_to_timespec(duration: Duration) -> libc::timespec {
+    libc::timespec {
+        tv_sec: duration.as_secs() as libc::time_t,
+        tv_nsec: duration.subsec_nanos() as libc::c_long,
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_zero_duration() {
+        let timer = TimerFd::new().unwrap();
+        assert!(timer.arm_oneshot(Duration::ZERO).is_err());
+    }
+
+    #[test]
+    fn one_shot_timer_fires() {
+        let timer = TimerFd::new().unwrap();
+        timer
+            .arm_oneshot(Duration::from_millis(10))
+            .expect("arm timer");
+        std::thread::sleep(Duration::from_millis(30));
+        assert!(timer.read().unwrap() >= 1);
+    }
+}

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1007,6 +1007,7 @@ pub fn build_microvm(
             event_manager,
             intc.clone(),
             vm_resources.metrics.clone(),
+            vm_resources.balloon_stats_interval,
         )?;
         trace.mark("balloon.attached");
     } else {
@@ -2384,10 +2385,13 @@ fn attach_balloon_device(
     event_manager: &mut EventManager,
     intc: IrqChip,
     metrics: utils::metrics::MetricsWriter,
+    stats_polling_interval: Option<std::time::Duration>,
 ) -> std::result::Result<(), StartMicrovmError> {
     use self::StartMicrovmError::*;
 
-    let balloon = Arc::new(Mutex::new(devices::virtio::Balloon::new(metrics).unwrap()));
+    let balloon = Arc::new(Mutex::new(
+        devices::virtio::Balloon::new(metrics, stats_polling_interval).unwrap(),
+    ));
 
     event_manager
         .add_subscriber(balloon.clone())

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -9,6 +9,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::os::fd::RawFd;
 use std::path::PathBuf;
+use std::time::Duration;
 
 #[cfg(feature = "tee")]
 use serde::{Deserialize, Serialize};
@@ -198,6 +199,8 @@ pub struct VmResources {
     pub request_vsock: bool,
     /// Whether to attach the virtio-balloon device.
     pub enable_balloon: bool,
+    /// Guest memory stats polling interval for the virtio-balloon device.
+    pub balloon_stats_interval: Option<Duration>,
     /// Whether to attach the virtio-rng device.
     pub enable_rng: bool,
     /// Do not create an implicit console device in the guest
@@ -250,6 +253,7 @@ impl Default for VmResources {
             metrics: MetricsWriter::default(),
             request_vsock: false,
             enable_balloon: true,
+            balloon_stats_interval: Some(Duration::from_secs(1)),
             enable_rng: true,
             disable_implicit_console: false,
             kernel_console: None,
@@ -508,6 +512,7 @@ mod tests {
             metrics: MetricsWriter::default(),
             request_vsock: false,
             enable_balloon: true,
+            balloon_stats_interval: Some(std::time::Duration::from_secs(1)),
             enable_rng: true,
             disable_implicit_console: false,
             serial_consoles: Vec::new(),


### PR DESCRIPTION
## TL;DR
Throttle virtio-balloon stats requests with a timer so idle guests do not bounce stats buffers with the host in a tight loop.

## Description
- Stop returning virtio-balloon stats descriptors from the stats queue handler, since that immediately requests another guest sample.
- Retain the parsed stats descriptor and return it only from a stats timer event, which keeps memory stats live without waking an idle vCPU continuously.
- Add a reusable `TimerFd` helper with Linux and macOS implementations so the same pacing works on both supported host paths.
- Guard stats descriptor length and clean up stale retained descriptors if a guest submits more than one stats buffer.
- Add `MachineBuilder::balloon_stats_interval` so callers can choose the stats polling cadence or disable active stats polling while keeping the balloon device attached.

```rust
use std::time::Duration;

use msb_krun::VmBuilder;

let builder = VmBuilder::new()
    .machine(|machine| machine.balloon_stats_interval(Some(Duration::from_secs(1))));
```

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p msb_krun_utils -p msb_krun_devices -p msb_krun_vmm -p msb_krun -- -D warnings`
- [x] `cargo test -p msb_krun_utils timerfd`
- [x] Build microsandbox against this local `msb_krun` patch and verify an idle v0.5.6 sandbox no longer burns a host CPU core

