### PR TITLE
fix(windows): let ARM64 guests boot multiple vCPUs

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1138,15 +1138,6 @@ pub fn build_microvm(
 
     #[allow(unused_mut)]
     let mut vcpu_config = vm_resources.vcpu_config();
-    #[cfg(all(target_arch = "aarch64", target_os = "windows"))]
-    if vcpu_config.vcpu_count > 1 {
-        debug!(
-            "WHP ARM64 PSCI bring-up is not implemented yet; booting with one vCPU instead of {}",
-            vcpu_config.vcpu_count
-        );
-        vcpu_config.vcpu_count = 1;
-        vcpu_config.max_vcpu_count = 1;
-    }
 
     // Clone the command-line so that a failed boot doesn't pollute the original.
     #[allow(unused_mut)]


### PR DESCRIPTION
## TL;DR
WHP ARM64 guests were silently clamped to one vCPU by a bring-up guard that assumed PSCI CPU_ON needed VMM-side work. It does not: WHP ships an in-hypervisor PSCI (the guest detects PSCIv1.1 firmware over the HVC conduit the FDT already advertises), and the clamp itself was what kept CPU 1 out of the device tree. Removing it makes SMP work.

## Description
- Deletes the aarch64-windows clamp in builder.rs that forced vcpu_count/max_vcpu_count to 1, which built a single-CPU FDT (guest saw possible=0, never attempted bring-up, no error anywhere).
- No other changes needed: the FDT already emits the psci node (method hvc) and per-CPU enable-method, and WHP's firmware PSCI answers CPU_ON.

## Test Plan
- [x] release build on the Snapdragon Surface Laptop 7 (Windows 11 build 26200, aarch64-pc-windows-msvc) exits 0
- [x] alpine with --cpus 2: nproc reports 2, /sys/devices/system/cpu/online shows 0-1 (was: 1 CPU, silent)
- [x] guest dmesg confirms PSCIv1.1 firmware detection over hvc
- [x] alpine with --cpus 1 unaffected
- [x] x86-64 Windows regression sweep: 1/2/4 vCPU boots report 1/2/4, online 0-3 (Azure Xeon box)
- [x] 4-vCPU ARM64 boot: nproc 4, online 0-3; dual-core CPU burn stable, exec responsive
