### PR TITLE
feat(windows): normalize guest CPUID and tick the PIT at the programmed rate

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -31,7 +31,7 @@ use std::os::fd::{BorrowedFd, FromRawFd};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicI32;
 #[cfg(all(target_arch = "x86_64", target_os = "windows"))]
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -2693,11 +2693,15 @@ pub fn setup_serial_device(
 struct WindowsX64PitStub {
     channels: [u8; 3],
     command: u8,
+    channel0_access: u8,
+    channel0_mode: u8,
+    channel0_write_lsb: Option<u8>,
+    channel0_period_ns: Arc<AtomicU64>,
+    channel0_periodic: Arc<AtomicBool>,
     channel2_latch: u32,
     channel2_started_at: Option<Instant>,
     channel2_write_lsb: Option<u8>,
     channel2_read_msb_next: bool,
-    armed: Arc<AtomicBool>,
     running: Arc<AtomicBool>,
 }
 
@@ -2720,19 +2724,38 @@ struct WindowsX64PostCodeStub {
 #[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 impl WindowsX64PitStub {
     fn new(intc: IrqChip) -> Self {
-        let armed = Arc::new(AtomicBool::new(false));
+        let channel0_period_ns = Arc::new(AtomicU64::new(0));
+        let channel0_periodic = Arc::new(AtomicBool::new(false));
         let running = Arc::new(AtomicBool::new(true));
-        let thread_armed = armed.clone();
+        let thread_period = channel0_period_ns.clone();
+        let thread_periodic = channel0_periodic.clone();
         let thread_running = running.clone();
 
+        // Channel 0 timer: ticks at the guest-programmed rate and injects
+        // IRQ0 through the IOAPIC route, which already drops it while the
+        // guest keeps the pin masked.
         std::thread::spawn(move || {
             while thread_running.load(Ordering::Relaxed) {
-                std::thread::sleep(std::time::Duration::from_millis(10));
-                if thread_armed.load(Ordering::Relaxed) {
+                let period_ns = thread_period.load(Ordering::Relaxed);
+                if period_ns == 0 {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    continue;
+                }
+                // Clamp so a tiny divisor cannot busy-spin the host;
+                // jiffies-grade timing is all a guest needs from a PIT.
+                std::thread::sleep(std::time::Duration::from_nanos(period_ns.max(1_000_000)));
+                if thread_period.load(Ordering::Relaxed) == 0 {
+                    continue;
+                }
+                {
                     let intc = intc.lock().unwrap();
                     if let Err(e) = intc.set_irq(Some(0), None) {
                         trace!("PIT tick interrupt injection failed: {e:?}");
                     }
+                }
+                if !thread_periodic.load(Ordering::Relaxed) {
+                    // One-shot modes fire once per reload.
+                    thread_period.store(0, Ordering::Relaxed);
                 }
             }
         });
@@ -2740,13 +2763,42 @@ impl WindowsX64PitStub {
         Self {
             channels: [0; 3],
             command: 0,
+            channel0_access: 0,
+            channel0_mode: 0,
+            channel0_write_lsb: None,
+            channel0_period_ns,
+            channel0_periodic,
             channel2_latch: 0,
             channel2_started_at: None,
             channel2_write_lsb: None,
             channel2_read_msb_next: false,
-            armed,
             running,
         }
+    }
+
+    fn write_channel0(&mut self, value: u8) {
+        self.channels[0] = value;
+
+        let divisor = match self.channel0_access {
+            0b01 => u32::from(value),
+            0b10 => u32::from(value) << 8,
+            _ => {
+                if let Some(lsb) = self.channel0_write_lsb.take() {
+                    u32::from(u16::from_le_bytes([lsb, value]))
+                } else {
+                    self.channel0_write_lsb = Some(value);
+                    return;
+                }
+            }
+        };
+        let divisor = if divisor == 0 { 0x1_0000 } else { divisor };
+        let period_ns = u64::from(divisor) * 1_000_000_000 / PIT_TICK_RATE_HZ as u64;
+
+        // Modes 2 (rate generator) and 3 (square wave) reload themselves;
+        // everything else behaves as a one-shot.
+        self.channel0_periodic
+            .store(matches!(self.channel0_mode, 2 | 3), Ordering::Relaxed);
+        self.channel0_period_ns.store(period_ns, Ordering::Relaxed);
     }
 
     fn read_channel2(&mut self) -> u8 {
@@ -2828,10 +2880,23 @@ impl devices::BusDevice for WindowsX64PitStub {
         }
 
         match offset {
-            0..=1 => self.channels[offset as usize] = data[0],
+            0 => self.write_channel0(data[0]),
+            1 => self.channels[1] = data[0],
             2 => self.write_channel2(data[0]),
             3 => {
                 self.command = data[0];
+                if self.command & 0xc0 == 0 {
+                    let access = (self.command >> 4) & 0x3;
+                    // Access 0 is the counter-latch command; anything else
+                    // reprograms the channel, so stop ticking until the
+                    // guest writes the new reload value.
+                    if access != 0 {
+                        self.channel0_access = access;
+                        self.channel0_mode = (self.command >> 1) & 0x7;
+                        self.channel0_write_lsb = None;
+                        self.channel0_period_ns.store(0, Ordering::Relaxed);
+                    }
+                }
                 if self.command & 0xc0 == 0x80 {
                     self.channel2_write_lsb = None;
                     self.channel2_read_msb_next = false;
@@ -2839,7 +2904,6 @@ impl devices::BusDevice for WindowsX64PitStub {
             }
             _ => {}
         }
-        self.armed.store(true, Ordering::Relaxed);
     }
 }
 

--- a/src/vmm/src/windows/vstate.rs
+++ b/src/vmm/src/windows/vstate.rs
@@ -40,16 +40,17 @@ use windows_sys::Win32::System::Hypervisor::{
     WHvCapabilityCodeExtendedVmExits, WHvPartitionPropertyCodeExtendedVmExits,
     WHvPartitionPropertyCodeLocalApicEmulationMode, WHvRegisterInternalActivityState,
     WHvRunVpExitReasonCanceled, WHvRunVpExitReasonMemoryAccess,
-    WHvRunVpExitReasonX64ApicInitSipiTrap, WHvRunVpExitReasonX64Halt,
+    WHvRunVpExitReasonX64ApicInitSipiTrap, WHvRunVpExitReasonX64Cpuid, WHvRunVpExitReasonX64Halt,
     WHvRunVpExitReasonX64IoPortAccess, WHvTranslateGva, WHvTranslateGvaResultSuccess,
     WHvX64LocalApicEmulationModeXApic, WHvX64RegisterApicId, WHvX64RegisterCr0, WHvX64RegisterCr2,
     WHvX64RegisterCr3, WHvX64RegisterCr4, WHvX64RegisterCs, WHvX64RegisterDs, WHvX64RegisterEfer,
     WHvX64RegisterEs, WHvX64RegisterFs, WHvX64RegisterGdtr, WHvX64RegisterGs, WHvX64RegisterIdtr,
-    WHvX64RegisterRbp, WHvX64RegisterRflags, WHvX64RegisterRip, WHvX64RegisterRsi,
-    WHvX64RegisterRsp, WHvX64RegisterSs, WHvX64RegisterTr, WHV_EMULATOR_CALLBACKS,
-    WHV_EMULATOR_IO_ACCESS_INFO, WHV_EMULATOR_MEMORY_ACCESS_INFO, WHV_EMULATOR_STATUS,
-    WHV_MEMORY_ACCESS_CONTEXT, WHV_RUN_VP_EXIT_CONTEXT, WHV_TRANSLATE_GVA_FLAGS,
-    WHV_TRANSLATE_GVA_RESULT, WHV_TRANSLATE_GVA_RESULT_CODE, WHV_X64_IO_PORT_ACCESS_CONTEXT,
+    WHvX64RegisterRax, WHvX64RegisterRbp, WHvX64RegisterRbx, WHvX64RegisterRcx, WHvX64RegisterRdx,
+    WHvX64RegisterRflags, WHvX64RegisterRip, WHvX64RegisterRsi, WHvX64RegisterRsp,
+    WHvX64RegisterSs, WHvX64RegisterTr, WHV_EMULATOR_CALLBACKS, WHV_EMULATOR_IO_ACCESS_INFO,
+    WHV_EMULATOR_MEMORY_ACCESS_INFO, WHV_EMULATOR_STATUS, WHV_MEMORY_ACCESS_CONTEXT,
+    WHV_RUN_VP_EXIT_CONTEXT, WHV_TRANSLATE_GVA_FLAGS, WHV_TRANSLATE_GVA_RESULT,
+    WHV_TRANSLATE_GVA_RESULT_CODE, WHV_X64_CPUID_ACCESS_CONTEXT, WHV_X64_IO_PORT_ACCESS_CONTEXT,
     WHV_X64_SEGMENT_REGISTER, WHV_X64_SEGMENT_REGISTER_0, WHV_X64_TABLE_REGISTER,
 };
 use windows_sys::Win32::System::Threading::{GetCurrentThread, GetThreadTimes};
@@ -483,6 +484,10 @@ impl ApStartupRouter {
             })
             .collect();
         Self { slots }
+    }
+
+    fn vcpu_count(&self) -> u8 {
+        self.slots.len() as u8
     }
 
     /// Applies a trapped ICR write. INIT is a no-op for parked APs (they
@@ -1333,23 +1338,37 @@ impl Partition {
     /// INIT/SIPI writes to the emulated local APIC are only surfaced to the
     /// VMM (as `X64ApicInitSipiTrap` exits) when the corresponding extended
     /// VM exit is enabled; without it, application processors can never be
-    /// started. Bit 6 = X64ApicInitSipiExitTrap (WinHvPlatformDefs.h);
-    /// windows-sys models WHV_EXTENDED_VM_EXITS as an opaque u64 bitfield.
+    /// started. CPUID exits let the VMM answer with a normalized result so
+    /// guest boot does not depend on the host CPU or the host's WHP build.
+    /// Bit 0 = X64CpuidExit, bit 6 = X64ApicInitSipiExitTrap
+    /// (WinHvPlatformDefs.h); windows-sys models WHV_EXTENDED_VM_EXITS as an
+    /// opaque u64 bitfield.
     #[cfg(target_arch = "x86_64")]
     fn set_x64_extended_vm_exits(&self, vcpu_count: u8) -> Result<()> {
+        const X64_CPUID_EXIT: u64 = 1 << 0;
         const X64_APIC_INIT_SIPI_EXIT_TRAP: u64 = 1 << 6;
 
         let supported = query_extended_vm_exits()?;
-        if supported & X64_APIC_INIT_SIPI_EXIT_TRAP == 0 {
+        let mut property: u64 = 0;
+
+        if supported & X64_CPUID_EXIT != 0 {
+            property |= X64_CPUID_EXIT;
+        } else {
+            warn!("WHP: CPUID exits unsupported; the guest sees host CPUID unnormalized");
+        }
+
+        if supported & X64_APIC_INIT_SIPI_EXIT_TRAP != 0 {
+            property |= X64_APIC_INIT_SIPI_EXIT_TRAP;
+        } else if vcpu_count > 1 {
             // Single-CPU guests never send startup IPIs, so this host can
             // still run them; refuse multi-CPU rather than hang at boot.
-            if vcpu_count > 1 {
-                return Err(Error::ApicInitSipiTrapUnsupported);
-            }
+            return Err(Error::ApicInitSipiTrapUnsupported);
+        }
+
+        if property == 0 {
             return Ok(());
         }
 
-        let property: u64 = X64_APIC_INIT_SIPI_EXIT_TRAP;
         let property_code = WHvPartitionPropertyCodeExtendedVmExits;
         let hresult = unsafe {
             WHvSetPartitionProperty(
@@ -1831,6 +1850,36 @@ fn run_vcpu(
         }
 
         #[cfg(target_arch = "x86_64")]
+        if reason == WHvRunVpExitReasonX64Cpuid {
+            let cpuid = unsafe { exit_context.Anonymous.CpuidAccess };
+            let vcpu_count = sipi_router.as_ref().map_or(1, |router| router.vcpu_count());
+            let result = normalize_cpuid(id, vcpu_count, &cpuid);
+            // The VpContext bitfield's low nibble is the instruction length.
+            let next_rip =
+                exit_context.VpContext.Rip + u64::from(exit_context.VpContext._bitfield & 0xf);
+            let names = [
+                WHvX64RegisterRax,
+                WHvX64RegisterRbx,
+                WHvX64RegisterRcx,
+                WHvX64RegisterRdx,
+                WHvX64RegisterRip,
+            ];
+            let values = [
+                register_value_u64(result.rax),
+                register_value_u64(result.rbx),
+                register_value_u64(result.rcx),
+                register_value_u64(result.rdx),
+                register_value_u64(next_rip),
+            ];
+            if let Err(err) = set_vcpu_registers(partition_handle, id, &names, &values) {
+                error!("{err}");
+                signal_vcpu_exit(&response_sender, &exit_evt, 1);
+                return;
+            }
+            continue;
+        }
+
+        #[cfg(target_arch = "x86_64")]
         if reason == WHvRunVpExitReasonX64ApicInitSipiTrap {
             let icr = unsafe { exit_context.Anonymous.ApicInitSipi.ApicIcr };
             debug!("WHP vCPU {id}: INIT/SIPI trap (icr={icr:#x})");
@@ -1893,6 +1942,73 @@ fn spawn_ap_probe(partition_handle: WHV_PARTITION_HANDLE, id: u8) {
             );
         }
     });
+}
+
+#[cfg(target_arch = "x86_64")]
+struct CpuidResult {
+    rax: u64,
+    rbx: u64,
+    rcx: u64,
+    rdx: u64,
+}
+
+/// Answers a trapped CPUID with the hypervisor's default result, normalized
+/// so the guest sees the virtual machine rather than the host: stable APIC
+/// IDs and topology derived from the vCPU count, the hypervisor-present
+/// bit, and no x2APIC (the local APIC emulation mode is xAPIC-only). Guest
+/// boot paths must not vary with the host CPU vendor or WHP build defaults.
+#[cfg(target_arch = "x86_64")]
+fn normalize_cpuid(id: u8, vcpu_count: u8, access: &WHV_X64_CPUID_ACCESS_CONTEXT) -> CpuidResult {
+    const CPUID_1_ECX_X2APIC: u32 = 1 << 21;
+    const CPUID_1_ECX_HYPERVISOR: u32 = 1 << 31;
+    const CPUID_1_EDX_HTT: u32 = 1 << 28;
+
+    let leaf = access.Rax as u32;
+    let subleaf = access.Rcx as u32;
+    let mut result = CpuidResult {
+        rax: access.DefaultResultRax,
+        rbx: access.DefaultResultRbx,
+        rcx: access.DefaultResultRcx,
+        rdx: access.DefaultResultRdx,
+    };
+
+    match leaf {
+        0x1 => {
+            let mut ebx = result.rbx as u32;
+            ebx = (ebx & 0x00ff_ffff) | (u32::from(id) << 24);
+            ebx = (ebx & 0xff00_ffff) | (u32::from(vcpu_count) << 16);
+            result.rbx = u64::from(ebx);
+
+            let mut ecx = result.rcx as u32;
+            ecx |= CPUID_1_ECX_HYPERVISOR;
+            ecx &= !CPUID_1_ECX_X2APIC;
+            result.rcx = u64::from(ecx);
+
+            let mut edx = result.rdx as u32;
+            if vcpu_count > 1 {
+                edx |= CPUID_1_EDX_HTT;
+            }
+            result.rdx = u64::from(edx);
+        }
+        // Extended topology: one thread per core, `vcpu_count` cores, and
+        // the vCPU index as the x2APIC ID, replacing whatever slice of the
+        // host topology the default result leaks.
+        0xB | 0x1F => {
+            let core_shift = u32::from(vcpu_count).next_power_of_two().trailing_zeros();
+            let (shift, count, level_type) = match subleaf {
+                0 => (0, 1, 1u32),                           // SMT level
+                1 => (core_shift, u32::from(vcpu_count), 2), // core level
+                _ => (0, 0, 0),                              // no further levels
+            };
+            result.rax = u64::from(shift);
+            result.rbx = u64::from(count);
+            result.rcx = u64::from(subleaf | (level_type << 8));
+            result.rdx = u64::from(id);
+        }
+        _ => {}
+    }
+
+    result
 }
 
 /// Applies the architectural SIPI effect: the AP starts in real mode at


### PR DESCRIPTION
## TL;DR
Guest boot on WHP depended on the host machine: CPUID passed straight through, so the host CPU vendor, topology, and Windows build all leaked into early boot, and the PIT armed a fixed 100Hz tick on any port write. This intercepts CPUID and answers with a normalized result, and makes the PIT tick at whatever rate the guest actually programs. Suspected root fix for the host-dependent triple faults in microsandbox#1092. Builds on the AP startup and IOAPIC routing work merged in #79.

## Description
- Enables the `X64CpuidExit` extended VM exit (capability-probed) and answers each trapped CPUID from the hypervisor's default result, normalized to the virtual machine: leaf 1 gets the vCPU index as the initial APIC ID, the vCPU count as the logical processor count, the hypervisor bit set, and x2APIC hidden since the local APIC emulation mode is xAPIC-only. Leaves 0xB/0x1F report a flat one-thread-per-core topology with the vCPU index as the x2APIC ID instead of a slice of the host topology.
- PIT channel 0 now ticks at the guest-programmed divisor and mode (one-shot or periodic), stops when the channel is reprogrammed, and clamps to 1ms so a tiny divisor cannot busy-spin the host. Previously any PIT port write, including channel 2 calibration polling, armed a permanent 100Hz IRQ0.
- IRQ0 injection reuses the IOAPIC route from #79, so ticks respect the guest's redirection entry (mask, destination, trigger).

Verified guest-visible effects on the test box: `GDS: Unknown: Dependent on hypervisor status` in dmesg (hypervisor bit seen), `apicid`/`initial apicid` read 0 and 1 on a 2-vCPU guest, SMP bring-up completes in ~12ms, and `time sleep 2` measures 2.00s.

## Test Plan
- [x] `cargo fmt --check -p msb_krun_vmm` is clean
- [x] release build for `x86_64-pc-windows-msvc` exits 0 on the Windows Server 2022 test box
- [x] alpine boots with `--cpus 1`, `2`, and `4`; `nproc` reports 1, 2, and 4; online shows `0-3`
- [x] `/proc/cpuinfo` shows per-vCPU `apicid` 0..N-1 and dmesg shows the hypervisor bit is visible
- [x] `time sleep 2` inside the guest measures 2.00s (timer paths intact)
- [ ] confirmation from a microsandbox#1092 reporter machine (needs their hardware)