### PR TITLE
chore(krun): bump msb_krun crates to 0.1.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -951,11 +951,11 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.20"
+version = "0.1.21"
 
 [[package]]
 name = "msb_krun_aws_nitro"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "libc",
  "log",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_display"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "bindgen 0.72.0",
  "bitflags 2.10.0",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "crossbeam-channel",
  "libloading",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_input"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "bindgen 0.72.0",
  "bitflags 2.10.0",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "msb_krun_utils",
  "vm-memory",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_rutabaga_gfx"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1078,14 +1078,14 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -722,7 +722,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "msb_krun_display"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "bindgen",
  "bitflags 2.11.0",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_input"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "bindgen",
  "bitflags 2.11.0",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_arch"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["The Chromium OS Authors"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
@@ -17,9 +17,9 @@ efi = []
 libc = ">=0.2.39"
 vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
 
-arch_gen = { package = "msb_krun_arch_gen", version = "0.1.20", path = "../arch_gen" }
-smbios = { package = "msb_krun_smbios", version = "0.1.20", path = "../smbios" }
-utils = { package = "msb_krun_utils", version = "0.1.20", path = "../utils" }
+arch_gen = { package = "msb_krun_arch_gen", version = "0.1.21", path = "../arch_gen" }
+smbios = { package = "msb_krun_smbios", version = "0.1.21", path = "../smbios" }
+utils = { package = "msb_krun_utils", version = "0.1.21", path = "../utils" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
@@ -27,4 +27,4 @@ kvm-ioctls = ">=0.21"
 tdx = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
-utils = { package = "msb_krun_utils", version = "0.1.20", path = "../utils" }
+utils = { package = "msb_krun_utils", version = "0.1.21", path = "../utils" }

--- a/src/arch_gen/Cargo.toml
+++ b/src/arch_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_arch_gen"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"

--- a/src/aws_nitro/Cargo.toml
+++ b/src/aws_nitro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_aws_nitro"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 license = "Apache-2.0"
 description = "AWS Nitro Enclaves support for msb_krun microVMs"
@@ -15,7 +15,7 @@ nix = { version = "0.30", features = ["poll"] }
 tar = "0.4"
 vsock = "0.5"
 
-devices = { package = "msb_krun_devices", version = "0.1.20", path = "../devices" }
+devices = { package = "msb_krun_devices", version = "0.1.21", path = "../devices" }
 log = "0.4"
 signal-hook = "0.3"
 

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_cpuid"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_devices"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["The Chromium OS Authors"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
@@ -34,21 +34,21 @@ thiserror = { version = "2.0", optional = true }
 virtio-bindings = "0.2.0"
 vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
 zerocopy = { version = "0.8.26", optional = true, features = ["derive"] }
-krun_display = { package = "msb_krun_display", version = "0.1.20", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
-krun_input = { package = "msb_krun_input", version = "0.1.20", path = "../krun_input", features = ["bindgen_clang_runtime"], optional = true }
+krun_display = { package = "msb_krun_display", version = "0.1.21", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
+krun_input = { package = "msb_krun_input", version = "0.1.21", path = "../krun_input", features = ["bindgen_clang_runtime"], optional = true }
 
-arch = { package = "msb_krun_arch", version = "0.1.20", path = "../arch" }
-utils = { package = "msb_krun_utils", version = "0.1.20", path = "../utils" }
-polly = { package = "msb_krun_polly", version = "0.1.20", path = "../polly" }
-rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.20", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
+arch = { package = "msb_krun_arch", version = "0.1.21", path = "../arch" }
+utils = { package = "msb_krun_utils", version = "0.1.21", path = "../utils" }
+polly = { package = "msb_krun_polly", version = "0.1.21", path = "../polly" }
+rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.21", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
 imago = { package = "msb-imago", version = "0.1.0", features = ["sync-wrappers", "vm-memory"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "msb_krun_hvf", version = "0.1.20", path = "../hvf" }
+hvf = { package = "msb_krun_hvf", version = "0.1.21", path = "../hvf" }
 lru = ">=0.9"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.20", path = "../rutabaga_gfx", features = ["x"], optional = true }
+rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.21", path = "../rutabaga_gfx", features = ["x"], optional = true }
 capng = "0.2.3"
 caps = "0.5.5"
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }

--- a/src/hvf/Cargo.toml
+++ b/src/hvf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_hvf"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["Sergio Lopez <slp@sinrega.org>"]
 edition = "2021"
 build = "build.rs"
@@ -13,4 +13,4 @@ crossbeam-channel = ">=0.5.15"
 libloading = "0.8"
 log = "0.4.0"
 
-arch = { package = "msb_krun_arch", version = "0.1.20", path = "../arch" }
+arch = { package = "msb_krun_arch", version = "0.1.21", path = "../arch" }

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_kernel"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
 description = "Kernel loading utilities for msb_krun microVMs"
@@ -9,4 +9,4 @@ repository = "https://github.com/containers/libkrun"
 [dependencies]
 vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
 
-utils = { package = "msb_krun_utils", version = "0.1.20", path = "../utils" }
+utils = { package = "msb_krun_utils", version = "0.1.21", path = "../utils" }

--- a/src/krun/Cargo.toml
+++ b/src/krun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["The libkrun Authors"]
 edition = "2021"
 description = "Native Rust API for libkrun microVMs"
@@ -26,21 +26,21 @@ libc = ">=0.2.39"
 libloading = "0.8"
 log = "0.4.0"
 
-devices = { package = "msb_krun_devices", version = "0.1.20", path = "../devices" }
-polly = { package = "msb_krun_polly", version = "0.1.20", path = "../polly" }
-utils = { package = "msb_krun_utils", version = "0.1.20", path = "../utils" }
-vmm = { package = "msb_krun_vmm", version = "0.1.20", path = "../vmm" }
+devices = { package = "msb_krun_devices", version = "0.1.21", path = "../devices" }
+polly = { package = "msb_krun_polly", version = "0.1.21", path = "../polly" }
+utils = { package = "msb_krun_utils", version = "0.1.21", path = "../utils" }
+vmm = { package = "msb_krun_vmm", version = "0.1.21", path = "../vmm" }
 
 # Optional dependencies
-krun_display = { package = "msb_krun_display", version = "0.1.20", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
-krun_input = { package = "msb_krun_input", version = "0.1.20", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
+krun_display = { package = "msb_krun_display", version = "0.1.21", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
+krun_input = { package = "msb_krun_input", version = "0.1.21", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "msb_krun_hvf", version = "0.1.20", path = "../hvf" }
+hvf = { package = "msb_krun_hvf", version = "0.1.21", path = "../hvf" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"
 vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
-aws-nitro = { package = "msb_krun_aws_nitro", version = "0.1.20", path = "../aws_nitro", optional = true }
+aws-nitro = { package = "msb_krun_aws_nitro", version = "0.1.21", path = "../aws_nitro", optional = true }
 nitro-enclaves = { version = "0.6.0", optional = true }

--- a/src/krun_display/Cargo.toml
+++ b/src/krun_display/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msb_krun_display"
 description = "Rust bindings for implemeting display backends in Rust for libkrun"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/containers/libkrun"

--- a/src/krun_input/Cargo.toml
+++ b/src/krun_input/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msb_krun_input"
 description = "Rust bindings for implementing input backends in Rust for libkrun"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/containers/libkrun"

--- a/src/polly/Cargo.toml
+++ b/src/polly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_polly"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -9,4 +9,4 @@ repository = "https://github.com/containers/libkrun"
 
 [dependencies]
 libc = ">=0.2.39"
-utils = { package = "msb_krun_utils", version = "0.1.20", path = "../utils" }
+utils = { package = "msb_krun_utils", version = "0.1.21", path = "../utils" }

--- a/src/polly/src/event_manager.rs
+++ b/src/polly/src/event_manager.rs
@@ -247,12 +247,17 @@ impl EventManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use std::os::unix::net::UnixStream;
+
     use utils::epoll::EventSet;
     use utils::eventfd::EventFd;
 
     struct DummySubscriber {
-        event_fd_1: EventFd,
-        event_fd_2: EventFd,
+        stream_1: UnixStream,
+        stream_1_peer: UnixStream,
+        stream_2: UnixStream,
+        _stream_2_peer: UnixStream,
 
         // Flags used for checking that the event manager called the `process`
         // function for ev1/ev2.
@@ -269,9 +274,14 @@ mod tests {
 
     impl DummySubscriber {
         fn new() -> Self {
+            let (stream_1, stream_1_peer) = UnixStream::pair().unwrap();
+            let (stream_2, stream_2_peer) = UnixStream::pair().unwrap();
+
             DummySubscriber {
-                event_fd_1: EventFd::new(0).unwrap(),
-                event_fd_2: EventFd::new(0).unwrap(),
+                stream_1,
+                stream_1_peer,
+                stream_2,
+                _stream_2_peer: stream_2_peer,
                 processed_ev1_out: false,
                 processed_ev2_out: false,
                 processed_ev1_in: false,
@@ -283,6 +293,14 @@ mod tests {
     }
 
     impl DummySubscriber {
+        fn stream_1_fd(&self) -> RawFd {
+            self.stream_1.as_raw_fd()
+        }
+
+        fn stream_2_fd(&self) -> RawFd {
+            self.stream_2.as_raw_fd()
+        }
+
         fn register_ev2(&mut self) {
             self.register_ev2 = true;
         }
@@ -307,6 +325,10 @@ mod tests {
             self.processed_ev1_in
         }
 
+        fn make_ev1_readable(&mut self) {
+            self.stream_1_peer.write_all(&[1]).unwrap();
+        }
+
         fn reset_state(&mut self) {
             self.processed_ev1_out = false;
             self.processed_ev2_out = false;
@@ -317,28 +339,24 @@ mod tests {
             if self.register_ev2 {
                 event_manager
                     .register(
-                        self.event_fd_2.as_raw_fd(),
-                        EpollEvent::new(EventSet::OUT, self.event_fd_2.as_raw_fd() as u64),
-                        event_manager
-                            .subscriber(self.event_fd_1.as_raw_fd())
-                            .unwrap(),
+                        self.stream_2_fd(),
+                        EpollEvent::new(EventSet::OUT, self.stream_2_fd() as u64),
+                        event_manager.subscriber(self.stream_1_fd()).unwrap(),
                     )
                     .unwrap();
                 self.register_ev2 = false;
             }
 
             if self.unregister_ev1 {
-                event_manager
-                    .unregister(self.event_fd_1.as_raw_fd())
-                    .unwrap();
+                event_manager.unregister(self.stream_1_fd()).unwrap();
                 self.unregister_ev1 = false;
             }
 
             if self.modify_ev1 {
                 event_manager
                     .modify(
-                        self.event_fd_1.as_raw_fd(),
-                        EpollEvent::new(EventSet::IN, self.event_fd_1.as_raw_fd() as u64),
+                        self.stream_1_fd(),
+                        EpollEvent::new(EventSet::IN, self.stream_1_fd() as u64),
                     )
                     .unwrap();
                 self.modify_ev1 = false;
@@ -346,17 +364,17 @@ mod tests {
         }
 
         fn handle_in(&mut self, source: RawFd) {
-            if self.event_fd_1.as_raw_fd() == source {
+            if self.stream_1_fd() == source {
                 self.processed_ev1_in = true;
             }
         }
 
         fn handle_out(&mut self, source: RawFd) {
             match source {
-                _ if self.event_fd_1.as_raw_fd() == source => {
+                _ if self.stream_1_fd() == source => {
                     self.processed_ev1_out = true;
                 }
-                _ if self.event_fd_2.as_raw_fd() == source => {
+                _ if self.stream_2_fd() == source => {
                     self.processed_ev2_out = true;
                 }
                 _ => {}
@@ -386,10 +404,7 @@ mod tests {
         }
 
         fn interest_list(&self) -> Vec<EpollEvent> {
-            vec![EpollEvent::new(
-                EventSet::OUT,
-                self.event_fd_1.as_raw_fd() as u64,
-            )]
+            vec![EpollEvent::new(EventSet::OUT, self.stream_1_fd() as u64)]
         }
     }
 
@@ -459,12 +474,7 @@ mod tests {
         dummy_subscriber.lock().unwrap().reset_state();
 
         // Make sure ev1 is ready for IN so that we don't loop forever.
-        dummy_subscriber
-            .lock()
-            .unwrap()
-            .event_fd_1
-            .write(1)
-            .unwrap();
+        dummy_subscriber.lock().unwrap().make_ev1_readable();
 
         event_manager.run().unwrap();
         assert!(!dummy_subscriber.lock().unwrap().processed_ev1_out());
@@ -505,15 +515,15 @@ mod tests {
 
         // At this point ev2 is not registered. Check that unregistering it throws an error.
         assert!(event_manager
-            .unregister(dummy_subscriber.lock().unwrap().event_fd_2.as_raw_fd())
+            .unregister(dummy_subscriber.lock().unwrap().stream_2_fd())
             .is_err());
 
         // Try to unregister ev1 twice. Only the first call should be successful.
         assert!(event_manager
-            .unregister(dummy_subscriber.lock().unwrap().event_fd_1.as_raw_fd())
+            .unregister(dummy_subscriber.lock().unwrap().stream_1_fd())
             .is_ok());
         assert!(event_manager
-            .unregister(dummy_subscriber.lock().unwrap().event_fd_1.as_raw_fd())
+            .unregister(dummy_subscriber.lock().unwrap().stream_1_fd())
             .is_err());
     }
 
@@ -526,7 +536,7 @@ mod tests {
             .add_subscriber(dummy_subscriber.clone())
             .unwrap();
 
-        let dummy_fd = dummy_subscriber.lock().unwrap().event_fd_1.as_raw_fd();
+        let dummy_fd = dummy_subscriber.lock().unwrap().stream_1_fd();
         assert!(event_manager.subscriber(dummy_fd).is_ok());
         assert!(event_manager.subscriber(-1).is_err());
     }

--- a/src/rutabaga_gfx/Cargo.toml
+++ b/src/rutabaga_gfx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_rutabaga_gfx"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["The ChromiumOS Authors + Android Open Source Project"]
 edition = "2021"
 description = "[highly unstable] Handling virtio-gpu protocols"

--- a/src/rutabaga_gfx/src/rutabaga_gralloc/gralloc.rs
+++ b/src/rutabaga_gfx/src/rutabaga_gralloc/gralloc.rs
@@ -354,6 +354,17 @@ impl RutabagaGralloc {
 mod tests {
     use super::*;
 
+    fn image_memory_requirements_or_skip(
+        gralloc: &mut RutabagaGralloc,
+        info: ImageAllocationInfo,
+    ) -> Option<ImageMemoryRequirements> {
+        match gralloc.get_image_memory_requirements(info) {
+            Ok(reqs) => Some(reqs),
+            Err(RutabagaError::Unsupported) => None,
+            Err(err) => panic!("unexpected gralloc requirements error: {err:?}"),
+        }
+    }
+
     #[test]
     #[cfg_attr(target_os = "windows", ignore)]
     fn create_render_target() {
@@ -371,7 +382,9 @@ mod tests {
             flags: RutabagaGrallocFlags::empty().use_scanout(true),
         };
 
-        let reqs = gralloc.get_image_memory_requirements(info).unwrap();
+        let Some(reqs) = image_memory_requirements_or_skip(&mut gralloc, info) else {
+            return;
+        };
         let min_reqs = canonical_image_requirements(info).unwrap();
 
         assert!(reqs.strides[0] >= min_reqs.strides[0]);
@@ -400,7 +413,9 @@ mod tests {
             flags: RutabagaGrallocFlags::empty().use_linear(true),
         };
 
-        let reqs = gralloc.get_image_memory_requirements(info).unwrap();
+        let Some(reqs) = image_memory_requirements_or_skip(&mut gralloc, info) else {
+            return;
+        };
         let min_reqs = canonical_image_requirements(info).unwrap();
 
         assert!(reqs.strides[0] >= min_reqs.strides[0]);
@@ -441,7 +456,9 @@ mod tests {
                 .use_sw_read(true),
         };
 
-        let mut reqs = gralloc.get_image_memory_requirements(info).unwrap();
+        let Some(mut reqs) = image_memory_requirements_or_skip(&mut gralloc, info) else {
+            return;
+        };
 
         // Anything else can use the mmap(..) system call.
         if reqs.vulkan_info.is_none() {

--- a/src/smbios/Cargo.toml
+++ b/src/smbios/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_smbios"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 license = "Apache-2.0"
 description = "SMBIOS table generation for msb_krun microVMs"

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_utils"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"

--- a/src/utils/src/macos/epoll.rs
+++ b/src/utils/src/macos/epoll.rs
@@ -146,6 +146,23 @@ impl Epoll {
         }
     }
 
+    fn delete_filter(&self, fd: RawFd, filter: i16, udata: u64) {
+        let kev = Kevent::new(fd as usize, filter, libc::EV_DELETE, udata);
+
+        // Deleting a missing kqueue filter is fine for our epoll-style API. Callers often ask to
+        // delete the whole mask without knowing which individual filters were registered.
+        let _ = unsafe {
+            libc::kevent(
+                self.queue,
+                &kev as *const Kevent as *const libc::kevent,
+                1,
+                ptr::null_mut(),
+                0,
+                ptr::null(),
+            )
+        };
+    }
+
     pub fn ctl(
         &self,
         operation: ControlOperation,
@@ -155,7 +172,14 @@ impl Epoll {
         let eset = EventSet::from_bits(event.events).unwrap();
 
         match operation {
-            ControlOperation::Add | ControlOperation::Modify => {
+            ControlOperation::Modify => {
+                // kqueue tracks read and write filters separately, while epoll MOD replaces the
+                // whole event mask. Drop any old filters first so stale readiness does not leak
+                // through after a caller narrows its interest set.
+                self.ctl(ControlOperation::Delete, fd, &EpollEvent::default())?;
+                self.ctl(ControlOperation::Add, fd, event)?;
+            }
+            ControlOperation::Add => {
                 let mut kevs: Vec<Kevent> = Vec::new();
                 let clear = if eset.contains(EventSet::EDGE_TRIGGERED) {
                     libc::EV_CLEAR
@@ -193,51 +217,20 @@ impl Epoll {
                 assert_eq!(ret, 0);
             }
             ControlOperation::Delete => {
-                let mut kevs: Vec<Kevent> = Vec::new();
                 if eset.bits() == 0 {
                     debug!("remove fd in and out: {fd}");
-                    kevs.push(Kevent::new(
-                        fd as usize,
-                        libc::EVFILT_READ,
-                        libc::EV_DELETE,
-                        event.u64,
-                    ));
-                    kevs.push(Kevent::new(
-                        fd as usize,
-                        libc::EVFILT_WRITE,
-                        libc::EV_DELETE,
-                        event.u64,
-                    ));
+                    self.delete_filter(fd, libc::EVFILT_READ, event.u64);
+                    self.delete_filter(fd, libc::EVFILT_WRITE, event.u64);
                 } else {
                     if eset.contains(EventSet::IN) {
                         debug!("remove fd in: {fd}");
-                        kevs.push(Kevent::new(
-                            fd as usize,
-                            libc::EVFILT_READ,
-                            libc::EV_DELETE,
-                            event.u64,
-                        ));
+                        self.delete_filter(fd, libc::EVFILT_READ, event.u64);
                     }
                     if eset.contains(EventSet::OUT) {
                         debug!("remove fd out: {fd}");
-                        kevs.push(Kevent::new(
-                            fd as usize,
-                            libc::EVFILT_WRITE,
-                            libc::EV_DELETE,
-                            event.u64,
-                        ));
+                        self.delete_filter(fd, libc::EVFILT_WRITE, event.u64);
                     }
                 }
-                let _ = unsafe {
-                    libc::kevent(
-                        self.queue,
-                        kevs.as_ptr() as *const libc::kevent,
-                        kevs.len() as i32,
-                        ptr::null_mut(),
-                        0,
-                        ptr::null(),
-                    )
-                };
             }
         }
         Ok(())
@@ -249,16 +242,18 @@ impl Epoll {
         timeout: i32,
         events: &mut [EpollEvent],
     ) -> io::Result<usize> {
-        let _tout = if timeout >= 0 {
+        let timeout_duration = if timeout >= 0 {
             Some(Duration::from_millis(timeout as u64))
         } else {
             None
         };
-
-        let ts = libc::timespec {
-            tv_sec: 3,
-            tv_nsec: 0,
-        };
+        let timeout_spec = timeout_duration.map(|timeout| libc::timespec {
+            tv_sec: timeout.as_secs() as libc::time_t,
+            tv_nsec: timeout.subsec_nanos() as libc::c_long,
+        });
+        let timeout_ptr = timeout_spec
+            .as_ref()
+            .map_or(ptr::null(), |ts| ts as *const libc::timespec);
 
         let mut kevs = vec![Kevent::default(); events.len()];
         debug!("kevs len: {}", kevs.len());
@@ -269,7 +264,7 @@ impl Epoll {
                 0,
                 kevs.as_mut_ptr() as *mut libc::kevent,
                 max_events as i32,
-                &ts as *const libc::timespec,
+                timeout_ptr,
             )
         };
 

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_vmm"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
@@ -26,15 +26,15 @@ libc = ">=0.2.39"
 log = "0.4.0"
 nix = { version = "0.30.1", features = ["fs", "term"] }
 vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
-krun_display = { package = "msb_krun_display", version = "0.1.20", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
-krun_input = { package = "msb_krun_input", version = "0.1.20", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
+krun_display = { package = "msb_krun_display", version = "0.1.21", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
+krun_input = { package = "msb_krun_input", version = "0.1.21", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
 
-arch = { package = "msb_krun_arch", version = "0.1.20", path = "../arch" }
-arch_gen = { package = "msb_krun_arch_gen", version = "0.1.20", path = "../arch_gen" }
-devices = { package = "msb_krun_devices", version = "0.1.20", path = "../devices" }
-kernel = { package = "msb_krun_kernel", version = "0.1.20", path = "../kernel" }
-utils = { package = "msb_krun_utils", version = "0.1.20", path = "../utils" }
-polly = { package = "msb_krun_polly", version = "0.1.20", path = "../polly" }
+arch = { package = "msb_krun_arch", version = "0.1.21", path = "../arch" }
+arch_gen = { package = "msb_krun_arch_gen", version = "0.1.21", path = "../arch_gen" }
+devices = { package = "msb_krun_devices", version = "0.1.21", path = "../devices" }
+kernel = { package = "msb_krun_kernel", version = "0.1.21", path = "../kernel" }
+utils = { package = "msb_krun_utils", version = "0.1.21", path = "../utils" }
+polly = { package = "msb_krun_polly", version = "0.1.21", path = "../polly" }
 
 # Dependencies for amd-sev
 kbs-types = { version = "0.13.0", optional = true }
@@ -49,7 +49,7 @@ bzip2 = "0.5"
 zstd = "0.13"
 
 [target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dependencies]
-cpuid = { package = "msb_krun_cpuid", version = "0.1.20", path = "../cpuid" }
+cpuid = { package = "msb_krun_cpuid", version = "0.1.21", path = "../cpuid" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tdx = { version = "0.1.0", optional = true }
@@ -57,11 +57,11 @@ kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "msb_krun_hvf", version = "0.1.20", path = "../hvf" }
+hvf = { package = "msb_krun_hvf", version = "0.1.21", path = "../hvf" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 libloading = "0.8"
 windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_System_Hypervisor", "Win32_System_ProcessStatus", "Win32_System_Threading"] }
 
 [dev-dependencies]
-devices = { package = "msb_krun_devices", version = "0.1.20", path = "../devices", features = ["test_utils"] }
+devices = { package = "msb_krun_devices", version = "0.1.21", path = "../devices", features = ["test_utils"] }

--- a/src/vmm/src/device_manager/hvf/mmio.rs
+++ b/src/vmm/src/device_manager/hvf/mmio.rs
@@ -368,7 +368,6 @@ impl DeviceInfoForFDT for MMIODeviceInfo {
 
 #[cfg(all(test, not(target_os = "windows")))]
 mod tests {
-    use super::super::super::builder;
     use super::*;
     use arch;
     use devices::legacy::DummyIrqChip;
@@ -383,7 +382,6 @@ mod tests {
     impl MMIODeviceManager {
         fn register_virtio_device(
             &mut self,
-            _vm: &Vm,
             guest_mem: GuestMemoryMmap,
             device: Arc<Mutex<dyn devices::virtio::VirtioDevice>>,
             _cmdline: &mut kernel_cmdline::Cmdline,
@@ -467,19 +465,14 @@ mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let mut vm = builder::setup_kvm_vm(&guest_mem).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
 
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
         let dummy = Arc::new(Mutex::new(DummyDevice::new()));
-        #[cfg(target_arch = "x86_64")]
-        assert!(builder::setup_interrupt_controller(&mut vm).is_ok());
-        #[cfg(target_arch = "aarch64")]
-        assert!(builder::setup_interrupt_controller(&mut vm, 1).is_ok());
 
         assert!(device_manager
-            .register_virtio_device(&vm, guest_mem, dummy, &mut cmdline, 0, "dummy")
+            .register_virtio_device(guest_mem, dummy, &mut cmdline, 0, "dummy")
             .is_ok());
     }
 
@@ -489,20 +482,14 @@ mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let mut vm = builder::setup_kvm_vm(&guest_mem).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
 
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
-        #[cfg(target_arch = "x86_64")]
-        assert!(builder::setup_interrupt_controller(&mut vm).is_ok());
-        #[cfg(target_arch = "aarch64")]
-        assert!(builder::setup_interrupt_controller(&mut vm, 1).is_ok());
 
         for _i in arch::IRQ_BASE..=arch::IRQ_MAX {
             device_manager
                 .register_virtio_device(
-                    &vm,
                     guest_mem.clone(),
                     Arc::new(Mutex::new(DummyDevice::new())),
                     &mut cmdline,
@@ -516,7 +503,6 @@ mod tests {
                 "{}",
                 device_manager
                     .register_virtio_device(
-                        &vm,
                         guest_mem,
                         Arc::new(Mutex::new(DummyDevice::new())),
                         &mut cmdline,
@@ -533,7 +519,7 @@ mod tests {
     fn test_dummy_device() {
         let dummy = DummyDevice::new();
         assert_eq!(dummy.device_type(), 0);
-        assert_eq!(dummy.queue_config().len(), QUEUE_CONFIG.len());
+        assert_eq!(dummy.queue_config().len(), QUEUE_SIZES.len());
     }
 
     #[test]
@@ -592,7 +578,6 @@ mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let vm = builder::setup_kvm_vm(&guest_mem).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);
@@ -601,7 +586,7 @@ mod tests {
         let type_id = 0;
         let id = String::from("foo");
         if let Ok(addr) =
-            device_manager.register_virtio_device(&vm, guest_mem, dummy, &mut cmdline, type_id, &id)
+            device_manager.register_virtio_device(guest_mem, dummy, &mut cmdline, type_id, &id)
         {
             assert!(device_manager
                 .get_device(DeviceType::Virtio(type_id), &id)

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -11,7 +11,6 @@ use std::fmt::{Display, Formatter};
 use std::io;
 use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};
-#[cfg(not(test))]
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -732,7 +731,7 @@ enum VcpuEmulation {
     WaitForEventTimeout(Duration),
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
     #[cfg(target_arch = "x86_64")]
     use crossbeam_channel::{unbounded, RecvTimeoutError};
@@ -1118,5 +1117,56 @@ mod tests {
         };
         // Setting default state should always fail.
         assert!(vcpu.restore_state(state).is_err());
+    }
+}
+
+#[cfg(all(test, target_arch = "aarch64"))]
+mod tests {
+    use super::*;
+
+    fn test_vcpu(id: u8) -> Vcpu {
+        Vcpu::new_aarch64(
+            id,
+            GuestAddress(0x1000),
+            None,
+            EventFd::new(utils::eventfd::EFD_NONBLOCK).unwrap(),
+            Arc::new(VcpuList::new(1)),
+            false,
+            MetricsWriter::default(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_set_mmio_bus() {
+        let mut vcpu = test_vcpu(0);
+
+        assert!(vcpu.mmio_bus.is_none());
+        vcpu.set_mmio_bus(devices::Bus::new());
+        assert!(vcpu.mmio_bus.is_some());
+    }
+
+    #[test]
+    fn test_configure_aarch64_records_fdt_addr() {
+        let mut vcpu = test_vcpu(0);
+        let mem_info = ArchMemoryInfo {
+            fdt_addr: 0x2000,
+            ..Default::default()
+        };
+
+        vcpu.configure_aarch64(&mem_info).unwrap();
+
+        assert_eq!(vcpu.fdt_addr, 0x2000);
+    }
+
+    #[test]
+    fn test_vcpu_tls_lifecycle() {
+        let mut vcpu = test_vcpu(0);
+
+        assert!(vcpu.reset_thread_local_data().is_err());
+        assert!(vcpu.init_thread_local_data().is_ok());
+        assert!(vcpu.init_thread_local_data().is_err());
+        assert!(vcpu.reset_thread_local_data().is_ok());
+        assert!(vcpu.reset_thread_local_data().is_err());
     }
 }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -535,64 +535,13 @@ mod tests {
     #[cfg(feature = "gpu")]
     use crate::resources::DisplayBackendConfig;
     use crate::resources::VmResources;
-    use crate::vmm_config::kernel_cmdline::KernelCmdlineConfig;
     use crate::vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig, VmConfigError};
     use crate::vmm_config::vsock::tests::{default_config, TempSockFile};
     use crate::vstate::VcpuConfig;
-    use utils::metrics::MetricsWriter;
     use utils::tempfile::TempFile;
 
-    fn default_kernel_cmdline() -> KernelCmdlineConfig {
-        KernelCmdlineConfig {
-            prolog: None,
-            krun_env: None,
-            epilog: None,
-        }
-    }
-
     fn default_vm_resources() -> VmResources {
-        VmResources {
-            vm_config: VmConfig::default(),
-            firmware_config: None,
-            kernel_cmdline: default_kernel_cmdline(),
-            kernel_bundle: Default::default(),
-            external_kernel: None,
-            fs: Default::default(),
-            #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
-            custom_fs: Default::default(),
-            vsock: Default::default(),
-            #[cfg(feature = "net")]
-            net_builder: Default::default(),
-            gpu_virgl_flags: None,
-            gpu_shm_size: None,
-            #[cfg(feature = "gpu")]
-            display_backend: None,
-            #[cfg(feature = "gpu")]
-            displays: Vec::new(),
-            #[cfg(feature = "input")]
-            input_backends: Vec::new(),
-            #[cfg(feature = "snd")]
-            snd_device: false,
-            console_output: None,
-            smbios_oem_strings: None,
-            nested_enabled: false,
-            split_irqchip: false,
-            metrics: MetricsWriter::default(),
-            request_vsock: false,
-            enable_balloon: true,
-            #[cfg(not(feature = "tee"))]
-            mem_device: None,
-            #[cfg(not(feature = "tee"))]
-            cpu_device: None,
-            balloon_stats_interval: Some(std::time::Duration::from_secs(1)),
-            enable_rng: true,
-            enable_msb_metrics: true,
-            disable_implicit_console: false,
-            #[cfg(not(target_os = "windows"))]
-            serial_consoles: Vec::new(),
-            virtio_consoles: Vec::new(),
-            kernel_console: None,
-        }
+        VmResources::default()
     }
 
     #[test]


### PR DESCRIPTION
## TL;DR
Bump the `msb_krun*` crate set to `0.1.21` and refresh the local macOS test blockers found while validating the release bump.

## Description
- Updates all `msb_krun*` package versions and internal Cargo references from `0.1.20` to `0.1.21`.
- Refreshes `Cargo.lock` so the workspace path packages resolve at `0.1.21`.
- Fixes the macOS epoll shim so `Modify` replaces the old kqueue filters and timeout values are honored.
- Updates `polly` event-manager tests to use Unix socket pairs for readable and writable readiness on macOS.
- Removes stale KVM setup from HVF MMIO tests and adds small macOS vCPU tests for the current HVF API.
- Lets gralloc tests return early when the active backend reports `Unsupported`, while still failing on unexpected errors.
- Uses `VmResources::default()` in resource tests so the helper stays aligned with the struct layout.

## Test Plan
- [x] `SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk BINDGEN_EXTRA_CLANG_ARGS='-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include' cargo build --all` exits 0
- [x] `SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk BINDGEN_EXTRA_CLANG_ARGS='-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include' cargo check --all` exits 0
- [x] `SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk BINDGEN_EXTRA_CLANG_ARGS='-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include' cargo test --all` passes
- [x] `SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk BINDGEN_EXTRA_CLANG_ARGS='-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include' cargo clippy --all` exits 0