### PR TITLE
feat(windows): allow reserved CPU capacity on x86_64

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1193,11 +1193,14 @@ pub fn build_microvm(
 
     #[cfg(not(feature = "tee"))]
     #[allow(unused_mut)]
-    let mut vm = setup_vm(
-        &guest_memory,
-        vm_resources.nested_enabled,
-        vcpu_config.vcpu_count,
-    )?;
+    // The WHP partition is sized to the full possible topology: reserved
+    // CPU capacity creates every vCPU up front (parked in the startup
+    // router), so the partition's processor count must cover them all.
+    #[cfg(target_os = "windows")]
+    let setup_vcpu_count = vcpu_config.max_vcpu_count.max(vcpu_config.vcpu_count);
+    #[cfg(not(target_os = "windows"))]
+    let setup_vcpu_count = vcpu_config.vcpu_count;
+    let mut vm = setup_vm(&guest_memory, vm_resources.nested_enabled, setup_vcpu_count)?;
     trace.mark("vm.ready");
 
     #[cfg(feature = "tee")]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1191,15 +1191,15 @@ pub fn build_microvm(
         kernel_cmdline.insert_str(cmdline).unwrap();
     }
 
-    #[cfg(not(feature = "tee"))]
-    #[allow(unused_mut)]
     // The WHP partition is sized to the full possible topology: reserved
     // CPU capacity creates every vCPU up front (parked in the startup
     // router), so the partition's processor count must cover them all.
     #[cfg(target_os = "windows")]
     let setup_vcpu_count = vcpu_config.max_vcpu_count.max(vcpu_config.vcpu_count);
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), not(feature = "tee")))]
     let setup_vcpu_count = vcpu_config.vcpu_count;
+    #[cfg(not(feature = "tee"))]
+    #[allow(unused_mut)]
     let mut vm = setup_vm(&guest_memory, vm_resources.nested_enabled, setup_vcpu_count)?;
     trace.mark("vm.ready");
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -3204,14 +3204,23 @@ fn create_vcpus_windows(
     metrics: utils::metrics::MetricsWriter,
     #[cfg(target_arch = "x86_64")] pio_bus: Option<&devices::Bus>,
 ) -> super::Result<Vec<Vcpu>> {
-    let mut vcpus = Vec::with_capacity(vcpu_config.vcpu_count as usize);
+    // Create the full possible topology; every AP parks in the startup
+    // router until the guest sends it INIT/SIPI, so CPUs beyond the boot
+    // online count (reserved capacity) simply wait until the guest onlines
+    // them through the msb-cpu driver. On aarch64 only the boot count is
+    // created because reserved capacity is rejected at config time.
+    #[cfg(target_arch = "x86_64")]
+    let create_count = vcpu_config.max_vcpu_count.max(vcpu_config.vcpu_count);
+    #[cfg(target_arch = "aarch64")]
+    let create_count = vcpu_config.vcpu_count;
+
+    let mut vcpus = Vec::with_capacity(create_count as usize);
     // One router shared by all vCPU threads: INIT/SIPI writes trap on the
     // sending vCPU and are applied to the parked target APs through it.
     #[cfg(target_arch = "x86_64")]
-    let sipi_router = std::sync::Arc::new(crate::windows::vstate::ApStartupRouter::new(
-        vcpu_config.vcpu_count,
-    ));
-    for cpu_index in 0..vcpu_config.vcpu_count {
+    let sipi_router =
+        std::sync::Arc::new(crate::windows::vstate::ApStartupRouter::new(create_count));
+    for cpu_index in 0..create_count {
         let mut vcpu = vm
             .create_vcpu(
                 cpu_index,

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1501,9 +1501,13 @@ pub fn build_microvm(
 
     #[cfg(target_os = "windows")]
     {
+        // Size the guest-visible GIC redistributor range to the created topology:
+        // with reserved CPU capacity the FDT lists every possible CPU, and the
+        // GICv3 driver must find each one's GICR frame inside the advertised
+        // range (the HVF GIC sizes by max for the same reason).
         intc = Arc::new(Mutex::new(IrqChipDevice::new(Box::new(WhpIrqChip::new(
             vm.partition_handle(),
-            u64::from(vcpu_config.vcpu_count),
+            u64::from(setup_vcpu_count),
         )))));
         #[cfg(target_arch = "x86_64")]
         let pio_bus = create_windows_x86_64_pio_bus(
@@ -3207,15 +3211,13 @@ fn create_vcpus_windows(
     metrics: utils::metrics::MetricsWriter,
     #[cfg(target_arch = "x86_64")] pio_bus: Option<&devices::Bus>,
 ) -> super::Result<Vec<Vcpu>> {
-    // Create the full possible topology; every AP parks in the startup
-    // router until the guest sends it INIT/SIPI, so CPUs beyond the boot
-    // online count (reserved capacity) simply wait until the guest onlines
-    // them through the msb-cpu driver. On aarch64 only the boot count is
-    // created because reserved capacity is rejected at config time.
-    #[cfg(target_arch = "x86_64")]
+    // Create the full possible topology so CPUs beyond the boot online count
+    // (reserved capacity) can come online later through the msb-cpu driver.
+    // On x86 every AP parks in the startup router until the guest sends it
+    // INIT/SIPI; on aarch64 only vCPU 0 gets an entry point and WHP's
+    // in-hypervisor PSCI keeps the rest powered off until the guest issues
+    // CPU_ON for them.
     let create_count = vcpu_config.max_vcpu_count.max(vcpu_config.vcpu_count);
-    #[cfg(target_arch = "aarch64")]
-    let create_count = vcpu_config.vcpu_count;
 
     let mut vcpus = Vec::with_capacity(create_count as usize);
     // One router shared by all vCPU threads: INIT/SIPI writes trap on the

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -355,12 +355,9 @@ impl VmResources {
             // Booting a wider possible topology than the online count relies on parked
             // vCPUs waiting for wake-ups (INIT/SIPI on x86, PSCI on aarch64) and on
             // non-TEE boot topology tables. On x86 Windows the AP startup router
-            // provides exactly that, so only the still-unwired platforms reject.
-            #[cfg(any(
-                all(target_os = "windows", target_arch = "aarch64"),
-                target_arch = "riscv64",
-                feature = "tee"
-            ))]
+            // provides exactly that and on aarch64 Windows WHP's in-hypervisor PSCI
+            // does, so only the still-unwired platforms reject.
+            #[cfg(any(target_arch = "riscv64", feature = "tee"))]
             if max_vcpu_count > vcpu_count_value {
                 return Err(VmConfigError::MaxCapacityUnsupported);
             }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -353,9 +353,14 @@ impl VmResources {
                 return Err(VmConfigError::InvalidMaxVcpuCount);
             }
             // Booting a wider possible topology than the online count relies on parked
-            // vCPUs waiting for PSCI/INIT-SIPI wake-ups, which the WHP backend does not
-            // implement, and on non-TEE boot topology tables. Reject rather than lie.
-            #[cfg(any(target_os = "windows", target_arch = "riscv64", feature = "tee"))]
+            // vCPUs waiting for wake-ups (INIT/SIPI on x86, PSCI on aarch64) and on
+            // non-TEE boot topology tables. On x86 Windows the AP startup router
+            // provides exactly that, so only the still-unwired platforms reject.
+            #[cfg(any(
+                all(target_os = "windows", target_arch = "aarch64"),
+                target_arch = "riscv64",
+                feature = "tee"
+            ))]
             if max_vcpu_count > vcpu_count_value {
                 return Err(VmConfigError::MaxCapacityUnsupported);
             }


### PR DESCRIPTION
## TL;DR
Lets x86 Windows guests boot with reserved CPU capacity and online the extra vCPUs live via msb modify. The MaxCapacityUnsupported guard predated the AP startup router (#79), which is exactly the parked-vCPU-wakes-on-SIPI mechanism a wider-than-online topology needs. Verified: a WHP guest live-grows 2 -> 4 CPUs and shrinks back.

## Description
- Lifts the config-time rejection for x86_64 only; aarch64 Windows and riscv/tee keep rejecting until their online paths are verified.
- create_vcpus_windows now creates the full possible topology (max_vcpu_count), each AP parked in the startup router until the guest onlines it through the msb-cpu driver; maxcpus= still caps boot onlining.
- Sizes the WHP partition to the full topology so creating the reserved vCPUs no longer fails with E_INVALIDARG.

## Test Plan
- [x] release build on the Azure WHP box exits 0
- [x] create --cpus 2 --max-cpus 4: nproc 2 at boot
- [x] modify --cpus 4 classifies live (converging), guest onlines to nproc 4 / online 0-3
- [x] modify --cpus 2 back down, and memory grow on the same sandbox still works (494,288 -> 1,018,072 kB)
- [ ] aarch64 Windows CPU capacity (kept rejected; separate once verified on the Surface)