### PR TITLE
feat(windows): report the TSC frequency through CPUID leaf 0x15

### DIFF
--- a/src/vmm/src/windows/vstate.rs
+++ b/src/vmm/src/windows/vstate.rs
@@ -37,9 +37,9 @@ use windows_sys::Win32::System::Hypervisor::{
 };
 #[cfg(target_arch = "x86_64")]
 use windows_sys::Win32::System::Hypervisor::{
-    WHvCapabilityCodeExtendedVmExits, WHvPartitionPropertyCodeExtendedVmExits,
-    WHvPartitionPropertyCodeLocalApicEmulationMode, WHvRegisterInternalActivityState,
-    WHvRunVpExitReasonCanceled, WHvRunVpExitReasonMemoryAccess,
+    WHvCapabilityCodeExtendedVmExits, WHvCapabilityCodeProcessorClockFrequency,
+    WHvPartitionPropertyCodeExtendedVmExits, WHvPartitionPropertyCodeLocalApicEmulationMode,
+    WHvRegisterInternalActivityState, WHvRunVpExitReasonCanceled, WHvRunVpExitReasonMemoryAccess,
     WHvRunVpExitReasonX64ApicInitSipiTrap, WHvRunVpExitReasonX64Cpuid, WHvRunVpExitReasonX64Halt,
     WHvRunVpExitReasonX64IoPortAccess, WHvTranslateGva, WHvTranslateGvaResultSuccess,
     WHvX64LocalApicEmulationModeXApic, WHvX64RegisterApicId, WHvX64RegisterCr0, WHvX64RegisterCr2,
@@ -1973,6 +1973,12 @@ fn normalize_cpuid(id: u8, vcpu_count: u8, access: &WHV_X64_CPUID_ACCESS_CONTEXT
     };
 
     match leaf {
+        // The guest must be able to reach the synthesized TSC leaf (0x15)
+        // even on hosts whose CPUID tops out below it (AMD stops at 0xD).
+        0x0 => {
+            let max_leaf = (result.rax as u32).max(0x15);
+            result.rax = u64::from(max_leaf);
+        }
         0x1 => {
             let mut ebx = result.rbx as u32;
             ebx = (ebx & 0x00ff_ffff) | (u32::from(id) << 24);
@@ -2005,10 +2011,48 @@ fn normalize_cpuid(id: u8, vcpu_count: u8, access: &WHV_X64_CPUID_ACCESS_CONTEXT
             result.rcx = u64::from(subleaf | (level_type << 8));
             result.rdx = u64::from(id);
         }
+        // TSC/crystal ratio: hand the guest its TSC frequency directly so
+        // it never falls back to PIT/HPET calibration (neither of which we
+        // emulate well enough) and the jiffies clocksource. The guest TSC
+        // runs at the host rate under WHP, which the platform reports via
+        // WHvCapabilityCodeProcessorClockFrequency.
+        0x15 => {
+            if let Some(tsc_hz) = host_tsc_frequency_hz() {
+                result.rax = 1; // ratio denominator
+                result.rbx = 1; // ratio numerator
+                result.rcx = tsc_hz; // "crystal" clock in Hz
+                result.rdx = 0;
+            }
+        }
         _ => {}
     }
 
     result
+}
+
+/// Host processor clock (TSC) frequency, queried once. `None` when the
+/// platform cannot report it; the guest then calibrates as before.
+#[cfg(target_arch = "x86_64")]
+fn host_tsc_frequency_hz() -> Option<u64> {
+    static TSC_HZ: std::sync::OnceLock<Option<u64>> = std::sync::OnceLock::new();
+    *TSC_HZ.get_or_init(|| {
+        let mut capability: WHV_CAPABILITY = unsafe { zeroed() };
+        let mut written_size = 0;
+        let hresult = unsafe {
+            WHvGetCapability(
+                WHvCapabilityCodeProcessorClockFrequency,
+                &mut capability as *mut WHV_CAPABILITY as *mut _,
+                size_of::<WHV_CAPABILITY>() as u32,
+                &mut written_size,
+            )
+        };
+        if hresult < 0 {
+            warn!("WHP: processor clock frequency unavailable (hresult {hresult:#x})");
+            return None;
+        }
+        let hz = unsafe { capability.ProcessorClockFrequency };
+        (hz != 0).then_some(hz)
+    })
 }
 
 /// Applies the architectural SIPI effect: the AP starts in real mode at


### PR DESCRIPTION
## TL;DR
WHP guests marked the TSC unstable and ran on the jiffies clocksource because nothing let them learn their TSC frequency. Synthesize CPUID leaf 0x15 from the platform's reported processor clock so the kernel reads it directly. Verified: guest now detects 2593.905 MHz and switches to the tsc clocksource.

## Description
- Queries WHvCapabilityCodeProcessorClockFrequency once (cached) and answers CPUID leaf 0x15 with a 1/1 ratio and that frequency as the crystal clock, which is correct because the guest TSC runs at the host rate under WHP.
- Raises the max basic leaf to at least 0x15 in leaf 0 so hosts whose CPUID tops out lower (AMD stops at 0xD) can still reach the synthesized leaf.
- Falls back to the previous calibration behavior when the platform cannot report the frequency.

## Test Plan
- [x] `cargo fmt --check -p msb_krun_vmm` is clean
- [x] release build for `x86_64-pc-windows-msvc` exits 0 on the test box
- [x] guest dmesg shows `tsc: Detected 2593.905 MHz processor` and `Switched to clocksource tsc` (previously refined-jiffies)
- [x] `time sleep 2` inside the guest measures ~2.0s
- [ ] AMD-host confirmation (no AMD Windows machine available)