### PR TITLE
feat(vmm): add live cpu and memory resize with host enforcement

### DIFF
--- a/src/devices/src/virtio/cpu/device.rs
+++ b/src/devices/src/virtio/cpu/device.rs
@@ -1,0 +1,247 @@
+use std::cmp;
+use std::io::Write;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+
+use utils::eventfd::EventFd;
+use vm_memory::{ByteValued, GuestMemoryMmap};
+
+use super::super::{
+    ActivateError, ActivateResult, CpuDeviceError, DeviceQueue, DeviceState, QueueConfig,
+    VirtioDevice,
+};
+use super::{defs, defs::uapi};
+use crate::virtio::InterruptTransport;
+
+pub(crate) const BASE_AVAIL_FEATURES: u64 = 1 << uapi::VIRTIO_F_VERSION_1 as u64;
+
+/// How long a vCPU above the enforced count keeps running before it is
+/// hard-parked, giving a cooperative guest time to offline it cleanly.
+pub const ENFORCEMENT_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+
+// Config space offsets (three little-endian u32 fields).
+const CONFIG_ACTUAL_ONLINE_OFFSET: u64 = 8;
+
+#[derive(Copy, Clone, Debug, Default)]
+#[repr(C, packed)]
+struct VirtioCpuConfig {
+    possible: u32,
+    requested_online: u32,
+    actual_online: u32,
+}
+
+// Safe because it only has data and has no implicit padding.
+unsafe impl ByteValued for VirtioCpuConfig {}
+
+/// Host-authoritative CPU count shared with every vCPU run loop.
+///
+/// vCPUs whose index is at or above `enforced` park between emulation steps
+/// until the count is raised again, so a guest that refuses to offline a CPU
+/// stops receiving execution time on it anyway. Run loops grant a short grace
+/// window ([`ENFORCEMENT_GRACE`]) before hard-parking, because a graceful
+/// offline needs the dying CPU to execute its own PSCI CPU_OFF path. The boot
+/// CPU is always runnable: `enforced` is clamped to at least 1.
+pub struct CpuEnforcement {
+    enforced: AtomicU32,
+    gate: Mutex<()>,
+    raised: Condvar,
+}
+
+impl CpuEnforcement {
+    fn new(enforced: u32) -> Arc<Self> {
+        Arc::new(Self {
+            enforced: AtomicU32::new(enforced.max(1)),
+            gate: Mutex::new(()),
+            raised: Condvar::new(),
+        })
+    }
+
+    fn set(&self, enforced: u32) {
+        self.enforced.store(enforced.max(1), Ordering::Release);
+        let _guard = self.gate.lock().unwrap();
+        self.raised.notify_all();
+    }
+
+    /// Current enforced online count.
+    pub fn enforced(&self) -> u32 {
+        self.enforced.load(Ordering::Acquire)
+    }
+
+    /// Whether the vCPU with this index may run right now. Cheap enough for
+    /// the per-iteration check in vCPU run loops.
+    pub fn runnable(&self, cpu_index: u32) -> bool {
+        cpu_index < self.enforced()
+    }
+
+    /// Park the calling vCPU thread until its index becomes runnable again.
+    pub fn wait_until_runnable(&self, cpu_index: u32) {
+        let mut guard = self.gate.lock().unwrap();
+        while cpu_index >= self.enforced.load(Ordering::Acquire) {
+            guard = self.raised.wait(guard).unwrap();
+        }
+    }
+}
+
+/// Point-in-time view of the device for host-side control and reporting.
+#[derive(Debug, Clone, Copy)]
+pub struct CpuStateSnapshot {
+    /// CPUs possible in this boot.
+    pub possible: u32,
+
+    /// Online count the host asked the guest to converge on.
+    pub requested_online: u32,
+
+    /// Online count the guest last reported.
+    pub actual_online: u32,
+
+    /// Online count the VMM currently enforces.
+    pub enforced: u32,
+}
+
+pub struct Cpu {
+    pub(crate) queues: Option<Vec<DeviceQueue>>,
+    pub(crate) avail_features: u64,
+    pub(crate) acked_features: u64,
+    pub(crate) activate_evt: EventFd,
+    pub(crate) device_state: DeviceState,
+    config: VirtioCpuConfig,
+    enforcement: Arc<CpuEnforcement>,
+}
+
+impl Cpu {
+    /// Create the CPU capacity device for a VM booting `initial_online` of
+    /// `possible` CPUs. Enforcement starts at the initial count.
+    pub fn new(possible: u32, initial_online: u32) -> super::Result<Cpu> {
+        Ok(Cpu {
+            queues: None,
+            avail_features: BASE_AVAIL_FEATURES,
+            acked_features: 0,
+            activate_evt: EventFd::new(utils::eventfd::EFD_NONBLOCK)
+                .map_err(CpuDeviceError::EventFd)?,
+            device_state: DeviceState::Inactive,
+            config: VirtioCpuConfig {
+                possible,
+                requested_online: initial_online,
+                actual_online: initial_online,
+            },
+            enforcement: CpuEnforcement::new(initial_online),
+        })
+    }
+
+    pub fn id(&self) -> &str {
+        defs::CPU_DEV_ID
+    }
+
+    /// The enforcement state vCPU run loops consult. Cloned once per vCPU at
+    /// creation time.
+    pub fn enforcement(&self) -> Arc<CpuEnforcement> {
+        self.enforcement.clone()
+    }
+
+    /// Host control: ask the guest to converge on `online` CPUs and enforce
+    /// that ceiling host-side. Clamps to 1..=possible; signals a config change
+    /// when the device is active. Returns the accepted target.
+    pub fn set_requested_online(&mut self, online: u32) -> u32 {
+        let online = cmp::min(online.max(1), self.config.possible);
+        self.config.requested_online = online;
+        self.enforcement.set(online);
+        if let DeviceState::Activated(_, ref interrupt) = self.device_state {
+            interrupt.signal_config_change();
+        }
+        online
+    }
+
+    /// Host control: current requested/actual/enforced view.
+    pub fn state_snapshot(&self) -> CpuStateSnapshot {
+        CpuStateSnapshot {
+            possible: self.config.possible,
+            requested_online: self.config.requested_online,
+            actual_online: self.config.actual_online,
+            enforced: self.enforcement.enforced(),
+        }
+    }
+}
+
+impl VirtioDevice for Cpu {
+    fn avail_features(&self) -> u64 {
+        self.avail_features
+    }
+
+    fn acked_features(&self) -> u64 {
+        self.acked_features
+    }
+
+    fn set_acked_features(&mut self, acked_features: u64) {
+        self.acked_features = acked_features
+    }
+
+    fn device_type(&self) -> u32 {
+        uapi::VIRTIO_ID_MSB_CPU
+    }
+
+    fn device_name(&self) -> &str {
+        "msb-cpu"
+    }
+
+    fn queue_config(&self) -> &[QueueConfig] {
+        &defs::QUEUE_CONFIG
+    }
+
+    fn read_config(&self, offset: u64, mut data: &mut [u8]) {
+        let config_slice = self.config.as_slice();
+        let config_len = config_slice.len() as u64;
+        if offset >= config_len {
+            error!("virtio-msb-cpu: failed to read config space");
+            return;
+        }
+        if let Some(end) = offset.checked_add(data.len() as u64) {
+            // This write can't fail, offset and end are checked against config_len.
+            data.write_all(&config_slice[offset as usize..cmp::min(end, config_len) as usize])
+                .unwrap();
+        }
+    }
+
+    fn write_config(&mut self, offset: u64, data: &[u8]) {
+        // The guest driver reports the online count it converged on; that is
+        // the only writable field.
+        if offset == CONFIG_ACTUAL_ONLINE_OFFSET && data.len() == 4 {
+            self.config.actual_online = u32::from_le_bytes(data.try_into().unwrap());
+            return;
+        }
+        warn!(
+            "virtio-msb-cpu: rejected guest config write (offset={:x}, len={:x})",
+            offset,
+            data.len()
+        );
+    }
+
+    fn activate(
+        &mut self,
+        mem: GuestMemoryMmap,
+        interrupt: InterruptTransport,
+        queues: Vec<DeviceQueue>,
+    ) -> ActivateResult {
+        if queues.len() != defs::NUM_QUEUES {
+            error!(
+                "Cannot perform activate. Expected {} queue(s), got {}",
+                defs::NUM_QUEUES,
+                queues.len()
+            );
+            return Err(ActivateError::BadActivate);
+        }
+
+        if self.activate_evt.write(1).is_err() {
+            error!("Cannot write to activate_evt");
+            return Err(ActivateError::BadActivate);
+        }
+
+        self.queues = Some(queues);
+        self.device_state = DeviceState::Activated(mem, interrupt);
+
+        Ok(())
+    }
+
+    fn is_activated(&self) -> bool {
+        self.device_state.is_activated()
+    }
+}

--- a/src/devices/src/virtio/cpu/device.rs
+++ b/src/devices/src/virtio/cpu/device.rs
@@ -1,7 +1,9 @@
 use std::cmp;
 use std::io::Write;
-use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use utils::eventfd::EventFd;
 use vm_memory::{ByteValued, GuestMemoryMmap};
@@ -25,6 +27,18 @@ pub const ENFORCEMENT_GRACE: std::time::Duration = std::time::Duration::from_sec
 /// guest — cross-CPU synchronization (IPIs, TLB shootdowns, RCU) waits forever for the parked CPU, wedging the initiating CPUs too. Waking for one emulation step per park
 /// interval keeps that machinery draining at a duty cycle too small to matter for compute.
 pub const THROTTLE_PARK: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// How long an enforced vCPU may stay inside a single emulation step before the kicker forces it back to the host.
+///
+/// A hard-spinning guest takes no VM exits at all (on HVF even the vtimer is hardware-virtualized), so without a forced exit an enforced vCPU's run loop would never observe
+/// enforcement. Together with [`THROTTLE_PARK`] this bounds an uncooperative vCPU's duty cycle to roughly `slice / (slice + park)`.
+const ENFORCED_RUN_SLICE: Duration = Duration::from_millis(5);
+
+/// How often the kicker thread scans for enforced vCPUs overstaying their run slice. It only runs while some vCPU is enforced off.
+const KICK_INTERVAL: Duration = Duration::from_millis(5);
+
+/// Sentinel for [`CpuKickSlot::entered_ns`]: the vCPU is not inside an emulation step.
+const NOT_IN_GUEST: u64 = u64::MAX;
 
 // Config space offsets (three little-endian u32 fields).
 const CONFIG_ACTUAL_ONLINE_OFFSET: u64 = 8;
@@ -50,24 +64,127 @@ unsafe impl ByteValued for VirtioCpuConfig {}
 /// the dying CPU to execute its own PSCI CPU_OFF path. The boot CPU is always
 /// runnable: `enforced` is clamped to at least 1.
 pub struct CpuEnforcement {
+    possible: u32,
     enforced: AtomicU32,
     gate: Mutex<()>,
     raised: Condvar,
+    kick_slots: Mutex<Vec<Arc<CpuKickSlot>>>,
+    kicker_running: AtomicBool,
+}
+
+/// A vCPU's registration with the enforcement kicker.
+///
+/// The vCPU run loop brackets every emulation step with [`enter_guest`](Self::enter_guest)/[`leave_guest`](Self::leave_guest); the kicker forces an exit only on vCPUs that
+/// have been inside one step longer than [`ENFORCED_RUN_SLICE`], so parked or event-waiting vCPUs never accumulate spurious cancellations that would swallow their next
+/// (progress-making) emulation step.
+pub struct CpuKickSlot {
+    cpu_index: u32,
+    /// Monotonic timestamp (ns) when the current emulation step started, or [`NOT_IN_GUEST`].
+    entered_ns: AtomicU64,
+    kick: Box<dyn Fn() + Send + Sync>,
+}
+
+impl CpuKickSlot {
+    /// Mark this vCPU as entering an emulation step.
+    pub fn enter_guest(&self) {
+        self.entered_ns.store(monotonic_ns(), Ordering::Release);
+    }
+
+    /// Mark this vCPU as back on the host.
+    pub fn leave_guest(&self) {
+        self.entered_ns.store(NOT_IN_GUEST, Ordering::Release);
+    }
 }
 
 impl CpuEnforcement {
-    fn new(enforced: u32) -> Arc<Self> {
+    fn new(possible: u32, enforced: u32) -> Arc<Self> {
         Arc::new(Self {
+            possible,
             enforced: AtomicU32::new(enforced.max(1)),
             gate: Mutex::new(()),
             raised: Condvar::new(),
+            kick_slots: Mutex::new(Vec::new()),
+            kicker_running: AtomicBool::new(false),
         })
     }
 
-    fn set(&self, enforced: u32) {
-        self.enforced.store(enforced.max(1), Ordering::Release);
-        let _guard = self.gate.lock().unwrap();
-        self.raised.notify_all();
+    fn set(this: &Arc<Self>, enforced: u32) {
+        let enforced = enforced.max(1);
+        this.enforced.store(enforced, Ordering::Release);
+        {
+            let _guard = this.gate.lock().unwrap();
+            this.raised.notify_all();
+        }
+        if enforced < this.possible {
+            Self::spawn_kicker(this);
+        }
+    }
+
+    /// Register the calling vCPU thread for forced exits. `kick` must make the vCPU's in-flight emulation step return to the host (`hv_vcpus_exit` on macOS, the vCPU kick
+    /// signal on Linux) and be callable from any thread.
+    pub fn register_kicker(
+        self: &Arc<Self>,
+        cpu_index: u32,
+        kick: Box<dyn Fn() + Send + Sync>,
+    ) -> Arc<CpuKickSlot> {
+        let slot = Arc::new(CpuKickSlot {
+            cpu_index,
+            entered_ns: AtomicU64::new(NOT_IN_GUEST),
+            kick,
+        });
+        self.kick_slots.lock().unwrap().push(slot.clone());
+        // The VM may boot (or a guest may CPU_ON a vCPU) with enforcement already below the possible count; make sure the kicker covers that from the start.
+        if self.enforced() < self.possible {
+            Self::spawn_kicker(self);
+        }
+        slot
+    }
+
+    /// Start the kicker thread if some vCPU is enforced off and no kicker is running.
+    ///
+    /// The kicker periodically forces enforced vCPUs that overstay [`ENFORCED_RUN_SLICE`] out of guest mode so their run loops observe enforcement even when the guest takes
+    /// no VM exits on its own. It exits once enforcement covers every possible vCPU again (holding only a `Weak`, so it also dies with the device).
+    fn spawn_kicker(this: &Arc<Self>) {
+        if this
+            .kicker_running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let weak = Arc::downgrade(this);
+        thread::Builder::new()
+            .name("msb-cpu kicker".into())
+            .spawn(move || loop {
+                thread::sleep(KICK_INTERVAL);
+                let Some(this) = weak.upgrade() else { return };
+                let enforced = this.enforced();
+                if enforced >= this.possible {
+                    this.kicker_running.store(false, Ordering::Release);
+                    // set() may have lowered enforcement between the check above and the store; reclaim the flag rather than leave that lowering unkicked.
+                    if this.enforced() < this.possible
+                        && this
+                            .kicker_running
+                            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                            .is_ok()
+                    {
+                        continue;
+                    }
+                    return;
+                }
+                let now = monotonic_ns();
+                let slice_ns = ENFORCED_RUN_SLICE.as_nanos() as u64;
+                for slot in this.kick_slots.lock().unwrap().iter() {
+                    if slot.cpu_index < enforced {
+                        continue;
+                    }
+                    let entered = slot.entered_ns.load(Ordering::Acquire);
+                    if entered != NOT_IN_GUEST && now.saturating_sub(entered) >= slice_ns {
+                        (slot.kick)();
+                    }
+                }
+            })
+            .expect("failed to spawn msb-cpu kicker thread");
     }
 
     /// Current enforced online count.
@@ -95,6 +212,12 @@ impl CpuEnforcement {
             guard = next;
         }
     }
+}
+
+/// Monotonic nanoseconds since the first call; only ever compared against itself.
+fn monotonic_ns() -> u64 {
+    static EPOCH: OnceLock<Instant> = OnceLock::new();
+    EPOCH.get_or_init(Instant::now).elapsed().as_nanos() as u64
 }
 
 /// Point-in-time view of the device for host-side control and reporting.
@@ -139,7 +262,7 @@ impl Cpu {
                 requested_online: initial_online,
                 actual_online: initial_online,
             },
-            enforcement: CpuEnforcement::new(initial_online),
+            enforcement: CpuEnforcement::new(possible, initial_online),
         })
     }
 
@@ -159,7 +282,7 @@ impl Cpu {
     pub fn set_requested_online(&mut self, online: u32) -> u32 {
         let online = cmp::min(online.max(1), self.config.possible);
         self.config.requested_online = online;
-        self.enforcement.set(online);
+        CpuEnforcement::set(&self.enforcement, online);
         if let DeviceState::Activated(_, ref interrupt) = self.device_state {
             interrupt.signal_config_change();
         }

--- a/src/devices/src/virtio/cpu/device.rs
+++ b/src/devices/src/virtio/cpu/device.rs
@@ -16,8 +16,15 @@ use crate::virtio::InterruptTransport;
 pub(crate) const BASE_AVAIL_FEATURES: u64 = 1 << uapi::VIRTIO_F_VERSION_1 as u64;
 
 /// How long a vCPU above the enforced count keeps running before it is
-/// hard-parked, giving a cooperative guest time to offline it cleanly.
+/// throttled, giving a cooperative guest time to offline it cleanly.
 pub const ENFORCEMENT_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// How long an enforced-off vCPU parks between emulation steps once the grace window expires.
+///
+/// Enforcement throttles instead of freezing the vCPU outright: a guest without the msb-cpu driver keeps the CPU online, and fully parking an online CPU deadlocks the whole
+/// guest — cross-CPU synchronization (IPIs, TLB shootdowns, RCU) waits forever for the parked CPU, wedging the initiating CPUs too. Waking for one emulation step per park
+/// interval keeps that machinery draining at a duty cycle too small to matter for compute.
+pub const THROTTLE_PARK: std::time::Duration = std::time::Duration::from_millis(100);
 
 // Config space offsets (three little-endian u32 fields).
 const CONFIG_ACTUAL_ONLINE_OFFSET: u64 = 8;
@@ -35,12 +42,13 @@ unsafe impl ByteValued for VirtioCpuConfig {}
 
 /// Host-authoritative CPU count shared with every vCPU run loop.
 ///
-/// vCPUs whose index is at or above `enforced` park between emulation steps
-/// until the count is raised again, so a guest that refuses to offline a CPU
-/// stops receiving execution time on it anyway. Run loops grant a short grace
-/// window ([`ENFORCEMENT_GRACE`]) before hard-parking, because a graceful
-/// offline needs the dying CPU to execute its own PSCI CPU_OFF path. The boot
-/// CPU is always runnable: `enforced` is clamped to at least 1.
+/// vCPUs whose index is at or above `enforced` are throttled between emulation
+/// steps until the count is raised again, so a guest that refuses to offline a
+/// CPU loses almost all execution time on it while the guest as a whole stays
+/// live (see [`THROTTLE_PARK`]). Run loops grant a short grace window
+/// ([`ENFORCEMENT_GRACE`]) before throttling, because a graceful offline needs
+/// the dying CPU to execute its own PSCI CPU_OFF path. The boot CPU is always
+/// runnable: `enforced` is clamped to at least 1.
 pub struct CpuEnforcement {
     enforced: AtomicU32,
     gate: Mutex<()>,
@@ -73,11 +81,18 @@ impl CpuEnforcement {
         cpu_index < self.enforced()
     }
 
-    /// Park the calling vCPU thread until its index becomes runnable again.
-    pub fn wait_until_runnable(&self, cpu_index: u32) {
+    /// Park the calling vCPU thread for one throttle interval ([`THROTTLE_PARK`]), returning early if its index becomes runnable. The caller runs one emulation step
+    /// between parks so guest-wide synchronization that involves this CPU still completes.
+    pub fn throttle(&self, cpu_index: u32) {
+        let deadline = std::time::Instant::now() + THROTTLE_PARK;
         let mut guard = self.gate.lock().unwrap();
         while cpu_index >= self.enforced.load(Ordering::Acquire) {
-            guard = self.raised.wait(guard).unwrap();
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return;
+            }
+            let (next, _timeout) = self.raised.wait_timeout(guard, deadline - now).unwrap();
+            guard = next;
         }
     }
 }

--- a/src/devices/src/virtio/cpu/event_handler.rs
+++ b/src/devices/src/virtio/cpu/event_handler.rs
@@ -1,0 +1,72 @@
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
+
+use polly::event_manager::{EventManager, Pollable, Subscriber};
+use utils::epoll::{EpollEvent, EventSet};
+
+use super::device::Cpu;
+
+impl Cpu {
+    fn queue_event(&self, idx: usize) -> &std::sync::Arc<utils::eventfd::EventFd> {
+        &self.queues.as_ref().expect("queues should exist")[idx].event
+    }
+
+    fn handle_activate_event(&mut self, event_manager: &mut EventManager) {
+        debug!("virtio-msb-cpu: activate event");
+        if let Err(e) = self.activate_evt.read() {
+            error!("Failed to consume virtio-msb-cpu activate event: {e:?}");
+        }
+        // All host<->guest communication happens through config space; the
+        // declared queue exists only to satisfy transport expectations, so
+        // there is nothing further to register.
+        let activate_evt = eventfd_pollable(&self.activate_evt);
+        event_manager.unregister(activate_evt).unwrap_or_else(|e| {
+            error!("Failed to unregister virtio-msb-cpu activate evt: {e:?}");
+        })
+    }
+}
+
+impl Subscriber for Cpu {
+    fn process(&mut self, event: &EpollEvent, event_manager: &mut EventManager) {
+        let source = event.fd();
+        let activate_evt = eventfd_pollable(&self.activate_evt);
+        let req = eventfd_pollable(self.queue_event(0));
+
+        if source == activate_evt {
+            self.handle_activate_event(event_manager);
+        } else if source == req {
+            let _ = self.queue_event(0).read();
+        } else {
+            warn!("Unexpected virtio-msb-cpu event received: {source:?}");
+        }
+    }
+
+    fn interest_list(&self) -> Vec<EpollEvent> {
+        vec![EpollEvent::new(
+            EventSet::IN,
+            pollable_token(eventfd_pollable(&self.activate_evt)),
+        )]
+    }
+}
+
+#[cfg(unix)]
+fn eventfd_pollable(event: &utils::eventfd::EventFd) -> Pollable {
+    event.as_raw_fd()
+}
+
+#[cfg(windows)]
+fn eventfd_pollable(event: &utils::eventfd::EventFd) -> Pollable {
+    event.as_raw_handle()
+}
+
+#[cfg(unix)]
+fn pollable_token(pollable: Pollable) -> u64 {
+    pollable as u64
+}
+
+#[cfg(windows)]
+fn pollable_token(pollable: Pollable) -> u64 {
+    pollable as usize as u64
+}

--- a/src/devices/src/virtio/cpu/mod.rs
+++ b/src/devices/src/virtio/cpu/mod.rs
@@ -2,7 +2,7 @@ mod device;
 mod event_handler;
 
 pub use self::defs::uapi::VIRTIO_ID_MSB_CPU as TYPE_MSB_CPU;
-pub use self::device::{Cpu, CpuEnforcement, CpuStateSnapshot, ENFORCEMENT_GRACE};
+pub use self::device::{Cpu, CpuEnforcement, CpuStateSnapshot, ENFORCEMENT_GRACE, THROTTLE_PARK};
 
 mod defs {
     use super::super::QueueConfig;

--- a/src/devices/src/virtio/cpu/mod.rs
+++ b/src/devices/src/virtio/cpu/mod.rs
@@ -2,7 +2,9 @@ mod device;
 mod event_handler;
 
 pub use self::defs::uapi::VIRTIO_ID_MSB_CPU as TYPE_MSB_CPU;
-pub use self::device::{Cpu, CpuEnforcement, CpuStateSnapshot, ENFORCEMENT_GRACE, THROTTLE_PARK};
+pub use self::device::{
+    Cpu, CpuEnforcement, CpuKickSlot, CpuStateSnapshot, ENFORCEMENT_GRACE, THROTTLE_PARK,
+};
 
 mod defs {
     use super::super::QueueConfig;

--- a/src/devices/src/virtio/cpu/mod.rs
+++ b/src/devices/src/virtio/cpu/mod.rs
@@ -1,0 +1,27 @@
+mod device;
+mod event_handler;
+
+pub use self::defs::uapi::VIRTIO_ID_MSB_CPU as TYPE_MSB_CPU;
+pub use self::device::{Cpu, CpuEnforcement, CpuStateSnapshot, ENFORCEMENT_GRACE};
+
+mod defs {
+    use super::super::QueueConfig;
+
+    pub const CPU_DEV_ID: &str = "virtio_msb_cpu";
+    pub const NUM_QUEUES: usize = 1;
+    pub const QUEUE_SIZE: u16 = 16;
+    pub static QUEUE_CONFIG: [QueueConfig; NUM_QUEUES] = [QueueConfig::new(QUEUE_SIZE); NUM_QUEUES];
+
+    pub mod uapi {
+        pub const VIRTIO_F_VERSION_1: u32 = 32;
+        pub const VIRTIO_ID_MSB_CPU: u32 = 0x4d43;
+    }
+}
+
+#[derive(Debug)]
+pub enum CpuDeviceError {
+    /// Failed to create event fd.
+    EventFd(std::io::Error),
+}
+
+type Result<T> = std::result::Result<T, CpuDeviceError>;

--- a/src/devices/src/virtio/mem/device.rs
+++ b/src/devices/src/virtio/mem/device.rs
@@ -123,7 +123,9 @@ impl Mem {
     /// Set the guest-physical placement of the hotplug region. Must be called
     /// before the VM boots; both values must be block-aligned.
     pub fn set_region(&mut self, addr: u64, size: u64) -> super::Result<()> {
-        if addr % VIRTIO_MEM_BLOCK_SIZE != 0 || size % VIRTIO_MEM_BLOCK_SIZE != 0 {
+        if !addr.is_multiple_of(VIRTIO_MEM_BLOCK_SIZE)
+            || !size.is_multiple_of(VIRTIO_MEM_BLOCK_SIZE)
+        {
             return Err(MemError::UnalignedRegion);
         }
         self.config.addr = addr;
@@ -160,7 +162,7 @@ impl Mem {
     /// Map a guest request range onto block indices, if fully inside the region.
     fn block_range(&self, addr: u64, nb_blocks: u16) -> Option<std::ops::Range<usize>> {
         let offset = addr.checked_sub(self.config.addr)?;
-        if offset % VIRTIO_MEM_BLOCK_SIZE != 0 {
+        if !offset.is_multiple_of(VIRTIO_MEM_BLOCK_SIZE) {
             return None;
         }
         let first = (offset / VIRTIO_MEM_BLOCK_SIZE) as usize;

--- a/src/devices/src/virtio/mem/device.rs
+++ b/src/devices/src/virtio/mem/device.rs
@@ -1,0 +1,413 @@
+use std::cmp;
+use std::io::Write;
+
+use utils::eventfd::EventFd;
+use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemoryBackend, GuestMemoryMmap};
+
+use super::super::{
+    ActivateError, ActivateResult, DeviceQueue, DeviceState, MemError, QueueConfig, VirtioDevice,
+};
+use super::{defs, defs::uapi};
+use crate::virtio::InterruptTransport;
+
+// Request queue.
+pub(crate) const REQ_INDEX: usize = 0;
+
+/// Hot(un)plug granularity. 2 MiB satisfies the Linux driver's requirement of
+/// max(page size, pageblock size) on 4K x86_64 and aarch64 kernels.
+pub const VIRTIO_MEM_BLOCK_SIZE: u64 = 2 << 20;
+
+// Guest request types.
+const VIRTIO_MEM_REQ_PLUG: u16 = 0;
+const VIRTIO_MEM_REQ_UNPLUG: u16 = 1;
+const VIRTIO_MEM_REQ_UNPLUG_ALL: u16 = 2;
+const VIRTIO_MEM_REQ_STATE: u16 = 3;
+
+// Response types.
+const VIRTIO_MEM_RESP_ACK: u16 = 0;
+const VIRTIO_MEM_RESP_NACK: u16 = 1;
+const VIRTIO_MEM_RESP_ERROR: u16 = 3;
+
+// STATE response payloads.
+const VIRTIO_MEM_STATE_PLUGGED: u16 = 0;
+const VIRTIO_MEM_STATE_UNPLUGGED: u16 = 1;
+const VIRTIO_MEM_STATE_MIXED: u16 = 2;
+
+pub(crate) const BASE_AVAIL_FEATURES: u64 = 1 << uapi::VIRTIO_F_VERSION_1 as u64;
+
+#[derive(Copy, Clone, Debug, Default)]
+#[repr(C, packed)]
+struct VirtioMemConfig {
+    block_size: u64,
+    node_id: u16,
+    padding: [u8; 6],
+    addr: u64,
+    region_size: u64,
+    usable_region_size: u64,
+    plugged_size: u64,
+    requested_size: u64,
+}
+
+// Safe because it only has data and has no implicit padding.
+unsafe impl ByteValued for VirtioMemConfig {}
+
+#[derive(Copy, Clone, Debug, Default)]
+#[repr(C, packed)]
+struct VirtioMemReq {
+    req_type: u16,
+    padding: [u16; 3],
+    addr: u64,
+    nb_blocks: u16,
+    padding2: [u16; 3],
+}
+
+unsafe impl ByteValued for VirtioMemReq {}
+
+#[derive(Copy, Clone, Debug, Default)]
+#[repr(C, packed)]
+struct VirtioMemResp {
+    resp_type: u16,
+    padding: [u16; 3],
+    state: u16,
+}
+
+unsafe impl ByteValued for VirtioMemResp {}
+
+/// Point-in-time view of the device for host-side control and reporting.
+#[derive(Debug, Clone, Copy)]
+pub struct MemStateSnapshot {
+    /// Bytes the host asked the guest to converge on.
+    pub requested_size: u64,
+
+    /// Bytes the guest currently has plugged.
+    pub plugged_size: u64,
+
+    /// Total hotpluggable capacity in bytes.
+    pub region_size: u64,
+}
+
+pub struct Mem {
+    pub(crate) queues: Option<Vec<DeviceQueue>>,
+    pub(crate) avail_features: u64,
+    pub(crate) acked_features: u64,
+    pub(crate) activate_evt: EventFd,
+    pub(crate) device_state: DeviceState,
+    config: VirtioMemConfig,
+    /// One bit per block; set = plugged.
+    plugged_blocks: Vec<bool>,
+}
+
+impl Mem {
+    /// Create a virtio-mem device. The hotplug region location is supplied
+    /// later through [`set_region`](Self::set_region) once the memory layout
+    /// is known; `requested_size` starts at zero until the host raises it.
+    pub fn new() -> super::Result<Mem> {
+        Ok(Mem {
+            queues: None,
+            avail_features: BASE_AVAIL_FEATURES,
+            acked_features: 0,
+            activate_evt: EventFd::new(utils::eventfd::EFD_NONBLOCK).map_err(MemError::EventFd)?,
+            device_state: DeviceState::Inactive,
+            config: VirtioMemConfig {
+                block_size: VIRTIO_MEM_BLOCK_SIZE,
+                ..Default::default()
+            },
+            plugged_blocks: Vec::new(),
+        })
+    }
+
+    pub fn id(&self) -> &str {
+        defs::MEM_DEV_ID
+    }
+
+    /// Set the guest-physical placement of the hotplug region. Must be called
+    /// before the VM boots; both values must be block-aligned.
+    pub fn set_region(&mut self, addr: u64, size: u64) -> super::Result<()> {
+        if addr % VIRTIO_MEM_BLOCK_SIZE != 0 || size % VIRTIO_MEM_BLOCK_SIZE != 0 {
+            return Err(MemError::UnalignedRegion);
+        }
+        self.config.addr = addr;
+        self.config.region_size = size;
+        self.config.usable_region_size = size;
+        self.plugged_blocks = vec![false; (size / VIRTIO_MEM_BLOCK_SIZE) as usize];
+        Ok(())
+    }
+
+    /// Host control: ask the guest to converge on `size` plugged bytes. Rounds
+    /// down to block granularity and caps at the region size. Signals a config
+    /// change when the device is active.
+    pub fn set_requested_size(&mut self, size: u64) -> u64 {
+        let size = cmp::min(
+            size - (size % VIRTIO_MEM_BLOCK_SIZE),
+            self.config.region_size,
+        );
+        self.config.requested_size = size;
+        if let DeviceState::Activated(_, ref interrupt) = self.device_state {
+            interrupt.signal_config_change();
+        }
+        size
+    }
+
+    /// Host control: current requested/plugged/capacity view.
+    pub fn state_snapshot(&self) -> MemStateSnapshot {
+        MemStateSnapshot {
+            requested_size: self.config.requested_size,
+            plugged_size: self.config.plugged_size,
+            region_size: self.config.region_size,
+        }
+    }
+
+    /// Map a guest request range onto block indices, if fully inside the region.
+    fn block_range(&self, addr: u64, nb_blocks: u16) -> Option<std::ops::Range<usize>> {
+        let offset = addr.checked_sub(self.config.addr)?;
+        if offset % VIRTIO_MEM_BLOCK_SIZE != 0 {
+            return None;
+        }
+        let first = (offset / VIRTIO_MEM_BLOCK_SIZE) as usize;
+        let end = first.checked_add(nb_blocks as usize)?;
+        if end > self.plugged_blocks.len() {
+            return None;
+        }
+        Some(first..end)
+    }
+
+    fn handle_plug(&mut self, addr: u64, nb_blocks: u16) -> VirtioMemResp {
+        let Some(range) = self.block_range(addr, nb_blocks) else {
+            return resp(VIRTIO_MEM_RESP_ERROR, 0);
+        };
+        let add = nb_blocks as u64 * VIRTIO_MEM_BLOCK_SIZE;
+        if self.config.plugged_size + add > self.config.requested_size
+            || self.plugged_blocks[range.clone()].iter().any(|b| *b)
+        {
+            return resp(VIRTIO_MEM_RESP_NACK, 0);
+        }
+        for block in &mut self.plugged_blocks[range] {
+            *block = true;
+        }
+        self.config.plugged_size += add;
+        resp(VIRTIO_MEM_RESP_ACK, 0)
+    }
+
+    fn handle_unplug(&mut self, addr: u64, nb_blocks: u16) -> VirtioMemResp {
+        let Some(range) = self.block_range(addr, nb_blocks) else {
+            return resp(VIRTIO_MEM_RESP_ERROR, 0);
+        };
+        if self.plugged_blocks[range.clone()].iter().any(|b| !*b) {
+            return resp(VIRTIO_MEM_RESP_NACK, 0);
+        }
+        for block in &mut self.plugged_blocks[range.clone()] {
+            *block = false;
+        }
+        self.config.plugged_size -= nb_blocks as u64 * VIRTIO_MEM_BLOCK_SIZE;
+        self.discard_range(addr, nb_blocks as u64 * VIRTIO_MEM_BLOCK_SIZE);
+        resp(VIRTIO_MEM_RESP_ACK, 0)
+    }
+
+    fn handle_unplug_all(&mut self) -> VirtioMemResp {
+        let addr = self.config.addr;
+        let size = self.config.region_size;
+        for block in &mut self.plugged_blocks {
+            *block = false;
+        }
+        self.config.plugged_size = 0;
+        self.discard_range(addr, size);
+        resp(VIRTIO_MEM_RESP_ACK, 0)
+    }
+
+    fn handle_state(&self, addr: u64, nb_blocks: u16) -> VirtioMemResp {
+        let Some(range) = self.block_range(addr, nb_blocks) else {
+            return resp(VIRTIO_MEM_RESP_ERROR, 0);
+        };
+        let plugged = self.plugged_blocks[range.clone()]
+            .iter()
+            .filter(|b| **b)
+            .count();
+        let state = if plugged == range.len() {
+            VIRTIO_MEM_STATE_PLUGGED
+        } else if plugged == 0 {
+            VIRTIO_MEM_STATE_UNPLUGGED
+        } else {
+            VIRTIO_MEM_STATE_MIXED
+        };
+        resp(VIRTIO_MEM_RESP_ACK, state)
+    }
+
+    /// Release the host pages backing an unplugged range. The mapping stays in
+    /// place (the region is a boot-time reservation); only residency is dropped.
+    fn discard_range(&self, guest_addr: u64, len: u64) {
+        let DeviceState::Activated(ref mem, _) = self.device_state else {
+            return;
+        };
+        let Ok(host_addr) = mem.get_host_address(GuestAddress(guest_addr)) else {
+            error!("virtio-mem: no host mapping for guest addr {guest_addr:#x}");
+            return;
+        };
+        if let Err(e) = discard_host_pages(host_addr, len as usize) {
+            error!("virtio-mem: failed to discard {len} bytes at {guest_addr:#x}: {e}");
+        }
+    }
+
+    pub fn process_req_queue(&mut self) -> bool {
+        let mem = match self.device_state {
+            DeviceState::Activated(ref mem, _) => mem.clone(),
+            DeviceState::Inactive => unreachable!(),
+        };
+
+        let mut have_used = false;
+        loop {
+            let head = {
+                let queues = self
+                    .queues
+                    .as_mut()
+                    .expect("queues should exist when activated");
+                match queues[REQ_INDEX].queue.pop(&mem) {
+                    Some(head) => head,
+                    None => break,
+                }
+            };
+            let index = head.index;
+
+            let mut req = VirtioMemReq::default();
+            let mut resp_addr = None;
+            for desc in head.into_iter() {
+                if desc.is_write_only() {
+                    resp_addr = Some(desc.addr);
+                } else if mem.read_obj::<VirtioMemReq>(desc.addr).is_ok() {
+                    req = mem.read_obj(desc.addr).unwrap();
+                }
+            }
+
+            let response = match req.req_type {
+                VIRTIO_MEM_REQ_PLUG => self.handle_plug(req.addr, req.nb_blocks),
+                VIRTIO_MEM_REQ_UNPLUG => self.handle_unplug(req.addr, req.nb_blocks),
+                VIRTIO_MEM_REQ_UNPLUG_ALL => self.handle_unplug_all(),
+                VIRTIO_MEM_REQ_STATE => self.handle_state(req.addr, req.nb_blocks),
+                other => {
+                    error!("virtio-mem: unknown request type {other}");
+                    resp(VIRTIO_MEM_RESP_ERROR, 0)
+                }
+            };
+
+            let mut written = 0;
+            if let Some(addr) = resp_addr {
+                if let Err(e) = mem.write_obj(response, addr) {
+                    error!("virtio-mem: failed to write response: {e}");
+                } else {
+                    written = std::mem::size_of::<VirtioMemResp>() as u32;
+                }
+            }
+
+            have_used = true;
+            let queues = self
+                .queues
+                .as_mut()
+                .expect("queues should exist when activated");
+            if let Err(e) = queues[REQ_INDEX].queue.add_used(&mem, index, written) {
+                error!("virtio-mem: failed to add used element: {e:?}");
+            }
+        }
+
+        have_used
+    }
+}
+
+fn resp(resp_type: u16, state: u16) -> VirtioMemResp {
+    VirtioMemResp {
+        resp_type,
+        padding: [0; 3],
+        state,
+    }
+}
+
+#[cfg(unix)]
+fn discard_host_pages(host_addr: *mut u8, len: usize) -> std::io::Result<()> {
+    let ret = unsafe { libc::madvise(host_addr as *mut libc::c_void, len, libc::MADV_DONTNEED) };
+    if ret < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn discard_host_pages(host_addr: *mut u8, len: usize) -> std::io::Result<()> {
+    unsafe { crate::windows::memory_mapping::discard_virtual_memory_range(host_addr.cast(), len) }
+}
+
+impl VirtioDevice for Mem {
+    fn avail_features(&self) -> u64 {
+        self.avail_features
+    }
+
+    fn acked_features(&self) -> u64 {
+        self.acked_features
+    }
+
+    fn set_acked_features(&mut self, acked_features: u64) {
+        self.acked_features = acked_features
+    }
+
+    fn device_type(&self) -> u32 {
+        uapi::VIRTIO_ID_MEM
+    }
+
+    fn device_name(&self) -> &str {
+        "mem"
+    }
+
+    fn queue_config(&self) -> &[QueueConfig] {
+        &defs::QUEUE_CONFIG
+    }
+
+    fn read_config(&self, offset: u64, mut data: &mut [u8]) {
+        let config_slice = self.config.as_slice();
+        let config_len = config_slice.len() as u64;
+        if offset >= config_len {
+            error!("virtio-mem: failed to read config space");
+            return;
+        }
+        if let Some(end) = offset.checked_add(data.len() as u64) {
+            // This write can't fail, offset and end are checked against config_len.
+            data.write_all(&config_slice[offset as usize..cmp::min(end, config_len) as usize])
+                .unwrap();
+        }
+    }
+
+    fn write_config(&mut self, offset: u64, data: &[u8]) {
+        warn!(
+            "virtio-mem: guest driver attempted to write device config (offset={:x}, len={:x})",
+            offset,
+            data.len()
+        );
+    }
+
+    fn activate(
+        &mut self,
+        mem: GuestMemoryMmap,
+        interrupt: InterruptTransport,
+        queues: Vec<DeviceQueue>,
+    ) -> ActivateResult {
+        if queues.len() != defs::NUM_QUEUES {
+            error!(
+                "Cannot perform activate. Expected {} queue(s), got {}",
+                defs::NUM_QUEUES,
+                queues.len()
+            );
+            return Err(ActivateError::BadActivate);
+        }
+
+        if self.activate_evt.write(1).is_err() {
+            error!("Cannot write to activate_evt");
+            return Err(ActivateError::BadActivate);
+        }
+
+        self.queues = Some(queues);
+        self.device_state = DeviceState::Activated(mem, interrupt);
+
+        Ok(())
+    }
+
+    fn is_activated(&self) -> bool {
+        self.device_state.is_activated()
+    }
+}

--- a/src/devices/src/virtio/mem/event_handler.rs
+++ b/src/devices/src/virtio/mem/event_handler.rs
@@ -1,0 +1,106 @@
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
+
+use polly::event_manager::{EventManager, Pollable, Subscriber};
+use utils::epoll::{EpollEvent, EventSet};
+
+use super::device::{Mem, REQ_INDEX};
+use crate::virtio::device::VirtioDevice;
+
+impl Mem {
+    fn queue_event(&self, idx: usize) -> &std::sync::Arc<utils::eventfd::EventFd> {
+        &self.queues.as_ref().expect("queues should exist")[idx].event
+    }
+
+    pub(crate) fn handle_req_event(&mut self, event: &EpollEvent) {
+        debug!("virtio-mem: request queue event");
+
+        let event_set = event.event_set();
+        if event_set != EventSet::IN {
+            warn!("virtio-mem: request queue unexpected event {event_set:?}");
+            return;
+        }
+
+        if let Err(e) = self.queue_event(REQ_INDEX).read() {
+            error!("Failed to read virtio-mem request queue event: {e:?}");
+        } else if self.process_req_queue() {
+            self.device_state.signal_used_queue();
+        }
+    }
+
+    fn handle_activate_event(&mut self, event_manager: &mut EventManager) {
+        debug!("virtio-mem: activate event");
+        if let Err(e) = self.activate_evt.read() {
+            error!("Failed to consume virtio-mem activate event: {e:?}");
+        }
+
+        // The subscriber must exist as we previously registered activate_evt via
+        // `interest_list()`.
+        let activate_evt = eventfd_pollable(&self.activate_evt);
+        let self_subscriber = event_manager.subscriber(activate_evt).unwrap();
+
+        let req = eventfd_pollable(self.queue_event(REQ_INDEX));
+
+        event_manager
+            .register(req, pollable_event(req), self_subscriber.clone())
+            .unwrap_or_else(|e| {
+                error!("Failed to register virtio-mem request queue with event manager: {e:?}");
+            });
+
+        event_manager.unregister(activate_evt).unwrap_or_else(|e| {
+            error!("Failed to unregister virtio-mem activate evt: {e:?}");
+        })
+    }
+}
+
+impl Subscriber for Mem {
+    fn process(&mut self, event: &EpollEvent, event_manager: &mut EventManager) {
+        let source = event.fd();
+        let req = eventfd_pollable(self.queue_event(REQ_INDEX));
+        let activate_evt = eventfd_pollable(&self.activate_evt);
+
+        if self.is_activated() {
+            match source {
+                _ if source == req => self.handle_req_event(event),
+                _ if source == activate_evt => {
+                    self.handle_activate_event(event_manager);
+                }
+                _ => warn!("Unexpected virtio-mem event received: {source:?}"),
+            }
+        } else {
+            warn!(
+                "virtio-mem: The device is not yet activated. Spurious event received: {source:?}"
+            );
+        }
+    }
+
+    fn interest_list(&self) -> Vec<EpollEvent> {
+        vec![pollable_event(eventfd_pollable(&self.activate_evt))]
+    }
+}
+
+#[cfg(unix)]
+fn eventfd_pollable(event: &utils::eventfd::EventFd) -> Pollable {
+    event.as_raw_fd()
+}
+
+#[cfg(windows)]
+fn eventfd_pollable(event: &utils::eventfd::EventFd) -> Pollable {
+    event.as_raw_handle()
+}
+
+fn pollable_event(pollable: Pollable) -> EpollEvent {
+    EpollEvent::new(EventSet::IN, pollable_token(pollable))
+}
+
+#[cfg(unix)]
+fn pollable_token(pollable: Pollable) -> u64 {
+    pollable as u64
+}
+
+#[cfg(windows)]
+fn pollable_token(pollable: Pollable) -> u64 {
+    pollable as usize as u64
+}

--- a/src/devices/src/virtio/mem/mod.rs
+++ b/src/devices/src/virtio/mem/mod.rs
@@ -1,0 +1,29 @@
+mod device;
+mod event_handler;
+
+pub use self::defs::uapi::VIRTIO_ID_MEM as TYPE_MEM;
+pub use self::device::{Mem, MemStateSnapshot, VIRTIO_MEM_BLOCK_SIZE};
+
+mod defs {
+    use super::super::QueueConfig;
+
+    pub const MEM_DEV_ID: &str = "virtio_mem";
+    pub const NUM_QUEUES: usize = 1;
+    pub const QUEUE_SIZE: u16 = 128;
+    pub static QUEUE_CONFIG: [QueueConfig; NUM_QUEUES] = [QueueConfig::new(QUEUE_SIZE); NUM_QUEUES];
+
+    pub mod uapi {
+        pub const VIRTIO_F_VERSION_1: u32 = 32;
+        pub const VIRTIO_ID_MEM: u32 = 24;
+    }
+}
+
+#[derive(Debug)]
+pub enum MemError {
+    /// Failed to create event fd.
+    EventFd(std::io::Error),
+    /// The hotplug region size is not a multiple of the block size.
+    UnalignedRegion,
+}
+
+type Result<T> = std::result::Result<T, MemError>;

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -38,6 +38,8 @@ pub mod linux_errno {
         std::io::Error::from_raw_os_error(error.raw_os_error().unwrap_or(5))
     }
 }
+#[cfg(not(feature = "tee"))]
+pub mod mem;
 mod mmio;
 pub mod msb_metrics;
 #[cfg(feature = "net")]
@@ -60,6 +62,8 @@ pub use self::device::*;
 pub use self::fs::*;
 #[cfg(feature = "gpu")]
 pub use self::gpu::*;
+#[cfg(not(feature = "tee"))]
+pub use self::mem::*;
 pub use self::mmio::*;
 pub use self::msb_metrics::*;
 #[cfg(feature = "net")]

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -38,7 +38,9 @@ pub mod linux_errno {
         std::io::Error::from_raw_os_error(error.raw_os_error().unwrap_or(5))
     }
 }
-#[cfg(not(feature = "tee"))]
+// The CPU capacity module is compiled under every feature: TEE builds never
+// instantiate the device (extra capacity is rejected at config time), but the
+// vCPU run loops still reference its enforcement types unconditionally.
 pub mod cpu;
 #[cfg(not(feature = "tee"))]
 pub mod mem;
@@ -59,7 +61,6 @@ pub use self::balloon::*;
 #[cfg(feature = "blk")]
 pub use self::block::{Block, CacheType};
 pub use self::console::*;
-#[cfg(not(feature = "tee"))]
 pub use self::cpu::*;
 pub use self::device::*;
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -39,6 +39,8 @@ pub mod linux_errno {
     }
 }
 #[cfg(not(feature = "tee"))]
+pub mod cpu;
+#[cfg(not(feature = "tee"))]
 pub mod mem;
 mod mmio;
 pub mod msb_metrics;
@@ -57,6 +59,8 @@ pub use self::balloon::*;
 #[cfg(feature = "blk")]
 pub use self::block::{Block, CacheType};
 pub use self::console::*;
+#[cfg(not(feature = "tee"))]
+pub use self::cpu::*;
 pub use self::device::*;
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 pub use self::fs::*;

--- a/src/hvf/src/lib.rs
+++ b/src/hvf/src/lib.rs
@@ -65,6 +65,10 @@ const PSR_D_BIT: u64 = 0x0000_0200;
 const PSTATE_EL1_FAULT_BITS_64: u64 = PSR_MODE_EL1H | PSR_A_BIT | PSR_F_BIT | PSR_I_BIT | PSR_D_BIT;
 const PSTATE_EL2_FAULT_BITS_64: u64 = PSR_MODE_EL2H | PSR_A_BIT | PSR_F_BIT | PSR_I_BIT | PSR_D_BIT;
 
+// Architectural reset value of SCTLR_EL1: only the RES1 bits (11, 20, 22, 23, 28, 29)
+// set, so MMU, caches, and alignment checking are all disabled.
+const SCTLR_EL1_RES1: u64 = (1 << 11) | (1 << 20) | (1 << 22) | (1 << 23) | (1 << 28) | (1 << 29);
+
 const HCR_TLOR: u64 = 1 << 35;
 const HCR_RW: u64 = 1 << 31;
 const HCR_TSW: u64 = 1 << 22;
@@ -321,8 +325,10 @@ impl HvfVm {
 
 #[derive(Debug)]
 pub enum VcpuExit<'a> {
+    AffinityInfo(u64),
     Breakpoint,
     Canceled,
+    CpuOff,
     CpuOn(u64, u64, u64),
     HypervisorCall,
     MmioRead(u64, &'a mut [u8]),
@@ -482,6 +488,21 @@ impl HvfVcpu<'_> {
             if ret != HV_SUCCESS {
                 return Err(Error::VcpuInitialRegisters);
             }
+
+            // Restore SCTLR_EL1 to its architectural reset value (RES1 bits only, so
+            // MMU/caches off). A vCPU restarted by PSCI CPU_ON after a CPU_OFF still
+            // carries the MMU state of its previous life, but the guest enters at a
+            // physical entry address and expects translation disabled.
+            let ret = unsafe {
+                hv_vcpu_set_sys_reg(
+                    self.vcpuid,
+                    hv_sys_reg_t_HV_SYS_REG_SCTLR_EL1,
+                    SCTLR_EL1_RES1,
+                )
+            };
+            if ret != HV_SUCCESS {
+                return Err(Error::VcpuInitialRegisters);
+            }
         }
 
         let ret = unsafe { hv_vcpu_set_reg(self.vcpuid, hv_reg_t_HV_REG_PC, entry_addr) };
@@ -557,20 +578,39 @@ impl HvfVcpu<'_> {
         }
     }
 
+    /// Write a PSCI return value into the guest's X0. Used by exits like
+    /// `AffinityInfo` whose result the VMM computes outside this crate.
+    pub fn write_psci_result(&self, val: u64) -> Result<(), Error> {
+        self.write_reg(hv_reg_t_HV_REG_X0, val)
+    }
+
     fn handle_psci_request(&self) -> Result<VcpuExit<'_>, Error> {
         match self.read_reg(hv_reg_t_HV_REG_X0)? {
             0x8400_0000 /* QEMU_PSCI_0_2_FN_PSCI_VERSION */ => {
                 self.write_reg(hv_reg_t_HV_REG_X0, 2)?;
                 Ok(VcpuExit::PsciHandled)
             },
+            0x8400_0002 /* QEMU_PSCI_0_2_FN_CPU_OFF */ => {
+                // Success does not return to the caller: the vCPU parks until a
+                // later CPU_ON targets it again.
+                Ok(VcpuExit::CpuOff)
+            },
+            0x8400_0004 /* QEMU_PSCI_0_2_FN_AFFINITY_INFO */ |
+            0xc400_0004 /* QEMU_PSCI_0_2_FN64_AFFINITY_INFO */ => {
+                let mpidr = self.read_reg(hv_reg_t_HV_REG_X1)?;
+                // The VMM answers ON/OFF through `write_psci_result`.
+                Ok(VcpuExit::AffinityInfo(mpidr))
+            },
             0x8400_0006 /* QEMU_PSCI_0_2_FN_MIGRATE_INFO_TYPE */ => {
                 self.write_reg(hv_reg_t_HV_REG_X0, 2)?;
                 Ok(VcpuExit::PsciHandled)
             },
             0x8400_0008 /* QEMU_PSCI_0_2_FN_SYSTEM_OFF */ => {
+                debug!("PSCI SYSTEM_OFF on vcpu {}", self.vcpuid);
                 Ok(VcpuExit::Shutdown)
             },
             0x8400_0009 /* QEMU_PSCI_0_2_FN_SYSTEM_RESET */ => {
+                debug!("PSCI SYSTEM_RESET on vcpu {}", self.vcpuid);
                 Ok(VcpuExit::Shutdown)
             },
             0xc400_0003 /* QEMU_PSCI_0_2_FN64_CPU_ON */ => {

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -359,6 +359,27 @@ impl VmBuilder {
         vmr.set_vm_config(&vm_config)
             .map_err(|err| map_vm_config_error(&self.machine, err))?;
 
+        // Reserved CPU capacity is realized through the private msb-cpu device:
+        // the guest driver converges on the requested online count and the
+        // device's enforcement state parks vCPUs above it host-side.
+        #[cfg(not(feature = "tee"))]
+        if self
+            .machine
+            .max_vcpus
+            .is_some_and(|max| max > self.machine.vcpus)
+        {
+            let cpu = devices::virtio::Cpu::new(
+                self.machine.max_vcpus.unwrap_or(self.machine.vcpus) as u32,
+                self.machine.vcpus as u32,
+            )
+            .map_err(|e| {
+                Error::Build(BuildError::DeviceRegistration(format!(
+                    "virtio-msb-cpu: {e:?}"
+                )))
+            })?;
+            vmr.cpu_device = Some(std::sync::Arc::new(std::sync::Mutex::new(cpu)));
+        }
+
         // Reserved memory capacity is realized through a virtio-mem device; the
         // VMM places its hotplug region during boot and `Vm::control_handle`
         // exposes the live resize knob.

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -358,6 +358,21 @@ impl VmBuilder {
         };
         vmr.set_vm_config(&vm_config)
             .map_err(|err| map_vm_config_error(&self.machine, err))?;
+
+        // Reserved memory capacity is realized through a virtio-mem device; the
+        // VMM places its hotplug region during boot and `Vm::control_handle`
+        // exposes the live resize knob.
+        #[cfg(not(feature = "tee"))]
+        if self
+            .machine
+            .max_memory_mib
+            .is_some_and(|max| max > self.machine.memory_mib)
+        {
+            let mem = devices::virtio::Mem::new().map_err(|e| {
+                Error::Build(BuildError::DeviceRegistration(format!("virtio-mem: {e:?}")))
+            })?;
+            vmr.mem_device = Some(std::sync::Arc::new(std::sync::Mutex::new(mem)));
+        }
         vmr.nested_enabled = self.machine.nested_virt;
         vmr.split_irqchip = self.machine.split_irqchip;
         vmr.request_vsock = self.machine.vsock;

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -622,9 +622,7 @@ fn map_vm_config_error(machine: &MachineBuilder, err: VmConfigError) -> Error {
         VmConfigError::InvalidMaxMemorySize => Error::Config(ConfigError::InvalidMaxMemorySize(
             machine.max_memory_mib.unwrap_or(machine.memory_mib),
         )),
-        VmConfigError::MaxCapacityUnsupported => {
-            Error::Config(ConfigError::MaxCapacityUnsupported)
-        }
+        VmConfigError::MaxCapacityUnsupported => Error::Config(ConfigError::MaxCapacityUnsupported),
     }
 }
 

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -351,6 +351,8 @@ impl VmBuilder {
         let vm_config = VmConfig {
             vcpu_count: Some(self.machine.vcpus),
             mem_size_mib: Some(self.machine.memory_mib),
+            max_vcpu_count: self.machine.max_vcpus,
+            max_mem_size_mib: self.machine.max_memory_mib,
             ht_enabled: Some(self.machine.hyperthreading),
             ..Default::default()
         };
@@ -614,6 +616,15 @@ fn map_vm_config_error(machine: &MachineBuilder, err: VmConfigError) -> Error {
         VmConfigError::InvalidMemorySize => {
             Error::Config(ConfigError::InvalidMemorySize(machine.memory_mib))
         }
+        VmConfigError::InvalidMaxVcpuCount => Error::Config(ConfigError::InvalidMaxVcpuCount(
+            machine.max_vcpus.unwrap_or(machine.vcpus),
+        )),
+        VmConfigError::InvalidMaxMemorySize => Error::Config(ConfigError::InvalidMaxMemorySize(
+            machine.max_memory_mib.unwrap_or(machine.memory_mib),
+        )),
+        VmConfigError::MaxCapacityUnsupported => {
+            Error::Config(ConfigError::MaxCapacityUnsupported)
+        }
     }
 }
 
@@ -637,6 +648,38 @@ mod tests {
 
         match err {
             Error::Config(ConfigError::InvalidVcpuCount(3)) => {}
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_rejects_max_vcpus_below_effective_count() {
+        let err = match VmBuilder::new()
+            .machine(|machine| machine.vcpus(4).max_vcpus(2))
+            .build()
+        {
+            Ok(_) => panic!("max vCPUs below the effective count should fail"),
+            Err(err) => err,
+        };
+
+        match err {
+            Error::Config(ConfigError::InvalidMaxVcpuCount(2)) => {}
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_rejects_max_memory_below_effective_size() {
+        let err = match VmBuilder::new()
+            .machine(|machine| machine.memory_mib(2048).max_memory_mib(1024))
+            .build()
+        {
+            Ok(_) => panic!("max memory below the effective size should fail"),
+            Err(err) => err,
+        };
+
+        match err {
+            Error::Config(ConfigError::InvalidMaxMemorySize(1024)) => {}
             other => panic!("unexpected error: {other:?}"),
         }
     }

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -44,6 +44,8 @@ use crate::backends::net::NetBackend;
 pub struct MachineBuilder {
     pub(crate) vcpus: u8,
     pub(crate) memory_mib: usize,
+    pub(crate) max_vcpus: Option<u8>,
+    pub(crate) max_memory_mib: Option<usize>,
     pub(crate) hyperthreading: bool,
     pub(crate) nested_virt: bool,
     pub(crate) split_irqchip: bool,
@@ -354,6 +356,8 @@ impl MachineBuilder {
         Self {
             vcpus: 1,
             memory_mib: 512,
+            max_vcpus: None,
+            max_memory_mib: None,
             hyperthreading: false,
             nested_virt: false,
             split_irqchip: false,
@@ -375,6 +379,28 @@ impl MachineBuilder {
     /// Set the memory size in MiB.
     pub fn memory_mib(mut self, mib: usize) -> Self {
         self.memory_mib = mib;
+        self
+    }
+
+    /// Set the maximum possible virtual CPUs.
+    ///
+    /// The VM boots with this full topology described to the guest but only
+    /// [`vcpus`](Self::vcpus) online (`maxcpus=` boot parameter); the guest can
+    /// online the remaining CPUs later through CPU hotplug. Defaults to the
+    /// effective vCPU count, which reserves no extra capacity.
+    pub fn max_vcpus(mut self, count: u8) -> Self {
+        self.max_vcpus = Some(count);
+        self
+    }
+
+    /// Set the maximum guest memory in MiB reserved for future memory hotplug.
+    ///
+    /// Currently configuration plumbing only: capacity above
+    /// [`memory_mib`](Self::memory_mib) is validated and recorded but not yet
+    /// consumed until the virtio-mem device lands. Defaults to the effective
+    /// memory size, which reserves no extra capacity.
+    pub fn max_memory_mib(mut self, mib: usize) -> Self {
+        self.max_memory_mib = Some(mib);
         self
     }
 

--- a/src/krun/src/api/error.rs
+++ b/src/krun/src/api/error.rs
@@ -33,6 +33,15 @@ pub enum ConfigError {
     /// Invalid memory size.
     InvalidMemorySize(usize),
 
+    /// Invalid maximum vCPU count: below the effective count or above the supported limit.
+    InvalidMaxVcpuCount(u8),
+
+    /// Invalid maximum memory size: below the boot memory size.
+    InvalidMaxMemorySize(usize),
+
+    /// Reserving capacity above the initial resources is not supported on this platform.
+    MaxCapacityUnsupported,
+
     /// Missing kernel configuration.
     MissingKernel,
 
@@ -107,6 +116,14 @@ impl fmt::Display for ConfigError {
         match self {
             ConfigError::InvalidVcpuCount(n) => write!(f, "invalid vCPU count: {}", n),
             ConfigError::InvalidMemorySize(n) => write!(f, "invalid memory size: {} MiB", n),
+            ConfigError::InvalidMaxVcpuCount(n) => write!(f, "invalid max vCPU count: {}", n),
+            ConfigError::InvalidMaxMemorySize(n) => {
+                write!(f, "invalid max memory size: {} MiB", n)
+            }
+            ConfigError::MaxCapacityUnsupported => write!(
+                f,
+                "reserving CPU or memory capacity above the initial resources is not supported on this platform"
+            ),
             ConfigError::MissingKernel => write!(f, "missing kernel configuration"),
             ConfigError::InvalidKernelBundle(s) => write!(f, "invalid kernel bundle: {}", s),
             ConfigError::Network(s) => write!(f, "network: {}", s),

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -55,3 +55,5 @@ pub use metrics::{
     VmMetrics,
 };
 pub use vm::Vm;
+#[cfg(not(feature = "tee"))]
+pub use vm::{VmControl, VmMemoryState};

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -56,4 +56,4 @@ pub use metrics::{
 };
 pub use vm::Vm;
 #[cfg(not(feature = "tee"))]
-pub use vm::{VmControl, VmMemoryState};
+pub use vm::{VmControl, VmCpuState, VmMemoryState};

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -66,6 +66,37 @@ pub struct Vm {
     _initramfs_data: Option<Vec<u8>>,
 }
 
+/// Cloneable handle for live VM resource control.
+///
+/// Obtained through [`Vm::control_handle`] before `enter()`; background
+/// threads use it to drive live resizes while the VM runs. Memory resize is
+/// backed by virtio-mem and only available when the machine reserved capacity
+/// with [`max_memory_mib`](super::builders::MachineBuilder::max_memory_mib).
+#[cfg(not(feature = "tee"))]
+#[derive(Clone)]
+pub struct VmControl {
+    boot_mib: u64,
+    mem: Option<Arc<std::sync::Mutex<devices::virtio::Mem>>>,
+}
+
+/// Point-in-time memory sizing of a running VM, in MiB, as seen through
+/// [`VmControl`]. `current` trails `target` while the guest converges.
+#[cfg(not(feature = "tee"))]
+#[derive(Debug, Clone, Copy)]
+pub struct VmMemoryState {
+    /// Memory the VM booted with.
+    pub boot_mib: u64,
+
+    /// Total memory the host asked the guest to converge on.
+    pub target_mib: u64,
+
+    /// Total memory currently usable by the guest (boot + plugged).
+    pub current_mib: u64,
+
+    /// Boot-time ceiling for live growth (boot + hotplug capacity).
+    pub max_mib: u64,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
@@ -136,6 +167,21 @@ impl Vm {
     /// on a successful boot.
     pub fn metrics_handle(&self) -> MetricsHandle {
         self.vmr.metrics.handle()
+    }
+
+    /// Get a cloneable handle for live VM resource control.
+    ///
+    /// Must be called **before** [`enter()`](Self::enter), because `enter()`
+    /// never returns on a successful boot. Live memory resize is only
+    /// available when the machine reserved capacity with
+    /// [`max_memory_mib`](super::builders::MachineBuilder::max_memory_mib)
+    /// above the boot memory size.
+    #[cfg(not(feature = "tee"))]
+    pub fn control_handle(&self) -> VmControl {
+        VmControl {
+            boot_mib: self.vmr.vm_config().mem_size_mib.unwrap_or(128) as u64,
+            mem: self.vmr.mem_device.clone(),
+        }
     }
 
     /// Start the VM. This call never returns on success — the VMM calls
@@ -646,5 +692,39 @@ mod tests {
         // already being set, so the default (no opt-in) drops both.
         assert!(!flags.contains(TsiFlags::HIJACK_INET));
         assert!(!flags.contains(TsiFlags::HIJACK_UNIX));
+    }
+}
+
+#[cfg(not(feature = "tee"))]
+impl VmControl {
+    /// Whether the running VM can resize memory live.
+    pub fn memory_resize_supported(&self) -> bool {
+        self.mem.is_some()
+    }
+
+    /// Ask the guest to converge on `total_mib` of usable memory.
+    ///
+    /// Returns the accepted target in MiB (clamped to the boot..max range and
+    /// rounded down to hotplug block granularity), or `None` when the VM
+    /// booted without hotplug capacity. The guest plugs/unplugs blocks
+    /// asynchronously; poll [`memory_state`](Self::memory_state) for
+    /// convergence.
+    pub fn set_memory_target_mib(&self, total_mib: u64) -> Option<u64> {
+        let mem = self.mem.as_ref()?;
+        let hotplug_target = total_mib.saturating_sub(self.boot_mib) << 20;
+        let accepted = mem.lock().unwrap().set_requested_size(hotplug_target);
+        Some(self.boot_mib + (accepted >> 20))
+    }
+
+    /// Current memory sizing, or `None` when the VM booted without capacity.
+    pub fn memory_state(&self) -> Option<VmMemoryState> {
+        let mem = self.mem.as_ref()?;
+        let snap = mem.lock().unwrap().state_snapshot();
+        Some(VmMemoryState {
+            boot_mib: self.boot_mib,
+            target_mib: self.boot_mib + (snap.requested_size >> 20),
+            current_mib: self.boot_mib + (snap.plugged_size >> 20),
+            max_mib: self.boot_mib + (snap.region_size >> 20),
+        })
     }
 }

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -77,6 +77,26 @@ pub struct Vm {
 pub struct VmControl {
     boot_mib: u64,
     mem: Option<Arc<std::sync::Mutex<devices::virtio::Mem>>>,
+    cpu: Option<Arc<std::sync::Mutex<devices::virtio::Cpu>>>,
+}
+
+/// Point-in-time CPU sizing of a running VM as seen through [`VmControl`].
+/// `actual` is what the guest driver last reported; `enforced` is what the
+/// VMM allows to execute regardless of guest cooperation.
+#[cfg(not(feature = "tee"))]
+#[derive(Debug, Clone, Copy)]
+pub struct VmCpuState {
+    /// CPUs possible in this boot.
+    pub possible: u32,
+
+    /// Online count the host asked the guest to converge on.
+    pub requested_online: u32,
+
+    /// Online count the guest driver last reported.
+    pub actual_online: u32,
+
+    /// Online count the VMM currently enforces.
+    pub enforced: u32,
 }
 
 /// Point-in-time memory sizing of a running VM, in MiB, as seen through
@@ -181,6 +201,7 @@ impl Vm {
         VmControl {
             boot_mib: self.vmr.vm_config().mem_size_mib.unwrap_or(128) as u64,
             mem: self.vmr.mem_device.clone(),
+            cpu: self.vmr.cpu_device.clone(),
         }
     }
 
@@ -700,6 +721,33 @@ impl VmControl {
     /// Whether the running VM can resize memory live.
     pub fn memory_resize_supported(&self) -> bool {
         self.mem.is_some()
+    }
+
+    /// Whether the running VM can resize its online CPU count live.
+    pub fn cpu_resize_supported(&self) -> bool {
+        self.cpu.is_some()
+    }
+
+    /// Ask the guest to converge on `online` CPUs and enforce that ceiling
+    /// host-side. Returns the accepted target (clamped to 1..=possible), or
+    /// `None` when the VM booted without CPU capacity. The guest driver
+    /// onlines/offlines asynchronously; poll [`cpu_state`](Self::cpu_state)
+    /// for convergence — enforcement applies immediately either way.
+    pub fn set_cpu_target(&self, online: u32) -> Option<u32> {
+        let cpu = self.cpu.as_ref()?;
+        Some(cpu.lock().unwrap().set_requested_online(online))
+    }
+
+    /// Current CPU sizing, or `None` when the VM booted without capacity.
+    pub fn cpu_state(&self) -> Option<VmCpuState> {
+        let cpu = self.cpu.as_ref()?;
+        let snap = cpu.lock().unwrap().state_snapshot();
+        Some(VmCpuState {
+            possible: snap.possible,
+            requested_online: snap.requested_online,
+            actual_online: snap.actual_online,
+            enforced: snap.enforced,
+        })
     }
 
     /// Ask the guest to converge on `total_mib` of usable memory.

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -58,7 +58,7 @@ pub use api::metrics::{
 };
 pub use api::vm::Vm;
 #[cfg(not(feature = "tee"))]
-pub use api::vm::{VmControl, VmMemoryState};
+pub use api::vm::{VmControl, VmCpuState, VmMemoryState};
 
 #[cfg(not(target_os = "windows"))]
 pub use backends::console::ConsolePortBackend;

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -57,6 +57,8 @@ pub use api::metrics::{
     VmMetrics,
 };
 pub use api::vm::Vm;
+#[cfg(not(feature = "tee"))]
+pub use api::vm::{VmControl, VmMemoryState};
 
 #[cfg(not(target_os = "windows"))]
 pub use backends::console::ConsolePortBackend;

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -619,9 +619,13 @@ pub extern "C" fn krun_set_vm_config(ctx_id: u32, num_vcpus: u8, ram_mib: u32) -
         }
     };
 
+    // The C API keeps the legacy contract: no capacity is reserved beyond the
+    // requested resources. Extra capacity is a Rust-API (msb_krun) feature.
     let vm_config = VmConfig {
         vcpu_count: Some(num_vcpus),
         mem_size_mib: Some(mem_size_mib),
+        max_vcpu_count: None,
+        max_mem_size_mib: None,
         ht_enabled: Some(false),
         cpu_template: None,
     };

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1129,10 +1129,22 @@ pub fn build_microvm(
 
     // When extra CPU capacity is reserved, every possible vCPU is described to the guest
     // (MPTABLE/FDT), so cap the number brought online at boot to the requested count. The
-    // remaining CPUs stay offline until onlined through /sys/devices/system/cpu.
+    // remaining CPUs stay offline until the guest's msb-cpu driver onlines them.
     if vcpu_config.max_vcpu_count > vcpu_config.vcpu_count {
         kernel_cmdline
             .insert_str(format!(" maxcpus={}", vcpu_config.vcpu_count))
+            .unwrap();
+    }
+
+    // Hotplugged virtio-mem blocks must come online automatically: without this,
+    // guests whose kernel lacks MEMORY_HOTPLUG_DEFAULT_ONLINE (and which run no
+    // udev onlining rule) accept the blocks but leave them offline, so a live
+    // grow silently adds no usable memory. The movable zone keeps later unplug
+    // reliable.
+    #[cfg(not(feature = "tee"))]
+    if vm_resources.mem_device.is_some() {
+        kernel_cmdline
+            .insert_str(" memhp_default_state=online_movable")
             .unwrap();
     }
     trace.mark("kernel_cmdline.ready");
@@ -1413,7 +1425,8 @@ pub fn build_microvm(
         Arc::new(VcpuList::new(vcpu_config.max_vcpu_count as u64))
     };
 
-    let vcpus;
+    #[allow(unused_mut)]
+    let mut vcpus;
     let intc: IrqChip;
     // For x86_64 we need to create the interrupt controller before calling `KVM_CREATE_VCPUS`
     // while on aarch64 we need to do it the other way around.
@@ -1585,6 +1598,14 @@ pub fn build_microvm(
         )?;
     }
 
+    #[cfg(all(not(feature = "tee"), any(target_os = "linux", target_os = "macos")))]
+    if let Some(cpu_device) = &vm_resources.cpu_device {
+        let enforcement = cpu_device.lock().unwrap().enforcement();
+        for vcpu in &mut vcpus {
+            vcpu.set_enforcement(enforcement.clone());
+        }
+    }
+
     #[cfg(all(target_arch = "riscv64", target_os = "linux"))]
     {
         vcpus = create_vcpus_riscv64(
@@ -1650,6 +1671,11 @@ pub fn build_microvm(
     if let Some(mem_device) = vm_resources.mem_device.clone() {
         attach_mem_device(&mut vmm, event_manager, intc.clone(), mem_device)?;
         trace.mark("mem.attached");
+    }
+    #[cfg(not(feature = "tee"))]
+    if let Some(cpu_device) = vm_resources.cpu_device.clone() {
+        attach_cpu_device(&mut vmm, event_manager, intc.clone(), cpu_device)?;
+        trace.mark("cpu.attached");
     }
     #[cfg(all(not(feature = "tee"), not(target_os = "windows")))]
     if vm_resources.enable_rng {
@@ -3737,6 +3763,27 @@ fn attach_balloon_device(
 
     // The device mutex mustn't be locked here otherwise it will deadlock.
     attach_mmio_device(vmm, id, intc.clone(), balloon).map_err(RegisterBalloonDevice)?;
+
+    Ok(())
+}
+
+#[cfg(not(feature = "tee"))]
+fn attach_cpu_device(
+    vmm: &mut Vmm,
+    event_manager: &mut EventManager,
+    intc: IrqChip,
+    cpu_device: Arc<Mutex<devices::virtio::Cpu>>,
+) -> std::result::Result<(), StartMicrovmError> {
+    use self::StartMicrovmError::*;
+
+    event_manager
+        .add_subscriber(cpu_device.clone())
+        .map_err(RegisterEvent)?;
+
+    let id = String::from(cpu_device.lock().unwrap().id());
+
+    // The device mutex mustn't be locked here otherwise it will deadlock.
+    attach_mmio_device(vmm, id, intc.clone(), cpu_device).map_err(RegisterBalloonDevice)?;
 
     Ok(())
 }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1646,6 +1646,11 @@ pub fn build_microvm(
     } else {
         trace.mark("balloon.skipped");
     }
+    #[cfg(not(feature = "tee"))]
+    if let Some(mem_device) = vm_resources.mem_device.clone() {
+        attach_mem_device(&mut vmm, event_manager, intc.clone(), mem_device)?;
+        trace.mark("mem.attached");
+    }
     #[cfg(all(not(feature = "tee"), not(target_os = "windows")))]
     if vm_resources.enable_rng {
         attach_rng_device(&mut vmm, event_manager, intc.clone())?;
@@ -2455,6 +2460,32 @@ pub fn create_guest_memory(
     }
 
     arch_mem_regions.extend(shm_manager.regions());
+
+    // Reserve the virtio-mem hotplug region above every other window. The
+    // backing is anonymous and lazily faulted, so unplugged capacity costs no
+    // host memory; the region is deliberately absent from the FDT/MPTABLE
+    // memory nodes — the guest discovers it through the virtio-mem device.
+    #[cfg(not(feature = "tee"))]
+    if let Some(mem_device) = &vm_resources.mem_device {
+        let boot_mib = vm_resources.vm_config().mem_size_mib.unwrap_or(128) as u64;
+        let max_mib = vm_resources
+            .vm_config()
+            .max_mem_size_mib
+            .map(|mib| mib as u64)
+            .unwrap_or(boot_mib);
+        let block = devices::virtio::VIRTIO_MEM_BLOCK_SIZE;
+        let hotplug_bytes = (max_mib.saturating_sub(boot_mib) << 20) / block * block;
+        if hotplug_bytes > 0 {
+            const GIB: u64 = 1 << 30;
+            let base = shm_manager.next_guest_addr().div_ceil(GIB) * GIB;
+            mem_device
+                .lock()
+                .unwrap()
+                .set_region(base, hotplug_bytes)
+                .expect("hotplug region is block-aligned by construction");
+            arch_mem_regions.push((GuestAddress(base), hotplug_bytes as usize));
+        }
+    }
 
     let guest_mem = GuestMemoryMmap::from_ranges(&arch_mem_regions)
         .map_err(StartMicrovmError::GuestMemoryMmapFromRanges)?;
@@ -3706,6 +3737,27 @@ fn attach_balloon_device(
 
     // The device mutex mustn't be locked here otherwise it will deadlock.
     attach_mmio_device(vmm, id, intc.clone(), balloon).map_err(RegisterBalloonDevice)?;
+
+    Ok(())
+}
+
+#[cfg(not(feature = "tee"))]
+fn attach_mem_device(
+    vmm: &mut Vmm,
+    event_manager: &mut EventManager,
+    intc: IrqChip,
+    mem_device: Arc<Mutex<devices::virtio::Mem>>,
+) -> std::result::Result<(), StartMicrovmError> {
+    use self::StartMicrovmError::*;
+
+    event_manager
+        .add_subscriber(mem_device.clone())
+        .map_err(RegisterEvent)?;
+
+    let id = String::from(mem_device.lock().unwrap().id());
+
+    // The device mutex mustn't be locked here otherwise it will deadlock.
+    attach_mmio_device(vmm, id, intc.clone(), mem_device).map_err(RegisterBalloonDevice)?;
 
     Ok(())
 }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1109,6 +1109,7 @@ pub fn build_microvm(
             vcpu_config.vcpu_count
         );
         vcpu_config.vcpu_count = 1;
+        vcpu_config.max_vcpu_count = 1;
     }
 
     // Clone the command-line so that a failed boot doesn't pollute the original.
@@ -1124,6 +1125,15 @@ pub fn build_microvm(
 
     if let Some(cmdline) = &vm_resources.kernel_cmdline.krun_env {
         kernel_cmdline.insert_str(cmdline.as_str()).unwrap();
+    }
+
+    // When extra CPU capacity is reserved, every possible vCPU is described to the guest
+    // (MPTABLE/FDT), so cap the number brought online at boot to the requested count. The
+    // remaining CPUs stay offline until onlined through /sys/devices/system/cpu.
+    if vcpu_config.max_vcpu_count > vcpu_config.vcpu_count {
+        kernel_cmdline
+            .insert_str(format!(" maxcpus={}", vcpu_config.vcpu_count))
+            .unwrap();
     }
     trace.mark("kernel_cmdline.ready");
 
@@ -1399,8 +1409,8 @@ pub fn build_microvm(
 
     #[cfg(target_os = "macos")]
     let vcpu_list = {
-        let cpu_count = vm_resources.vm_config().vcpu_count.unwrap();
-        Arc::new(VcpuList::new(cpu_count as u64))
+        // Size for the full possible topology so parked vCPUs can register too.
+        Arc::new(VcpuList::new(vcpu_config.max_vcpu_count as u64))
     };
 
     let vcpus;
@@ -1518,7 +1528,8 @@ pub fn build_microvm(
             // architected vGIC, which is required for requesting KVM the instantiation of a
             // GICv3. To relieve the users from having to configure the gic version manually,
             // try first to instantiate a GICv3, and fall back to a GICv2 if it fails.
-            let vcpu_count = vm_resources.vm_config().vcpu_count.unwrap() as u64;
+            // Redistributors must cover the full possible topology, not just online CPUs.
+            let vcpu_count = vcpu_config.max_vcpu_count as u64;
             let gic = match KvmGicV3::new(vm.fd(), vcpu_count) {
                 Ok(gicv3) => IrqChipDevice::new(Box::new(gicv3)),
                 Err(_) => {
@@ -1542,8 +1553,9 @@ pub fn build_microvm(
     {
         intc = {
             // If the system supports the in-kernel GIC, use it. Otherwise, fall back to the
-            // userspace implementation.
-            let gic = match HvfGicV3::new(vm_resources.vm_config().vcpu_count.unwrap() as u64) {
+            // userspace implementation. Redistributors must cover the full possible
+            // topology, not just online CPUs.
+            let gic = match HvfGicV3::new(vcpu_config.max_vcpu_count as u64) {
                 Ok(hvfgic) => IrqChipDevice::new(Box::new(hvfgic)),
                 Err(_) => IrqChipDevice::new(Box::new(GicV3::new(vcpu_list.clone()))),
             };
@@ -3008,8 +3020,10 @@ fn create_vcpus_x86_64(
     metrics: utils::metrics::MetricsWriter,
     #[cfg(feature = "tee")] pm_sender: Sender<WorkerMessage>,
 ) -> super::Result<Vec<Vcpu>> {
-    let mut vcpus = Vec::with_capacity(vcpu_config.vcpu_count as usize);
-    for cpu_index in 0..vcpu_config.vcpu_count {
+    // Create the full possible topology; CPUs beyond `vcpu_count` boot offline (maxcpus=)
+    // and wait inside KVM for INIT/SIPI until the guest onlines them.
+    let mut vcpus = Vec::with_capacity(vcpu_config.max_vcpu_count as usize);
+    for cpu_index in 0..vcpu_config.max_vcpu_count {
         let mut vcpu = Vcpu::new_x86_64(
             cpu_index,
             vm.fd(),
@@ -3071,8 +3085,10 @@ fn create_vcpus_aarch64(
     exit_evt: &EventFd,
     metrics: utils::metrics::MetricsWriter,
 ) -> super::Result<Vec<Vcpu>> {
-    let mut vcpus = Vec::with_capacity(vcpu_config.vcpu_count as usize);
-    for cpu_index in 0..vcpu_config.vcpu_count {
+    // Create the full possible topology; CPUs beyond `vcpu_count` boot powered off
+    // (KVM_ARM_VCPU_POWER_OFF) and wait for PSCI CPU_ON when the guest onlines them.
+    let mut vcpus = Vec::with_capacity(vcpu_config.max_vcpu_count as usize);
+    for cpu_index in 0..vcpu_config.max_vcpu_count {
         let mut vcpu = Vcpu::new_aarch64(
             cpu_index,
             vm.fd(),
@@ -3101,10 +3117,12 @@ fn create_vcpus_aarch64(
     nested_enabled: bool,
     metrics: utils::metrics::MetricsWriter,
 ) -> super::Result<Vec<Vcpu>> {
-    let mut vcpus = Vec::with_capacity(vcpu_config.vcpu_count as usize);
+    // Create the full possible topology; CPUs beyond `vcpu_count` park on their boot
+    // channel until vCPU 0 relays a PSCI CPU_ON when the guest onlines them.
+    let mut vcpus = Vec::with_capacity(vcpu_config.max_vcpu_count as usize);
     let mut boot_senders: HashMap<u64, Sender<u64>> = HashMap::new();
 
-    for cpu_index in 0..vcpu_config.vcpu_count {
+    for cpu_index in 0..vcpu_config.max_vcpu_count {
         let (boot_sender, boot_receiver) = if cpu_index != 0 {
             let (boot_sender, boot_receiver) = unbounded();
             (Some(boot_sender), Some(boot_receiver))
@@ -3862,6 +3880,7 @@ pub mod tests {
 
         let vcpu_config = VcpuConfig {
             vcpu_count,
+            max_vcpu_count: vcpu_count,
             ht_enabled: false,
             cpu_template: None,
         };
@@ -3898,6 +3917,7 @@ pub mod tests {
 
         let vcpu_config = VcpuConfig {
             vcpu_count,
+            max_vcpu_count: vcpu_count,
             ht_enabled: false,
             cpu_template: None,
         };

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -3118,22 +3118,20 @@ fn create_vcpus_aarch64(
     metrics: utils::metrics::MetricsWriter,
 ) -> super::Result<Vec<Vcpu>> {
     // Create the full possible topology; CPUs beyond `vcpu_count` park on their boot
-    // channel until vCPU 0 relays a PSCI CPU_ON when the guest onlines them.
+    // channel until a PSCI CPU_ON supplies an entry point when the guest onlines them.
     let mut vcpus = Vec::with_capacity(vcpu_config.max_vcpu_count as usize);
     let mut boot_senders: HashMap<u64, Sender<u64>> = HashMap::new();
+    let mut parked_cpus: HashMap<u64, std::sync::atomic::AtomicBool> = HashMap::new();
 
     for cpu_index in 0..vcpu_config.max_vcpu_count {
-        let (boot_sender, boot_receiver) = if cpu_index != 0 {
-            let (boot_sender, boot_receiver) = unbounded();
-            (Some(boot_sender), Some(boot_receiver))
-        } else {
-            (None, None)
-        };
+        // Every CPU gets a boot channel so it can re-park and restart across
+        // guest offline/online cycles; only vCPU 0 skips waiting at first boot.
+        let (boot_sender, boot_receiver) = unbounded();
 
         let mut vcpu = Vcpu::new_aarch64(
             cpu_index,
             entry_addr,
-            boot_receiver,
+            Some(boot_receiver),
             exit_evt.try_clone().map_err(Error::EventFd)?,
             vcpu_list.clone(),
             nested_enabled,
@@ -3143,14 +3141,23 @@ fn create_vcpus_aarch64(
 
         vcpu.configure_aarch64(mem_info).map_err(Error::Vcpu)?;
 
-        if let Some(boot_sender) = boot_sender {
-            boot_senders.insert(vcpu.get_mpidr(), boot_sender);
-        }
+        boot_senders.insert(vcpu.get_mpidr(), boot_sender);
+        parked_cpus.insert(
+            vcpu.get_mpidr(),
+            std::sync::atomic::AtomicBool::new(cpu_index != 0),
+        );
 
         vcpus.push(vcpu);
     }
 
-    vcpus[0].set_boot_senders(boot_senders);
+    // CPU_ON can be issued from any online vCPU and AFFINITY_INFO answered from
+    // any thread, so every vCPU shares the relay and parked-state maps.
+    let boot_senders = Arc::new(boot_senders);
+    let parked_cpus = Arc::new(parked_cpus);
+    for vcpu in &mut vcpus {
+        vcpu.set_boot_senders(boot_senders.clone());
+        vcpu.set_parked_cpus(parked_cpus.clone());
+    }
 
     Ok(vcpus)
 }

--- a/src/vmm/src/device_manager/shm.rs
+++ b/src/vmm/src/device_manager/shm.rs
@@ -33,6 +33,11 @@ impl ShmManager {
         }
     }
 
+    /// First guest address above every window this manager has handed out.
+    pub fn next_guest_addr(&self) -> u64 {
+        self.next_guest_addr
+    }
+
     pub fn regions(&self) -> Vec<(GuestAddress, usize)> {
         let mut regions: Vec<(GuestAddress, usize)> = Vec::new();
 

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -910,6 +910,8 @@ pub struct VmState {
 pub struct VcpuConfig {
     /// Number of guest VCPUs.
     pub vcpu_count: u8,
+    /// Maximum possible guest VCPUs; vcpus above `vcpu_count` boot parked awaiting hotplug.
+    pub max_vcpu_count: u8,
     /// Enable hyperthreading in the CPUID configuration.
     pub ht_enabled: bool,
     /// CPUID template to use.
@@ -1918,6 +1920,7 @@ mod tests {
 
         let mut vcpu_config = VcpuConfig {
             vcpu_count: 1,
+            max_vcpu_count: 1,
             ht_enabled: false,
             cpu_template: None,
         };

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -925,6 +925,9 @@ type VcpuCell = Cell<Option<*mut Vcpu>>;
 pub struct Vcpu {
     fd: VcpuFd,
     id: u8,
+    // Host-authoritative online ceiling; vCPUs at or above it park between
+    // emulation steps regardless of guest cooperation.
+    enforcement: Option<std::sync::Arc<devices::virtio::CpuEnforcement>>,
     mmio_bus: Option<devices::Bus>,
     #[allow(dead_code)]
     #[cfg_attr(all(test, target_arch = "aarch64"), allow(unused))]
@@ -1077,6 +1080,7 @@ impl Vcpu {
         Ok(Vcpu {
             fd: kvm_vcpu,
             id,
+            enforcement: None,
             mmio_bus: None,
             exit_evt,
             io_bus,
@@ -1115,6 +1119,7 @@ impl Vcpu {
         Ok(Vcpu {
             fd: kvm_vcpu,
             id,
+            enforcement: None,
             mmio_bus: None,
             exit_evt,
             mpidr: 0,
@@ -1148,6 +1153,7 @@ impl Vcpu {
         Ok(Vcpu {
             fd: kvm_vcpu,
             id,
+            enforcement: None,
             mmio_bus: None,
             exit_evt,
             event_receiver,
@@ -1161,6 +1167,13 @@ impl Vcpu {
     /// Returns the cpu index as seen by the guest OS.
     pub fn cpu_index(&self) -> u8 {
         self.id
+    }
+
+    pub fn set_enforcement(
+        &mut self,
+        enforcement: std::sync::Arc<devices::virtio::CpuEnforcement>,
+    ) {
+        self.enforcement = Some(enforcement);
     }
 
     /// Gets the MPIDR register value.
@@ -1592,7 +1605,28 @@ impl Vcpu {
         // This loop is here just for optimizing the emulation path.
         // No point in ticking the state machine if there are no external events.
         let mut last_thread_cpu_ns = get_time(ClockType::ThreadCpu);
+        let mut enforcement_deadline: Option<std::time::Instant> = None;
         loop {
+            // Host-side enforcement: stop scheduling this vCPU while its index
+            // is at or above the enforced online count. A cooperative guest
+            // offlines it via PSCI/hotplug first; an uncooperative one just
+            // stops receiving execution time here.
+            if let Some(enforcement) = &self.enforcement {
+                if enforcement.runnable(self.id as u32) {
+                    enforcement_deadline = None;
+                } else {
+                    // Give the guest a grace window to offline this CPU
+                    // gracefully (the dying CPU must run its own PSCI CPU_OFF
+                    // path); hard-park it only if the guest refuses.
+                    let deadline = *enforcement_deadline.get_or_insert_with(|| {
+                        std::time::Instant::now() + devices::virtio::ENFORCEMENT_GRACE
+                    });
+                    if std::time::Instant::now() >= deadline {
+                        enforcement.wait_until_runnable(self.id as u32);
+                        enforcement_deadline = None;
+                    }
+                }
+            }
             let emulation = self.run_emulation();
             let thread_cpu_ns = get_time(ClockType::ThreadCpu);
             self.metrics

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -1617,13 +1617,18 @@ impl Vcpu {
                 } else {
                     // Give the guest a grace window to offline this CPU
                     // gracefully (the dying CPU must run its own PSCI CPU_OFF
-                    // path); hard-park it only if the guest refuses.
+                    // path); throttle it only if the guest refuses. Throttling
+                    // (one emulation step per park interval) rather than fully
+                    // parking keeps an uncooperative guest live: IPIs and TLB
+                    // shootdowns aimed at this CPU still complete. The duty
+                    // cycle is only as tight as KVM_RUN exit frequency; a
+                    // spinning guest thread runs until its next exit (typically
+                    // the guest timer tick) before the next park.
                     let deadline = *enforcement_deadline.get_or_insert_with(|| {
                         std::time::Instant::now() + devices::virtio::ENFORCEMENT_GRACE
                     });
                     if std::time::Instant::now() >= deadline {
-                        enforcement.wait_until_runnable(self.id as u32);
-                        enforcement_deadline = None;
+                        enforcement.throttle(self.id as u32);
                     }
                 }
             }

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -928,6 +928,8 @@ pub struct Vcpu {
     // Host-authoritative online ceiling; vCPUs at or above it park between
     // emulation steps regardless of guest cooperation.
     enforcement: Option<std::sync::Arc<devices::virtio::CpuEnforcement>>,
+    // This vCPU's registration with the enforcement kicker, filled in on the vcpu thread.
+    kick_slot: Option<std::sync::Arc<devices::virtio::CpuKickSlot>>,
     mmio_bus: Option<devices::Bus>,
     #[allow(dead_code)]
     #[cfg_attr(all(test, target_arch = "aarch64"), allow(unused))]
@@ -1081,6 +1083,7 @@ impl Vcpu {
             fd: kvm_vcpu,
             id,
             enforcement: None,
+            kick_slot: None,
             mmio_bus: None,
             exit_evt,
             io_bus,
@@ -1120,6 +1123,7 @@ impl Vcpu {
             fd: kvm_vcpu,
             id,
             enforcement: None,
+            kick_slot: None,
             mmio_bus: None,
             exit_evt,
             mpidr: 0,
@@ -1154,6 +1158,7 @@ impl Vcpu {
             fd: kvm_vcpu,
             id,
             enforcement: None,
+            kick_slot: None,
             mmio_bus: None,
             exit_evt,
             event_receiver,
@@ -1596,6 +1601,18 @@ impl Vcpu {
     /// Note that the state of the VCPU and associated VM must be setup first for this to do
     /// anything useful.
     pub fn run(&mut self) {
+        // Register with the enforcement kicker: a guest thread spinning without VM exits would never let the enforcement check in `running` observe a lowered ceiling, so
+        // the kicker signals this thread (same mechanism as `VcpuHandle::send_event`) to force KVM_RUN back to the host.
+        if let Some(enforcement) = &self.enforcement {
+            let thread = unsafe { libc::pthread_self() };
+            self.kick_slot = Some(enforcement.register_kicker(
+                self.id as u32,
+                Box::new(move || unsafe {
+                    libc::pthread_kill(thread, sigrtmin() + VCPU_RTSIG_OFFSET);
+                }),
+            ));
+        }
+
         // Start running the machine state in the `Paused` state.
         StateMachine::run(self, Self::paused);
     }
@@ -1620,10 +1637,9 @@ impl Vcpu {
                     // path); throttle it only if the guest refuses. Throttling
                     // (one emulation step per park interval) rather than fully
                     // parking keeps an uncooperative guest live: IPIs and TLB
-                    // shootdowns aimed at this CPU still complete. The duty
-                    // cycle is only as tight as KVM_RUN exit frequency; a
-                    // spinning guest thread runs until its next exit (typically
-                    // the guest timer tick) before the next park.
+                    // shootdowns aimed at this CPU still complete. The kicker
+                    // bounds each emulation step, so even a guest thread that
+                    // spins without taking exits is forced back here.
                     let deadline = *enforcement_deadline.get_or_insert_with(|| {
                         std::time::Instant::now() + devices::virtio::ENFORCEMENT_GRACE
                     });
@@ -1632,7 +1648,13 @@ impl Vcpu {
                     }
                 }
             }
+            if let Some(slot) = &self.kick_slot {
+                slot.enter_guest();
+            }
             let emulation = self.run_emulation();
+            if let Some(slot) = &self.kick_slot {
+                slot.leave_guest();
+            }
             let thread_cpu_ns = get_time(ClockType::ThreadCpu);
             self.metrics
                 .add_vcpu_time_ns(thread_cpu_ns.saturating_sub(last_thread_cpu_ns));

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -194,6 +194,9 @@ pub struct Vcpu {
     // Shared parked/offline flags (keyed by MPIDR) so AFFINITY_INFO can be answered
     // from any vCPU thread.
     parked_cpus: Option<Arc<HashMap<u64, AtomicBool>>>,
+    // Host-authoritative online ceiling; vCPUs at or above it park between
+    // emulation steps regardless of guest cooperation.
+    enforcement: Option<Arc<devices::virtio::CpuEnforcement>>,
     fdt_addr: u64,
     mmio_bus: Option<devices::Bus>,
     #[cfg_attr(all(test, target_arch = "aarch64"), allow(unused))]
@@ -299,6 +302,7 @@ impl Vcpu {
             boot_receiver,
             boot_senders: None,
             parked_cpus: None,
+            enforcement: None,
             fdt_addr: 0,
             mmio_bus: None,
             exit_evt,
@@ -334,6 +338,10 @@ impl Vcpu {
 
     pub fn set_parked_cpus(&mut self, parked_cpus: Arc<HashMap<u64, AtomicBool>>) {
         self.parked_cpus = Some(parked_cpus);
+    }
+
+    pub fn set_enforcement(&mut self, enforcement: Arc<devices::virtio::CpuEnforcement>) {
+        self.enforcement = Some(enforcement);
     }
 
     /// Record this vCPU's parked/offline state for AFFINITY_INFO queries.
@@ -516,7 +524,28 @@ impl Vcpu {
             .unwrap_or_else(|_| panic!("Can't set HVF vCPU {hvf_vcpuid} initial state"));
 
         let mut last_exec_time_ns = hvf_vcpu.exec_time_ns().unwrap_or(0);
+        let mut enforcement_deadline: Option<std::time::Instant> = None;
         loop {
+            // Host-side enforcement: stop scheduling this vCPU while its index
+            // is at or above the enforced online count. A cooperative guest
+            // offlines it via PSCI first; an uncooperative one just stops
+            // receiving execution time here.
+            if let Some(enforcement) = &self.enforcement {
+                if enforcement.runnable(self.id as u32) {
+                    enforcement_deadline = None;
+                } else {
+                    // Give the guest a grace window to offline this CPU
+                    // gracefully (the dying CPU must run its own PSCI CPU_OFF
+                    // path); hard-park it only if the guest refuses.
+                    let deadline = *enforcement_deadline.get_or_insert_with(|| {
+                        std::time::Instant::now() + devices::virtio::ENFORCEMENT_GRACE
+                    });
+                    if std::time::Instant::now() >= deadline {
+                        enforcement.wait_until_runnable(self.id as u32);
+                        enforcement_deadline = None;
+                    }
+                }
+            }
             let emulation = self.run_emulation(&mut hvf_vcpu);
             if let Some(exec_time_ns) = hvf_vcpu.exec_time_ns() {
                 self.metrics

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::io;
 use std::result;
+use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(not(test))]
 use std::sync::Arc;
 use std::thread;
@@ -39,6 +40,8 @@ pub enum Error {
     REGSConfiguration(arch::aarch64::regs::Error),
     /// Cannot set the memory regions.
     SetUserMemoryRegion(hvf::Error),
+    /// Failed writing a PSCI result into the vCPU.
+    VcpuHvf(hvf::Error),
     /// Failed to signal Vcpu.
     SignalVcpu(utils::errno::Error),
     /// Error doing Vcpu Init on Arm.
@@ -75,6 +78,7 @@ impl Display for Error {
                 "The number of configured slots is bigger than the maximum reported by KVM"
             ),
             SetUserMemoryRegion(e) => write!(f, "Cannot set the memory regions: {e:?}"),
+            VcpuHvf(e) => write!(f, "Failed writing a PSCI result into the vCPU: {e:?}"),
             SignalVcpu(e) => write!(f, "Failed to signal Vcpu: {e}"),
             REGSConfiguration(e) => write!(
                 f,
@@ -184,7 +188,12 @@ pub struct Vcpu {
     id: u8,
     boot_entry_addr: u64,
     boot_receiver: Option<Receiver<u64>>,
-    boot_senders: Option<HashMap<u64, Sender<u64>>>,
+    // Shared by every vCPU: a runtime CPU online (PSCI CPU_ON) can be issued from
+    // whichever vCPU the guest scheduled the hotplug path on, not just the boot CPU.
+    boot_senders: Option<Arc<HashMap<u64, Sender<u64>>>>,
+    // Shared parked/offline flags (keyed by MPIDR) so AFFINITY_INFO can be answered
+    // from any vCPU thread.
+    parked_cpus: Option<Arc<HashMap<u64, AtomicBool>>>,
     fdt_addr: u64,
     mmio_bus: Option<devices::Bus>,
     #[cfg_attr(all(test, target_arch = "aarch64"), allow(unused))]
@@ -289,6 +298,7 @@ impl Vcpu {
             boot_entry_addr: boot_entry_addr.raw_value(),
             boot_receiver,
             boot_senders: None,
+            parked_cpus: None,
             fdt_addr: 0,
             mmio_bus: None,
             exit_evt,
@@ -318,8 +328,23 @@ impl Vcpu {
         self.mmio_bus = Some(mmio_bus);
     }
 
-    pub fn set_boot_senders(&mut self, boot_senders: HashMap<u64, Sender<u64>>) {
+    pub fn set_boot_senders(&mut self, boot_senders: Arc<HashMap<u64, Sender<u64>>>) {
         self.boot_senders = Some(boot_senders);
+    }
+
+    pub fn set_parked_cpus(&mut self, parked_cpus: Arc<HashMap<u64, AtomicBool>>) {
+        self.parked_cpus = Some(parked_cpus);
+    }
+
+    /// Record this vCPU's parked/offline state for AFFINITY_INFO queries.
+    fn set_parked(&self, parked: bool) {
+        if let Some(flag) = self
+            .parked_cpus
+            .as_ref()
+            .and_then(|parked_cpus| parked_cpus.get(&self.mpidr))
+        {
+            flag.store(parked, Ordering::Release);
+        }
     }
 
     /// Configures an aarch64 specific vcpu.
@@ -375,14 +400,33 @@ impl Vcpu {
                     debug!("vCPU {vcpuid} canceled");
                     Ok(VcpuEmulation::Handled)
                 }
+                VcpuExit::AffinityInfo(mpidr) => {
+                    debug!("AffinityInfo: mpidr=0x{mpidr:x}");
+                    let off = self
+                        .parked_cpus
+                        .as_ref()
+                        .and_then(|parked| parked.get(&mpidr))
+                        .is_some_and(|flag| flag.load(Ordering::Acquire));
+                    // PSCI AFFINITY_INFO: 0 = ON, 1 = OFF.
+                    hvf_vcpu
+                        .write_psci_result(if off { 1 } else { 0 })
+                        .map_err(Error::VcpuHvf)?;
+                    Ok(VcpuEmulation::Handled)
+                }
+                VcpuExit::CpuOff => {
+                    debug!("CpuOff: vCPU {vcpuid}");
+                    Ok(VcpuEmulation::CpuOff)
+                }
                 VcpuExit::CpuOn(mpidr, entry, context_id) => {
                     debug!("CpuOn: mpidr=0x{mpidr:x} entry=0x{entry:x} context_id={context_id}");
-                    if let Some(boot_senders) = &self.boot_senders {
-                        if let Some(sender) = boot_senders.get(&mpidr) {
-                            sender.send(entry).unwrap()
-                        }
+                    if let Some(sender) = self
+                        .boot_senders
+                        .as_ref()
+                        .and_then(|senders| senders.get(&mpidr))
+                    {
+                        sender.send(entry).unwrap()
                     } else {
-                        error!("CpuOn request coming from an unexpected vCPU={}", self.id);
+                        error!("CPU_ON for unknown target mpidr=0x{mpidr:x}");
                     }
                     Ok(VcpuEmulation::Handled)
                 }
@@ -454,8 +498,15 @@ impl Vcpu {
         let (wfe_sender, wfe_receiver) = unbounded();
         self.vcpu_list.register(hvf_vcpuid, wfe_sender);
 
-        let entry_addr = if let Some(boot_receiver) = &self.boot_receiver {
-            boot_receiver.recv().unwrap()
+        // The boot CPU starts immediately at the kernel entry point; every other CPU
+        // parks on its boot channel until PSCI CPU_ON supplies an entry point.
+        let entry_addr = if self.id == 0 {
+            self.boot_entry_addr
+        } else if let Some(boot_receiver) = &self.boot_receiver {
+            self.set_parked(true);
+            let entry = boot_receiver.recv().unwrap();
+            self.set_parked(false);
+            entry
         } else {
             self.boot_entry_addr
         };
@@ -476,6 +527,26 @@ impl Vcpu {
             match emulation {
                 // Emulation ran successfully, continue.
                 Ok(VcpuEmulation::Handled) => (),
+                // The guest offlined this CPU (PSCI CPU_OFF). Park until a later
+                // CPU_ON supplies a fresh entry point, then restart from it.
+                Ok(VcpuEmulation::CpuOff) => {
+                    if let Some(boot_receiver) = &self.boot_receiver {
+                        self.set_parked(true);
+                        let entry = boot_receiver.recv().unwrap();
+                        self.set_parked(false);
+                        hvf_vcpu
+                            .set_initial_state(entry, self.fdt_addr)
+                            .unwrap_or_else(|_| {
+                                panic!("Can't reset HVF vCPU {hvf_vcpuid} state after CPU_OFF")
+                            });
+                    } else {
+                        error!(
+                            "vCPU {} received CPU_OFF without a boot channel; stopping it",
+                            self.id
+                        );
+                        break;
+                    }
+                }
                 // Emulation was interrupted by a breakpoint.
                 Ok(VcpuEmulation::Interrupted) => self.wait_for_resume(),
                 // Wait for an external event.
@@ -604,6 +675,7 @@ impl VcpuHandle {
 }
 
 enum VcpuEmulation {
+    CpuOff,
     Handled,
     Interrupted,
     Stopped,

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -22,7 +22,7 @@ use crate::vmm_config::machine_config::CpuFeaturesTemplate;
 use arch::ArchMemoryInfo;
 use crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender};
 use devices::legacy::VcpuList;
-use hvf::{HvfVcpu, HvfVm, VcpuExit, Vcpus};
+use hvf::{vcpu_request_exit, HvfVcpu, HvfVm, VcpuExit, Vcpus};
 use utils::eventfd::EventFd;
 use utils::metrics::MetricsWriter;
 use vm_memory::{
@@ -506,6 +506,17 @@ impl Vcpu {
         let (wfe_sender, wfe_receiver) = unbounded();
         self.vcpu_list.register(hvf_vcpuid, wfe_sender);
 
+        // Register with the enforcement kicker: a hard-spinning guest takes no VM exits on HVF (even the vtimer is hardware-virtualized), so when enforcement drops below
+        // this vCPU's index the kicker must be able to force it out of guest mode for the enforcement check below to run at all — and to bound its slice while throttled.
+        let kick_slot = self.enforcement.as_ref().map(|enforcement| {
+            enforcement.register_kicker(
+                self.id as u32,
+                Box::new(move || {
+                    let _ = vcpu_request_exit(hvf_vcpuid);
+                }),
+            )
+        });
+
         // The boot CPU starts immediately at the kernel entry point; every other CPU
         // parks on its boot channel until PSCI CPU_ON supplies an entry point.
         let entry_addr = if self.id == 0 {
@@ -548,7 +559,13 @@ impl Vcpu {
                     }
                 }
             }
+            if let Some(slot) = &kick_slot {
+                slot.enter_guest();
+            }
             let emulation = self.run_emulation(&mut hvf_vcpu);
+            if let Some(slot) = &kick_slot {
+                slot.leave_guest();
+            }
             if let Some(exec_time_ns) = hvf_vcpu.exec_time_ns() {
                 self.metrics
                     .add_vcpu_time_ns(exec_time_ns.saturating_sub(last_exec_time_ns));

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -168,6 +168,8 @@ impl Vm {
 pub struct VcpuConfig {
     /// Number of guest VCPUs.
     pub vcpu_count: u8,
+    /// Maximum possible guest VCPUs; vcpus above `vcpu_count` boot parked awaiting hotplug.
+    pub max_vcpu_count: u8,
     /// Enable hyperthreading in the CPUID configuration.
     pub ht_enabled: bool,
     /// CPUID template to use.
@@ -762,6 +764,7 @@ mod tests {
 
         let mut vcpu_config = VcpuConfig {
             vcpu_count: 1,
+            max_vcpu_count: 1,
             ht_enabled: false,
             cpu_template: None,
         };

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -536,13 +536,15 @@ impl Vcpu {
                 } else {
                     // Give the guest a grace window to offline this CPU
                     // gracefully (the dying CPU must run its own PSCI CPU_OFF
-                    // path); hard-park it only if the guest refuses.
+                    // path); throttle it only if the guest refuses. Throttling
+                    // (one emulation step per park interval) rather than fully
+                    // parking keeps an uncooperative guest live: IPIs and TLB
+                    // shootdowns aimed at this CPU still complete.
                     let deadline = *enforcement_deadline.get_or_insert_with(|| {
                         std::time::Instant::now() + devices::virtio::ENFORCEMENT_GRACE
                     });
                     if std::time::Instant::now() >= deadline {
-                        enforcement.wait_until_runnable(self.id as u32);
-                        enforcement_deadline = None;
+                        enforcement.throttle(self.id as u32);
                     }
                 }
             }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -223,6 +223,11 @@ pub struct VmResources {
     /// the runtime control handle.
     #[cfg(not(feature = "tee"))]
     pub mem_device: Option<std::sync::Arc<std::sync::Mutex<devices::virtio::Mem>>>,
+    /// The CPU capacity device backing live CPU resize, created by the API
+    /// layer when max vCPUs exceed the boot count. Also the source of the
+    /// enforcement state every vCPU run loop consults.
+    #[cfg(not(feature = "tee"))]
+    pub cpu_device: Option<std::sync::Arc<std::sync::Mutex<devices::virtio::Cpu>>>,
     /// Guest memory stats polling interval for the virtio-balloon device.
     pub balloon_stats_interval: Option<Duration>,
     /// Whether to attach the virtio-rng device.
@@ -281,6 +286,8 @@ impl Default for VmResources {
             enable_balloon: true,
             #[cfg(not(feature = "tee"))]
             mem_device: None,
+            #[cfg(not(feature = "tee"))]
+            cpu_device: None,
             balloon_stats_interval: Some(Duration::from_secs(1)),
             enable_rng: true,
             enable_msb_metrics: true,
@@ -575,6 +582,8 @@ mod tests {
             enable_balloon: true,
             #[cfg(not(feature = "tee"))]
             mem_device: None,
+            #[cfg(not(feature = "tee"))]
+            cpu_device: None,
             balloon_stats_interval: Some(std::time::Duration::from_secs(1)),
             enable_rng: true,
             enable_msb_metrics: true,

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -217,6 +217,12 @@ pub struct VmResources {
     pub request_vsock: bool,
     /// Whether to attach the virtio-balloon device.
     pub enable_balloon: bool,
+    /// The virtio-mem device backing live memory resize, created by the API
+    /// layer when max memory exceeds boot memory. The builder places the
+    /// hotplug region and attaches the device; the API layer keeps a clone as
+    /// the runtime control handle.
+    #[cfg(not(feature = "tee"))]
+    pub mem_device: Option<std::sync::Arc<std::sync::Mutex<devices::virtio::Mem>>>,
     /// Guest memory stats polling interval for the virtio-balloon device.
     pub balloon_stats_interval: Option<Duration>,
     /// Whether to attach the virtio-rng device.
@@ -273,6 +279,8 @@ impl Default for VmResources {
             metrics: MetricsWriter::default(),
             request_vsock: false,
             enable_balloon: true,
+            #[cfg(not(feature = "tee"))]
+            mem_device: None,
             balloon_stats_interval: Some(Duration::from_secs(1)),
             enable_rng: true,
             enable_msb_metrics: true,
@@ -565,6 +573,8 @@ mod tests {
             metrics: MetricsWriter::default(),
             request_vsock: false,
             enable_balloon: true,
+            #[cfg(not(feature = "tee"))]
+            mem_device: None,
             balloon_stats_interval: Some(std::time::Duration::from_secs(1)),
             enable_rng: true,
             enable_msb_metrics: true,

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -290,8 +290,10 @@ impl VmResources {
     pub fn vcpu_config(&self) -> VcpuConfig {
         // The unwraps are ok to use because the values are initialized using defaults if not
         // supplied by the user.
+        let vcpu_count = self.vm_config().vcpu_count.unwrap();
         VcpuConfig {
-            vcpu_count: self.vm_config().vcpu_count.unwrap(),
+            vcpu_count,
+            max_vcpu_count: self.vm_config().max_vcpu_count.unwrap_or(vcpu_count),
             ht_enabled: self.vm_config().ht_enabled.unwrap(),
             cpu_template: self.vm_config().cpu_template,
         }
@@ -326,9 +328,38 @@ impl VmResources {
             return Err(VmConfigError::InvalidVcpuCount);
         }
 
+        if let Some(max_vcpu_count) = machine_config.max_vcpu_count {
+            if max_vcpu_count < vcpu_count_value
+                || max_vcpu_count > crate::vmm_config::machine_config::MAX_SUPPORTED_VCPUS
+            {
+                return Err(VmConfigError::InvalidMaxVcpuCount);
+            }
+            if ht_enabled && max_vcpu_count > 1 && max_vcpu_count % 2 == 1 {
+                return Err(VmConfigError::InvalidMaxVcpuCount);
+            }
+            // Booting a wider possible topology than the online count relies on parked
+            // vCPUs waiting for PSCI/INIT-SIPI wake-ups, which the WHP backend does not
+            // implement, and on non-TEE boot topology tables. Reject rather than lie.
+            #[cfg(any(target_os = "windows", target_arch = "riscv64", feature = "tee"))]
+            if max_vcpu_count > vcpu_count_value {
+                return Err(VmConfigError::MaxCapacityUnsupported);
+            }
+        }
+
+        if let Some(max_mem_size_mib) = machine_config.max_mem_size_mib {
+            let mem_size_mib = machine_config
+                .mem_size_mib
+                .unwrap_or_else(|| self.vm_config.mem_size_mib.unwrap());
+            if max_mem_size_mib < mem_size_mib {
+                return Err(VmConfigError::InvalidMaxMemorySize);
+            }
+        }
+
         // Update all the fields that have a new value.
         self.vm_config.vcpu_count = Some(vcpu_count_value);
         self.vm_config.ht_enabled = Some(ht_enabled);
+        self.vm_config.max_vcpu_count = machine_config.max_vcpu_count;
+        self.vm_config.max_mem_size_mib = machine_config.max_mem_size_mib;
 
         if machine_config.mem_size_mib.is_some() {
             self.vm_config.mem_size_mib = machine_config.mem_size_mib;
@@ -471,6 +502,8 @@ impl VmResources {
         self.set_vm_config(&VmConfig {
             vcpu_count: Some(tee_config.cpus),
             mem_size_mib: Some(tee_config.ram_mib),
+            max_vcpu_count: None,
+            max_mem_size_mib: None,
             ht_enabled: Some(false),
             cpu_template: None,
         })
@@ -548,6 +581,7 @@ mod tests {
         let vm_resources = default_vm_resources();
         let expected_vcpu_config = VcpuConfig {
             vcpu_count: vm_resources.vm_config().vcpu_count.unwrap(),
+            max_vcpu_count: vm_resources.vm_config().vcpu_count.unwrap(),
             ht_enabled: vm_resources.vm_config().ht_enabled.unwrap(),
             cpu_template: vm_resources.vm_config().cpu_template,
         };
@@ -570,6 +604,8 @@ mod tests {
         let mut aux_vm_config = VmConfig {
             vcpu_count: Some(32),
             mem_size_mib: Some(512),
+            max_vcpu_count: None,
+            max_mem_size_mib: None,
             ht_enabled: Some(true),
             cpu_template: Some(CpuFeaturesTemplate::T2),
         };
@@ -596,6 +632,61 @@ mod tests {
         assert_eq!(
             vm_resources.set_vm_config(&aux_vm_config),
             Err(VmConfigError::InvalidMemorySize)
+        );
+    }
+
+    #[test]
+    fn test_set_vm_config_max_capacity() {
+        let mut vm_resources = default_vm_resources();
+        let mut vm_config = VmConfig {
+            vcpu_count: Some(2),
+            mem_size_mib: Some(1024),
+            max_vcpu_count: Some(8),
+            max_mem_size_mib: Some(8192),
+            ht_enabled: Some(false),
+            cpu_template: None,
+        };
+
+        vm_resources.set_vm_config(&vm_config).unwrap();
+        let vcpu_config = vm_resources.vcpu_config();
+        assert_eq!(vcpu_config.vcpu_count, 2);
+        assert_eq!(vcpu_config.max_vcpu_count, 8);
+
+        // Without explicit capacity, max tracks the effective count.
+        vm_config.max_vcpu_count = None;
+        vm_config.max_mem_size_mib = None;
+        vm_resources.set_vm_config(&vm_config).unwrap();
+        assert_eq!(vm_resources.vcpu_config().max_vcpu_count, 2);
+
+        // Max vcpus below the effective count.
+        vm_config.max_vcpu_count = Some(1);
+        assert_eq!(
+            vm_resources.set_vm_config(&vm_config),
+            Err(VmConfigError::InvalidMaxVcpuCount)
+        );
+
+        // Max vcpus above the supported limit.
+        vm_config.max_vcpu_count = Some(65);
+        assert_eq!(
+            vm_resources.set_vm_config(&vm_config),
+            Err(VmConfigError::InvalidMaxVcpuCount)
+        );
+
+        // Odd max vcpus with hyperthreading enabled.
+        vm_config.max_vcpu_count = Some(3);
+        vm_config.ht_enabled = Some(true);
+        assert_eq!(
+            vm_resources.set_vm_config(&vm_config),
+            Err(VmConfigError::InvalidMaxVcpuCount)
+        );
+        vm_config.ht_enabled = Some(false);
+
+        // Max memory below the boot memory size.
+        vm_config.max_vcpu_count = Some(8);
+        vm_config.max_mem_size_mib = Some(512);
+        assert_eq!(
+            vm_resources.set_vm_config(&vm_config),
+            Err(VmConfigError::InvalidMaxMemorySize)
         );
     }
 

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -3,9 +3,10 @@
 
 use std::fmt;
 
-/// Firecracker aims to support small scale workloads only, so limit the maximum
-/// vCPUs supported.
-pub const MAX_SUPPORTED_VCPUS: u8 = 32;
+/// Ceiling for possible vCPUs (`max_vcpu_count`). Matches `CONFIG_NR_CPUS=64` in the
+/// non-confidential libkrunfw kernels; a wider topology than the guest kernel can
+/// address would silently strand the extra CPUs.
+pub const MAX_SUPPORTED_VCPUS: u8 = 64;
 
 /// Errors associated with configuring the microVM.
 #[derive(Debug, Eq, PartialEq)]
@@ -15,6 +16,13 @@ pub enum VmConfigError {
     InvalidVcpuCount,
     /// The memory size is invalid. The memory can only be an unsigned integer.
     InvalidMemorySize,
+    /// The maximum vcpu count is invalid: it must be non-zero, at least the effective vcpu
+    /// count, no larger than the supported vcpu limit, and even when hyperthreading is enabled.
+    InvalidMaxVcpuCount,
+    /// The maximum memory size is invalid: it must be non-zero and at least the boot memory size.
+    InvalidMaxMemorySize,
+    /// Reserving capacity above the initial resources is not supported on this platform yet.
+    MaxCapacityUnsupported,
 }
 
 impl fmt::Display for VmConfigError {
@@ -27,6 +35,21 @@ impl fmt::Display for VmConfigError {
                  be 1 or an even number when hyperthreading is enabled.",
             ),
             InvalidMemorySize => write!(f, "The memory size (MiB) is invalid.",),
+            InvalidMaxVcpuCount => write!(
+                f,
+                "The maximum vCPU number is invalid! It must be at least the \
+                 vCPU count and no larger than the supported vCPU limit.",
+            ),
+            InvalidMaxMemorySize => write!(
+                f,
+                "The maximum memory size (MiB) is invalid! It must be at least \
+                 the boot memory size.",
+            ),
+            MaxCapacityUnsupported => write!(
+                f,
+                "Reserving CPU or memory capacity above the initial resources \
+                 is not supported on this platform yet.",
+            ),
         }
     }
 }
@@ -35,10 +58,16 @@ impl fmt::Display for VmConfigError {
 /// microvm.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VmConfig {
-    /// The number of vCPUs.
+    /// The number of vCPUs online at boot.
     pub vcpu_count: Option<u8>,
-    /// The memory size in MiB.
+    /// The boot memory size in MiB.
     pub mem_size_mib: Option<usize>,
+    /// Maximum possible vCPUs. The VM boots with this topology created but only `vcpu_count`
+    /// online, so the guest can online the rest later. `None` means equal to `vcpu_count`.
+    pub max_vcpu_count: Option<u8>,
+    /// Maximum guest memory in MiB reserved for future hotplug (virtio-mem). `None` means
+    /// equal to `mem_size_mib`. Currently config plumbing only; no device consumes it yet.
+    pub max_mem_size_mib: Option<usize>,
     /// Enables or disabled hyperthreading.
     pub ht_enabled: Option<bool>,
     /// A CPU template that it is used to filter the CPU features exposed to the guest.
@@ -50,6 +79,8 @@ impl Default for VmConfig {
         VmConfig {
             vcpu_count: Some(1),
             mem_size_mib: Some(128),
+            max_vcpu_count: None,
+            max_mem_size_mib: None,
             ht_enabled: Some(false),
             cpu_template: None,
         }
@@ -60,12 +91,14 @@ impl fmt::Display for VmConfig {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let vcpu_count = self.vcpu_count.unwrap_or(1);
         let mem_size = self.mem_size_mib.unwrap_or(128);
+        let max_vcpu_count = self.max_vcpu_count.unwrap_or(vcpu_count);
+        let max_mem_size = self.max_mem_size_mib.unwrap_or(mem_size);
         let ht_enabled = self.ht_enabled.unwrap_or(false);
         let cpu_template = self
             .cpu_template
             .map_or("Uninitialized".to_string(), |c| c.to_string());
 
-        write!(f, "{{ \"vcpu_count\": {vcpu_count:?}, \"mem_size_mib\": {mem_size:?},  \"ht_enabled\": {ht_enabled:?},  \"cpu_template\": {cpu_template:?} }}")
+        write!(f, "{{ \"vcpu_count\": {vcpu_count:?}, \"mem_size_mib\": {mem_size:?},  \"max_vcpu_count\": {max_vcpu_count:?},  \"max_mem_size_mib\": {max_mem_size:?},  \"ht_enabled\": {ht_enabled:?},  \"cpu_template\": {cpu_template:?} }}")
     }
 }
 

--- a/src/vmm/src/windows/vstate.rs
+++ b/src/vmm/src/windows/vstate.rs
@@ -415,6 +415,9 @@ pub struct Vm {
 #[derive(Debug, Eq, PartialEq)]
 pub struct VcpuConfig {
     pub vcpu_count: u8,
+    /// Maximum possible guest VCPUs. Always equal to `vcpu_count` on WHP, which
+    /// has no parked-vcpu bring-up; wider capacity is rejected at config time.
+    pub max_vcpu_count: u8,
     pub ht_enabled: bool,
     pub cpu_template: Option<CpuFeaturesTemplate>,
 }


### PR DESCRIPTION
## TL;DR
Add the VMM building blocks for live sandbox resize: boot-time max CPU and memory capacity, a virtio-mem device for live memory, a private CPU capacity device with host-side enforcement, and a VmControl handle so the host can drive both while the VM runs.

## Description
- Add boot-time capacity to the machine config: MachineBuilder gains max_vcpus() and max_memory_mib(), and VmConfig/VmResources carry the max vs effective split. Both default to the effective values, so existing callers are unaffected, and MAX_SUPPORTED_VCPUS is raised to 64. Windows, riscv64, and TEE reject capacity above the initial count.
- Boot the full possible vCPU topology with only the requested count online (maxcpus=), reusing existing SMP bring-up: KVM secondaries power off awaiting PSCI, HVF secondaries park on a boot channel. HVF gains CPU_ON/CPU_OFF/AFFINITY_INFO handling so the guest can online and offline CPUs at runtime.
- Add a virtio-mem device (plug/unplug/state over a 2 MiB block bitmap, madvise on unplug) plus a boot-time reserved hotplug region above the SHM windows, lazily backed so unused capacity costs nothing.
- Add a private CPU capacity device (id 0x4d43) whose config space carries possible, requested_online, and actual_online; the guest driver converges and reports back.
- Enforce CPU shrink host-side regardless of guest cooperation: a shared enforced count is consulted by every vCPU run loop, throttling over-count vCPUs after a grace window, and a forced-exit kicker (hv_vcpus_exit on HVF, a signal on KVM) makes even a hard-spinning vCPU observe enforcement.
- Add Vm::control_handle() returning a cloneable VmControl (obtained before enter(), like ExitHandle) with set_cpu_target/cpu_state and set_memory_target_mib/memory_state. The C ABI is unchanged.
- Inject memhp_default_state=online_movable when virtio-mem is attached, so hotplugged blocks come online on guests without MEMORY_HOTPLUG_DEFAULT_ONLINE.

```rust
let vm = VmBuilder::new()
    .machine(|m| m.vcpus(2).max_vcpus(8).memory_mib(512).max_memory_mib(2048))
    .build()?;

let control = vm.control_handle();   // must be taken before enter()
control.set_cpu_target(4);           // online CPUs up to 4, enforced host-side
control.set_memory_target_mib(1024); // grow guest memory to 1 GiB via virtio-mem
let cpu = control.cpu_state();       // requested / actual / enforced
```

## Test Plan
- [x] `cargo test -p msb_krun --lib` passes
- [x] `cargo clippy -p msb_krun -p msb_krun_vmm -p msb_krun_devices` is clean
- [x] live CPU grow, shrink, and uncooperative-guest enforcement verified on macOS HVF (spinner drops from ~200% to ~105% host CPU after the grace window)
- [x] live memory grow and shrink verified on macOS HVF and Linux KVM
- [ ] full workspace build including the GUI crates (blocked locally by an unrelated bindgen/inttypes toolchain issue, runs in CI)