### PR TITLE
feat(metrics): make msb_metrics device configurable

### DIFF
--- a/src/devices/src/virtio/msb_metrics/device.rs
+++ b/src/devices/src/virtio/msb_metrics/device.rs
@@ -170,13 +170,15 @@ impl VirtioDevice for MsbMetrics {
             return Err(ActivateError::BadActivate);
         }
 
-        if self.activate_evt.write(1).is_err() {
-            error!("Cannot write to activate_evt");
-            return Err(ActivateError::BadActivate);
-        }
-
         self.queues = Some(queues);
         self.device_state = DeviceState::Activated(mem, interrupt);
+
+        if self.activate_evt.write(1).is_err() {
+            error!("Cannot write to activate_evt");
+            self.queues = None;
+            self.device_state = DeviceState::Inactive;
+            return Err(ActivateError::BadActivate);
+        }
 
         Ok(())
     }

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -352,6 +352,7 @@ impl VmBuilder {
         vmr.enable_balloon = self.machine.balloon;
         vmr.balloon_stats_interval = self.machine.balloon_stats_interval;
         vmr.enable_rng = self.machine.rng;
+        vmr.enable_msb_metrics = self.machine.msb_metrics;
 
         // Apply filesystem configuration
         #[cfg(not(feature = "tee"))]

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -48,6 +48,7 @@ pub struct MachineBuilder {
     pub(crate) balloon: bool,
     pub(crate) balloon_stats_interval: Option<Duration>,
     pub(crate) rng: bool,
+    pub(crate) msb_metrics: bool,
     pub(crate) enable_inet_hijack: bool,
 }
 
@@ -342,6 +343,7 @@ impl MachineBuilder {
             balloon: true,
             balloon_stats_interval: Some(Duration::from_secs(1)),
             rng: true,
+            msb_metrics: true,
             enable_inet_hijack: false,
         }
     }
@@ -420,6 +422,15 @@ impl MachineBuilder {
     /// path can disable it to remove one virtio-mmio device from cold start.
     pub fn rng(mut self, enabled: bool) -> Self {
         self.rng = enabled;
+        self
+    }
+
+    /// Enable or disable the private microsandbox metrics virtio device.
+    ///
+    /// The device is enabled by default so protected guest filesystem metrics
+    /// are available for bundled microsandbox kernels.
+    pub fn msb_metrics(mut self, enabled: bool) -> Self {
+        self.msb_metrics = enabled;
         self
     }
 
@@ -946,5 +957,21 @@ impl From<SyncMode> for devices::virtio::block::SyncMode {
             SyncMode::Relaxed => devices::virtio::block::SyncMode::Relaxed,
             SyncMode::Full => devices::virtio::block::SyncMode::Full,
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn machine_builder_msb_metrics_defaults_on_and_can_be_disabled() {
+        assert!(MachineBuilder::new().msb_metrics);
+        assert!(!MachineBuilder::new().msb_metrics(false).msb_metrics);
+        assert!(MachineBuilder::new().msb_metrics(true).msb_metrics);
     }
 }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1031,7 +1031,7 @@ pub fn build_microvm(
         trace.mark("rng.skipped");
     }
     #[cfg(not(feature = "tee"))]
-    {
+    if vm_resources.enable_msb_metrics {
         attach_msb_metrics_device(
             &mut vmm,
             event_manager,
@@ -1039,6 +1039,8 @@ pub fn build_microvm(
             vm_resources.metrics.clone(),
         )?;
         trace.mark("msb_metrics.attached");
+    } else {
+        trace.mark("msb_metrics.skipped");
     }
     let mut console_id = 0;
     if !vm_resources.disable_implicit_console {

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -203,6 +203,8 @@ pub struct VmResources {
     pub balloon_stats_interval: Option<Duration>,
     /// Whether to attach the virtio-rng device.
     pub enable_rng: bool,
+    /// Whether to attach the private microsandbox metrics device.
+    pub enable_msb_metrics: bool,
     /// Do not create an implicit console device in the guest
     pub disable_implicit_console: bool,
     /// The console id to use for console= in the kernel cmdline
@@ -255,6 +257,7 @@ impl Default for VmResources {
             enable_balloon: true,
             balloon_stats_interval: Some(Duration::from_secs(1)),
             enable_rng: true,
+            enable_msb_metrics: true,
             disable_implicit_console: false,
             kernel_console: None,
             serial_consoles: Vec::new(),
@@ -514,6 +517,7 @@ mod tests {
             enable_balloon: true,
             balloon_stats_interval: Some(std::time::Duration::from_secs(1)),
             enable_rng: true,
+            enable_msb_metrics: true,
             disable_implicit_console: false,
             serial_consoles: Vec::new(),
             virtio_consoles: Vec::new(),


### PR DESCRIPTION
## TL;DR
Add a toggle so consumers can turn the private microsandbox metrics virtio device on or off. It stays on by default, so nothing changes unless you opt out.

## Description
- Add `MachineBuilder::msb_metrics(bool)` plus an `msb_metrics` field that defaults to on, with unit tests for the default, enable, and disable cases.
- Add `VmResources::enable_msb_metrics` (defaults to on) and wire the builder flag through to it.
- Gate the metrics device attachment in `build_microvm` on the flag, and mark `msb_metrics.skipped` in the trace when it is disabled.
- Make device activation atomic: set the queues and device state before signalling `activate_evt`, and roll both back to inactive if the eventfd write fails, so a failed activation can no longer leave the device half-initialized.

```rust
// Disable the metrics device (it is enabled by default)
let machine = MachineBuilder::new()
    .msb_metrics(false);
```

## Test Plan
- [x] `cargo build -p msb_krun_vmm -p msb_krun` exits 0
- [x] `cargo test -p msb_krun machine_builder_msb_metrics` passes
- [x] `cargo clippy -p msb_krun_vmm -p msb_krun` is clean