### PR TITLE
feat(metrics): add upper filesystem metrics

### DIFF
--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -29,6 +29,7 @@ pub mod gpu;
 pub mod input;
 pub mod linux_errno;
 mod mmio;
+pub mod msb_metrics;
 #[cfg(feature = "net")]
 pub mod net;
 mod queue;
@@ -49,6 +50,7 @@ pub use self::fs::*;
 #[cfg(feature = "gpu")]
 pub use self::gpu::*;
 pub use self::mmio::*;
+pub use self::msb_metrics::*;
 #[cfg(feature = "net")]
 pub use self::net::Net;
 pub use self::queue::{Descriptor, DescriptorChain, Queue};

--- a/src/devices/src/virtio/msb_metrics/device.rs
+++ b/src/devices/src/virtio/msb_metrics/device.rs
@@ -1,0 +1,240 @@
+use utils::eventfd::EventFd;
+use utils::metrics::MetricsWriter;
+use vm_memory::{ByteValued, Bytes, GuestMemoryMmap, Le32, Le64};
+
+use super::super::{
+    ActivateError, ActivateResult, DeviceQueue, DeviceState, QueueConfig, VirtioDevice,
+};
+use super::{defs, defs::uapi, MsbMetricsError};
+use crate::virtio::InterruptTransport;
+
+pub(crate) const RX_INDEX: usize = 0;
+const SAMPLE_VERSION: u32 = 1;
+const SAMPLE_SIZE: u32 = std::mem::size_of::<UpperFilesystemSample>() as u32;
+pub(crate) const AVAIL_FEATURES: u64 = 1 << uapi::VIRTIO_F_VERSION_1 as u64;
+
+#[derive(Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct UpperFilesystemSample {
+    pub version: Le32,
+    pub size: Le32,
+    pub upper_used_bytes: Le64,
+    pub upper_free_bytes: Le64,
+}
+
+unsafe impl ByteValued for UpperFilesystemSample {}
+
+pub struct MsbMetrics {
+    pub(crate) queues: Option<Vec<DeviceQueue>>,
+    pub(crate) avail_features: u64,
+    pub(crate) acked_features: u64,
+    pub(crate) activate_evt: EventFd,
+    pub(crate) device_state: DeviceState,
+    metrics: MetricsWriter,
+}
+
+impl MsbMetrics {
+    pub(crate) fn queue_event(&self, idx: usize) -> &std::sync::Arc<utils::eventfd::EventFd> {
+        &self.queues.as_ref().expect("queues should exist")[idx].event
+    }
+
+    pub fn new(metrics: MetricsWriter) -> super::Result<MsbMetrics> {
+        Ok(MsbMetrics {
+            queues: None,
+            avail_features: AVAIL_FEATURES,
+            acked_features: 0,
+            activate_evt: EventFd::new(utils::eventfd::EFD_NONBLOCK)
+                .map_err(MsbMetricsError::EventFd)?,
+            device_state: DeviceState::Inactive,
+            metrics,
+        })
+    }
+
+    pub fn id(&self) -> &str {
+        defs::MSB_METRICS_DEV_ID
+    }
+
+    pub(crate) fn process_rx(&mut self) -> bool {
+        debug!("msb_metrics: process_rx()");
+        let mem = match self.device_state {
+            DeviceState::Activated(ref mem, _) => mem,
+            DeviceState::Inactive => unreachable!(),
+        };
+        let metrics = self.metrics.clone();
+
+        let queues = self
+            .queues
+            .as_mut()
+            .expect("queues should exist when activated");
+        let mut have_used = false;
+
+        while let Some(head) = queues[RX_INDEX].queue.pop(mem) {
+            let index = head.index;
+            let mut processed = 0;
+
+            for desc in head.into_iter() {
+                if desc.is_write_only() {
+                    continue;
+                }
+                if desc.len < SAMPLE_SIZE {
+                    warn!(
+                        "msb_metrics: short sample descriptor len={} expected={}",
+                        desc.len, SAMPLE_SIZE
+                    );
+                    continue;
+                }
+
+                match mem.read_obj::<UpperFilesystemSample>(desc.addr) {
+                    Ok(sample) => process_upper_filesystem_sample(&metrics, sample),
+                    Err(err) => warn!("msb_metrics: failed to read sample descriptor: {err:?}"),
+                }
+                processed = SAMPLE_SIZE;
+                break;
+            }
+
+            have_used = true;
+            if let Err(err) = queues[RX_INDEX].queue.add_used(mem, index, processed) {
+                error!("msb_metrics: failed to add used element: {err:?}");
+            }
+        }
+
+        have_used
+    }
+}
+
+fn process_upper_filesystem_sample(metrics: &MetricsWriter, sample: UpperFilesystemSample) {
+    if sample.version.to_native() != SAMPLE_VERSION || sample.size.to_native() != SAMPLE_SIZE {
+        warn!(
+            "msb_metrics: unsupported sample version={} size={}",
+            sample.version.to_native(),
+            sample.size.to_native()
+        );
+        return;
+    }
+
+    metrics.set_upper_filesystem_bytes(
+        sample.upper_used_bytes.to_native(),
+        sample.upper_free_bytes.to_native(),
+    );
+}
+
+impl VirtioDevice for MsbMetrics {
+    fn avail_features(&self) -> u64 {
+        self.avail_features
+    }
+
+    fn acked_features(&self) -> u64 {
+        self.acked_features
+    }
+
+    fn set_acked_features(&mut self, acked_features: u64) {
+        self.acked_features = acked_features
+    }
+
+    fn device_type(&self) -> u32 {
+        uapi::VIRTIO_ID_MSB_METRICS
+    }
+
+    fn device_name(&self) -> &str {
+        "msb_metrics"
+    }
+
+    fn queue_config(&self) -> &[QueueConfig] {
+        &defs::QUEUE_CONFIG
+    }
+
+    fn read_config(&self, _offset: u64, _data: &mut [u8]) {
+        error!("msb_metrics: invalid request to read config space");
+    }
+
+    fn write_config(&mut self, offset: u64, data: &[u8]) {
+        warn!(
+            "msb_metrics: guest driver attempted to write device config (offset={:x}, len={:x})",
+            offset,
+            data.len()
+        );
+    }
+
+    fn activate(
+        &mut self,
+        mem: GuestMemoryMmap,
+        interrupt: InterruptTransport,
+        queues: Vec<DeviceQueue>,
+    ) -> ActivateResult {
+        if queues.len() != defs::NUM_QUEUES {
+            error!(
+                "Cannot perform activate. Expected {} queue(s), got {}",
+                defs::NUM_QUEUES,
+                queues.len()
+            );
+            return Err(ActivateError::BadActivate);
+        }
+
+        if self.activate_evt.write(1).is_err() {
+            error!("Cannot write to activate_evt");
+            return Err(ActivateError::BadActivate);
+        }
+
+        self.queues = Some(queues);
+        self.device_state = DeviceState::Activated(mem, interrupt);
+
+        Ok(())
+    }
+
+    fn is_activated(&self) -> bool {
+        self.device_state.is_activated()
+    }
+
+    fn reset(&mut self) -> bool {
+        self.queues = None;
+        self.device_state = DeviceState::Inactive;
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_sample_updates_filesystem_metrics() {
+        let writer = MetricsWriter::default();
+
+        process_upper_filesystem_sample(
+            &writer,
+            UpperFilesystemSample {
+                version: Le32::from(SAMPLE_VERSION),
+                size: Le32::from(SAMPLE_SIZE),
+                upper_used_bytes: Le64::from(4096),
+                upper_free_bytes: Le64::from(8192),
+            },
+        );
+
+        assert_eq!(
+            writer.handle().snapshot().filesystem.upper_used_bytes,
+            Some(4096)
+        );
+        assert_eq!(
+            writer.handle().snapshot().filesystem.upper_free_bytes,
+            Some(8192)
+        );
+    }
+
+    #[test]
+    fn invalid_sample_is_ignored() {
+        let writer = MetricsWriter::default();
+
+        process_upper_filesystem_sample(
+            &writer,
+            UpperFilesystemSample {
+                version: Le32::from(SAMPLE_VERSION + 1),
+                size: Le32::from(SAMPLE_SIZE),
+                upper_used_bytes: Le64::from(4096),
+                upper_free_bytes: Le64::from(8192),
+            },
+        );
+
+        assert_eq!(writer.handle().snapshot().filesystem.upper_used_bytes, None);
+        assert_eq!(writer.handle().snapshot().filesystem.upper_free_bytes, None);
+    }
+}

--- a/src/devices/src/virtio/msb_metrics/event_handler.rs
+++ b/src/devices/src/virtio/msb_metrics/event_handler.rs
@@ -1,0 +1,87 @@
+use std::os::unix::io::AsRawFd;
+
+use polly::event_manager::{EventManager, Subscriber};
+use utils::epoll::{EpollEvent, EventSet};
+
+use super::device::{MsbMetrics, RX_INDEX};
+use crate::virtio::device::VirtioDevice;
+
+impl MsbMetrics {
+    pub(crate) fn handle_rx_event(&mut self, event: &EpollEvent) {
+        debug!("msb_metrics: rx queue event");
+
+        let event_set = event.event_set();
+        if event_set != EventSet::IN {
+            warn!("msb_metrics: rx queue unexpected event {event_set:?}");
+            return;
+        }
+
+        if let Err(err) = self.queue_event(RX_INDEX).read() {
+            error!("msb_metrics: failed to read rx queue event: {err:?}");
+        } else if self.process_rx() {
+            self.device_state.signal_used_queue();
+        }
+    }
+
+    fn handle_activate_event(&self, event_manager: &mut EventManager) {
+        debug!("msb_metrics: activate event");
+        if let Err(err) = self.activate_evt.read() {
+            error!("msb_metrics: failed to consume activate event: {err:?}");
+        }
+
+        let self_subscriber = event_manager
+            .subscriber(self.activate_evt.as_raw_fd())
+            .unwrap();
+
+        event_manager
+            .register(
+                self.queue_event(RX_INDEX).as_raw_fd(),
+                EpollEvent::new(EventSet::IN, self.queue_event(RX_INDEX).as_raw_fd() as u64),
+                self_subscriber.clone(),
+            )
+            .unwrap_or_else(|err| {
+                error!("msb_metrics: failed to register rx queue: {err:?}");
+            });
+
+        event_manager
+            .unregister(self.activate_evt.as_raw_fd())
+            .unwrap_or_else(|err| {
+                error!("msb_metrics: failed to unregister activate event: {err:?}");
+            })
+    }
+}
+
+impl Subscriber for MsbMetrics {
+    fn process(&mut self, event: &EpollEvent, event_manager: &mut EventManager) {
+        let source = event.fd();
+        let activate_evt = self.activate_evt.as_raw_fd();
+
+        if source == activate_evt {
+            if !self.is_activated() {
+                warn!("msb_metrics: device is not activated; spurious event received: {source:?}");
+                return;
+            }
+
+            self.handle_activate_event(event_manager);
+            return;
+        }
+
+        if !self.is_activated() {
+            warn!("msb_metrics: device is not activated; spurious event received: {source:?}");
+            return;
+        }
+
+        let rx = self.queue_event(RX_INDEX).as_raw_fd();
+        match source {
+            _ if source == rx => self.handle_rx_event(event),
+            _ => warn!("msb_metrics: unexpected event received: {source:?}"),
+        }
+    }
+
+    fn interest_list(&self) -> Vec<EpollEvent> {
+        vec![EpollEvent::new(
+            EventSet::IN,
+            self.activate_evt.as_raw_fd() as u64,
+        )]
+    }
+}

--- a/src/devices/src/virtio/msb_metrics/mod.rs
+++ b/src/devices/src/virtio/msb_metrics/mod.rs
@@ -1,0 +1,27 @@
+mod device;
+mod event_handler;
+
+pub use self::defs::uapi::VIRTIO_ID_MSB_METRICS as TYPE_MSB_METRICS;
+pub use self::device::{MsbMetrics, UpperFilesystemSample};
+
+mod defs {
+    use crate::virtio::QueueConfig;
+
+    pub const MSB_METRICS_DEV_ID: &str = "virtio_msb_metrics";
+    pub const NUM_QUEUES: usize = 1;
+    const QUEUE_SIZE: u16 = 64;
+    pub static QUEUE_CONFIG: [QueueConfig; NUM_QUEUES] = [QueueConfig::new(QUEUE_SIZE); NUM_QUEUES];
+
+    pub mod uapi {
+        pub const VIRTIO_F_VERSION_1: u32 = 32;
+        pub const VIRTIO_ID_MSB_METRICS: u32 = 0x4d53;
+    }
+}
+
+#[derive(Debug)]
+pub enum MsbMetricsError {
+    /// Failed to create event fd.
+    EventFd(std::io::Error),
+}
+
+type Result<T> = std::result::Result<T, MsbMetricsError>;

--- a/src/krun/src/api/metrics.rs
+++ b/src/krun/src/api/metrics.rs
@@ -5,5 +5,6 @@
 //--------------------------------------------------------------------------------------------------
 
 pub use utils::metrics::{
-    BlockDeviceMetrics, BlockMetrics, CpuMetrics, MemoryMetrics, MetricsHandle, VmMetrics,
+    BlockDeviceMetrics, BlockMetrics, CpuMetrics, FilesystemMetrics, MemoryMetrics, MetricsHandle,
+    VmMetrics,
 };

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -49,6 +49,7 @@ pub use builders::{ConsoleBuilder, ExecBuilder, FsBuilder, KernelBuilder, Machin
 pub use error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use exit_handle::ExitHandle;
 pub use metrics::{
-    BlockDeviceMetrics, BlockMetrics, CpuMetrics, MemoryMetrics, MetricsHandle, VmMetrics,
+    BlockDeviceMetrics, BlockMetrics, CpuMetrics, FilesystemMetrics, MemoryMetrics, MetricsHandle,
+    VmMetrics,
 };
 pub use vm::Vm;

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -52,7 +52,8 @@ pub use api::builders::{ConsoleBuilder, ExecBuilder, FsBuilder, KernelBuilder, M
 pub use api::error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use api::exit_handle::ExitHandle;
 pub use api::metrics::{
-    BlockDeviceMetrics, BlockMetrics, CpuMetrics, MemoryMetrics, MetricsHandle, VmMetrics,
+    BlockDeviceMetrics, BlockMetrics, CpuMetrics, FilesystemMetrics, MemoryMetrics, MetricsHandle,
+    VmMetrics,
 };
 pub use api::vm::Vm;
 

--- a/src/utils/src/metrics.rs
+++ b/src/utils/src/metrics.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -40,6 +41,8 @@ pub struct VmMetrics {
     pub memory: MemoryMetrics,
     /// Block device metrics.
     pub block: BlockMetrics,
+    /// Filesystem metrics.
+    pub filesystem: FilesystemMetrics,
 }
 
 /// CPU metrics.
@@ -84,6 +87,17 @@ pub struct BlockDeviceMetrics {
     pub write_bytes: u64,
 }
 
+/// Filesystem metrics.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct FilesystemMetrics {
+    /// Guest-visible used bytes on the microsandbox OCI upper filesystem.
+    pub upper_used_bytes: Option<u64>,
+    /// Guest-visible bytes available to ordinary allocation on the microsandbox OCI upper filesystem.
+    pub upper_free_bytes: Option<u64>,
+    /// Unix milliseconds when the upper filesystem sample was received by the host.
+    pub upper_sampled_at_unix_ms: Option<u64>,
+}
+
 struct MetricsState {
     vcpu_time_ns: AtomicU64,
     vcpu_time_valid: AtomicU64,
@@ -96,6 +110,11 @@ struct MetricsState {
     block_read_bytes: AtomicU64,
     block_write_bytes: AtomicU64,
     block_devices: Mutex<Vec<Arc<BlockDeviceState>>>,
+    filesystem_upper_used_bytes: AtomicU64,
+    filesystem_upper_used_valid: AtomicU64,
+    filesystem_upper_free_bytes: AtomicU64,
+    filesystem_upper_free_valid: AtomicU64,
+    filesystem_upper_sampled_at_unix_ms: AtomicU64,
 }
 
 #[derive(Debug)]
@@ -162,6 +181,20 @@ impl MetricsHandle {
                 } else {
                     Vec::new()
                 },
+            },
+            filesystem: FilesystemMetrics {
+                upper_used_bytes: valid_value(
+                    &self.state.filesystem_upper_used_valid,
+                    &self.state.filesystem_upper_used_bytes,
+                ),
+                upper_free_bytes: valid_value(
+                    &self.state.filesystem_upper_free_valid,
+                    &self.state.filesystem_upper_free_bytes,
+                ),
+                upper_sampled_at_unix_ms: valid_value(
+                    &self.state.filesystem_upper_used_valid,
+                    &self.state.filesystem_upper_sampled_at_unix_ms,
+                ),
             },
         }
     }
@@ -242,6 +275,35 @@ impl MetricsWriter {
         *self.state.memory_host_resident_sampler.lock().unwrap() = Some(Arc::new(sampler));
     }
 
+    /// Set guest-visible OCI upper filesystem used/free bytes.
+    pub fn set_upper_filesystem_bytes(&self, used_bytes: u64, free_bytes: u64) {
+        self.state
+            .filesystem_upper_used_bytes
+            .store(used_bytes, Ordering::Relaxed);
+        self.state
+            .filesystem_upper_free_bytes
+            .store(free_bytes, Ordering::Relaxed);
+        self.state
+            .filesystem_upper_sampled_at_unix_ms
+            .store(unix_timestamp_ms(), Ordering::Relaxed);
+        self.state
+            .filesystem_upper_used_valid
+            .store(1, Ordering::Release);
+        self.state
+            .filesystem_upper_free_valid
+            .store(1, Ordering::Release);
+    }
+
+    /// Clear guest-visible OCI upper filesystem metrics.
+    pub fn clear_upper_filesystem_bytes(&self) {
+        self.state
+            .filesystem_upper_used_valid
+            .store(0, Ordering::Release);
+        self.state
+            .filesystem_upper_free_valid
+            .store(0, Ordering::Release);
+    }
+
     /// Add guest vCPU execution time.
     pub fn add_vcpu_time_ns(&self, ns: u64) {
         self.state.vcpu_time_ns.fetch_add(ns, Ordering::Relaxed);
@@ -303,6 +365,11 @@ impl Default for MetricsState {
             block_read_bytes: AtomicU64::new(0),
             block_write_bytes: AtomicU64::new(0),
             block_devices: Mutex::new(Vec::new()),
+            filesystem_upper_used_bytes: AtomicU64::new(0),
+            filesystem_upper_used_valid: AtomicU64::new(0),
+            filesystem_upper_free_bytes: AtomicU64::new(0),
+            filesystem_upper_free_valid: AtomicU64::new(0),
+            filesystem_upper_sampled_at_unix_ms: AtomicU64::new(0),
         }
     }
 }
@@ -323,6 +390,13 @@ fn valid_value(valid: &AtomicU64, value: &AtomicU64) -> Option<u64> {
     } else {
         Some(value.load(Ordering::Relaxed))
     }
+}
+
+fn unix_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -461,5 +535,35 @@ mod tests {
         assert_eq!(snapshot.block.read_bytes, 128);
         assert_eq!(snapshot.block.write_bytes, 256);
         assert!(snapshot.block.devices.is_empty());
+    }
+
+    #[test]
+    fn filesystem_metrics_are_unavailable_until_written() {
+        let writer = MetricsWriter::default();
+
+        assert_eq!(
+            writer.handle().snapshot().filesystem,
+            FilesystemMetrics::default()
+        );
+
+        writer.set_upper_filesystem_bytes(4096, 8192);
+
+        let snapshot = writer.handle().snapshot();
+        assert_eq!(snapshot.filesystem.upper_used_bytes, Some(4096));
+        assert_eq!(snapshot.filesystem.upper_free_bytes, Some(8192));
+        assert!(snapshot.filesystem.upper_sampled_at_unix_ms.is_some());
+    }
+
+    #[test]
+    fn filesystem_metrics_can_be_cleared() {
+        let writer = MetricsWriter::default();
+
+        writer.set_upper_filesystem_bytes(4096, 8192);
+        writer.clear_upper_filesystem_bytes();
+
+        assert_eq!(
+            writer.handle().snapshot().filesystem,
+            FilesystemMetrics::default()
+        );
     }
 }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -205,6 +205,8 @@ pub enum StartMicrovmError {
     RegisterInputDevice(device_manager::mmio::Error),
     /// Cannot initialize a MMIO Network Device or add a device to the MMIO Bus.
     RegisterNetDevice(device_manager::mmio::Error),
+    /// Cannot initialize a MMIO microsandbox metrics device or add it to the MMIO Bus.
+    RegisterMsbMetricsDevice(device_manager::mmio::Error),
     /// Cannot initialize a MMIO Rng device or add a device to the MMIO Bus.
     RegisterRngDevice(device_manager::mmio::Error),
     /// Cannot initialize a MMIO Snd device or add a device to the MMIO Bus.
@@ -443,6 +445,14 @@ impl Display for StartMicrovmError {
                 write!(
                     f,
                     "Cannot initialize a MMIO Network Device or add a device to the MMIO Bus. {err_msg}"
+                )
+            }
+            RegisterMsbMetricsDevice(ref err) => {
+                let mut err_msg = format!("{err}");
+                err_msg = err_msg.replace('\"', "");
+                write!(
+                    f,
+                    "Cannot initialize a MMIO microsandbox metrics Device or add a device to the MMIO Bus. {err_msg}"
                 )
             }
             RegisterRngDevice(ref err) => {
@@ -1019,6 +1029,16 @@ pub fn build_microvm(
         trace.mark("rng.attached");
     } else {
         trace.mark("rng.skipped");
+    }
+    #[cfg(not(feature = "tee"))]
+    {
+        attach_msb_metrics_device(
+            &mut vmm,
+            event_manager,
+            intc.clone(),
+            vm_resources.metrics.clone(),
+        )?;
+        trace.mark("msb_metrics.attached");
     }
     let mut console_id = 0;
     if !vm_resources.disable_implicit_console {
@@ -2375,6 +2395,30 @@ fn attach_unixsock_vsock_device(
 
     // The device mutex mustn't be locked here otherwise it will deadlock.
     attach_mmio_device(vmm, id, intc, unix_vsock.clone()).map_err(RegisterVsockDevice)?;
+
+    Ok(())
+}
+
+#[cfg(not(feature = "tee"))]
+fn attach_msb_metrics_device(
+    vmm: &mut Vmm,
+    event_manager: &mut EventManager,
+    intc: IrqChip,
+    metrics: utils::metrics::MetricsWriter,
+) -> std::result::Result<(), StartMicrovmError> {
+    use self::StartMicrovmError::*;
+
+    let device = Arc::new(Mutex::new(
+        devices::virtio::MsbMetrics::new(metrics).unwrap(),
+    ));
+
+    event_manager
+        .add_subscriber(device.clone())
+        .map_err(RegisterEvent)?;
+
+    let id = String::from(device.lock().unwrap().id());
+
+    attach_mmio_device(vmm, id, intc, device).map_err(RegisterMsbMetricsDevice)?;
 
     Ok(())
 }


### PR DESCRIPTION
## TL;DR
Add a libkrun metrics path for microsandbox upper filesystem used/free bytes, backed by a private virtio device.

## Description
- Add `FilesystemMetrics` to VM metrics with optional upper used bytes, upper free bytes, and host receive timestamp fields.
- Add metrics writer methods for setting and clearing protected upper filesystem samples.
- Add a private `msb_metrics` virtio device that accepts fixed-size upper filesystem payloads from the guest.
- Attach the metrics device to non-TEE microvms so bundled kernels can publish upper usage without going through guest-writable files.
- Re-export `FilesystemMetrics` through the public krun metrics API.
- Example field access:

```rust
let metrics = vm.metrics_handle().snapshot();
let upper_used = metrics.filesystem.upper_used_bytes;
let upper_free = metrics.filesystem.upper_free_bytes;
let sampled_at = metrics.filesystem.upper_sampled_at_unix_ms;
```

## Test Plan
- [x] `cargo fmt --manifest-path src/utils/Cargo.toml -- --check`
- [x] `cargo fmt --manifest-path src/devices/Cargo.toml -- --check`
- [x] `cargo fmt --manifest-path src/vmm/Cargo.toml -- --check`
- [x] `cargo fmt --manifest-path src/krun/Cargo.toml -- --check`
- [x] `cargo test --manifest-path src/utils/Cargo.toml metrics::tests::filesystem`
- [x] `cargo test --manifest-path src/devices/Cargo.toml msb_metrics`
- [x] `cargo check --manifest-path src/krun/Cargo.toml`
