### PR TITLE
feat(windows): allow reserved CPU capacity on aarch64

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1501,9 +1501,13 @@ pub fn build_microvm(
 
     #[cfg(target_os = "windows")]
     {
+        // Size the guest-visible GIC redistributor range to the created topology:
+        // with reserved CPU capacity the FDT lists every possible CPU, and the
+        // GICv3 driver must find each one's GICR frame inside the advertised
+        // range (the HVF GIC sizes by max for the same reason).
         intc = Arc::new(Mutex::new(IrqChipDevice::new(Box::new(WhpIrqChip::new(
             vm.partition_handle(),
-            u64::from(vcpu_config.vcpu_count),
+            u64::from(setup_vcpu_count),
         )))));
         #[cfg(target_arch = "x86_64")]
         let pio_bus = create_windows_x86_64_pio_bus(
@@ -3207,15 +3211,13 @@ fn create_vcpus_windows(
     metrics: utils::metrics::MetricsWriter,
     #[cfg(target_arch = "x86_64")] pio_bus: Option<&devices::Bus>,
 ) -> super::Result<Vec<Vcpu>> {
-    // Create the full possible topology; every AP parks in the startup
-    // router until the guest sends it INIT/SIPI, so CPUs beyond the boot
-    // online count (reserved capacity) simply wait until the guest onlines
-    // them through the msb-cpu driver. On aarch64 only the boot count is
-    // created because reserved capacity is rejected at config time.
-    #[cfg(target_arch = "x86_64")]
+    // Create the full possible topology so CPUs beyond the boot online count
+    // (reserved capacity) can come online later through the msb-cpu driver.
+    // On x86 every AP parks in the startup router until the guest sends it
+    // INIT/SIPI; on aarch64 only vCPU 0 gets an entry point and WHP's
+    // in-hypervisor PSCI keeps the rest powered off until the guest issues
+    // CPU_ON for them.
     let create_count = vcpu_config.max_vcpu_count.max(vcpu_config.vcpu_count);
-    #[cfg(target_arch = "aarch64")]
-    let create_count = vcpu_config.vcpu_count;
 
     let mut vcpus = Vec::with_capacity(create_count as usize);
     // One router shared by all vCPU threads: INIT/SIPI writes trap on the

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -355,12 +355,9 @@ impl VmResources {
             // Booting a wider possible topology than the online count relies on parked
             // vCPUs waiting for wake-ups (INIT/SIPI on x86, PSCI on aarch64) and on
             // non-TEE boot topology tables. On x86 Windows the AP startup router
-            // provides exactly that, so only the still-unwired platforms reject.
-            #[cfg(any(
-                all(target_os = "windows", target_arch = "aarch64"),
-                target_arch = "riscv64",
-                feature = "tee"
-            ))]
+            // provides exactly that and on aarch64 Windows WHP's in-hypervisor PSCI
+            // does, so only the still-unwired platforms reject.
+            #[cfg(any(target_arch = "riscv64", feature = "tee"))]
             if max_vcpu_count > vcpu_count_value {
                 return Err(VmConfigError::MaxCapacityUnsupported);
             }


### PR DESCRIPTION
## TL;DR
Lets aarch64 Windows guests boot with reserved CPU capacity and online the extra vCPUs live via msb modify. Stacked on #85. The MaxCapacityUnsupported guard assumed aarch64 WHP lacked a parking mechanism for reserved vCPUs, but it already has one: secondaries get no entry point at configure time and WHP's in-hypervisor PSCI keeps them powered off until the guest issues CPU_ON — the same path boot-time SMP onlining has used since #84. The real blocker was the guest GIC. Verified: a WHP ARM64 guest live-grows 2 -> 4 CPUs and shrinks back.

## Description
- The FDT's GIC redistributor range was sized by the boot online count, while reserved capacity creates (and lists in the FDT) the full possible topology. The GICv3 driver then can't find GICR frames for the reserved CPUs and the guest panics and resets during early boot (WHP ARM64 reset exit on vCPU 0, reset_type=REBOOT). Size the range by the created topology instead, matching the HVF GIC which sizes by max for the same reason.
- create_vcpus_windows now creates the full possible topology on aarch64 too; only vCPU 0 gets PC/X0, so reserved vCPUs stay powered off in the hypervisor until PSCI CPU_ON.
- Lifts the config-time rejection for aarch64 Windows; riscv64 and tee keep rejecting.
- x86_64 is untouched in behavior: the irqchip count argument is unused there (IOAPIC path, no FDT), and the create-count expression is unchanged for x86.

## Test Plan
Surface Laptop (Snapdragon aarch64, WHP), msb branch appcypher/windows-live-resize with msb_krun path override to this branch, libkrunfw kernel with the virtio-mem/msb-cpu guest drivers:
- [x] release msb build exits 0
- [x] create --cpus 2 --max-cpus 4 boots clean: nproc 2, online 0-1 (before this change: guest reset during early boot)
- [x] modify --cpus 4 classifies live and converges: nproc 4, online 0-3
- [x] modify --cpus 2 shrinks back: nproc 2, online 0-1
- [x] memory grow/shrink on the same sandbox unaffected: MemTotal 490,840 -> 1,015,128 -> exactly 490,840 kB
- [ ] x86_64 Windows regression run on the Azure box (change is provably inert on x86 — count arg unused — so deferred to the #85 stack's next run)