### PR TITLE
feat(krun): expose vsock port maps on MachineBuilder

### DIFF
--- a/src/devices/src/virtio/vsock/backend.rs
+++ b/src/devices/src/virtio/vsock/backend.rs
@@ -1,0 +1,58 @@
+use std::io;
+use std::os::fd::RawFd;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Metadata for a guest-initiated connection to a registered host port.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct VsockConnectRequest {
+    /// CID of the guest opening the connection.
+    pub guest_cid: u64,
+    /// Ephemeral source port selected by the guest.
+    pub guest_port: u32,
+    /// Host port on which the backend was registered.
+    pub host_port: u32,
+}
+
+/// Direction requested by a guest shutdown packet.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum VsockShutdown {
+    Read,
+    Write,
+    Both,
+}
+
+/// Factory for custom, in-process services exposed on one host vsock port.
+///
+/// The factory is shared between connections and may be called concurrently.
+/// It should return promptly; expensive setup belongs in backend-managed work.
+pub trait VsockPortBackend: Send + Sync {
+    /// Accept a guest connection and return its byte-stream endpoint.
+    fn connect(&self, request: VsockConnectRequest) -> io::Result<Box<dyn VsockStreamBackend>>;
+}
+
+/// One nonblocking byte stream served by a custom vsock backend.
+///
+/// Implementations return [`io::ErrorKind::WouldBlock`] when progress is not
+/// currently possible. `poll_fd` must become readable whenever a blocked read
+/// or write may make progress; libkrun continues to own virtio-vsock framing,
+/// credit flow, shutdown, and reset handling around this stream.
+pub trait VsockStreamBackend: Send {
+    /// Read bytes that should be delivered to the guest.
+    fn read(&self, buf: &mut [u8]) -> io::Result<usize>;
+
+    /// Consume bytes received from the guest.
+    fn write(&self, buf: &[u8]) -> io::Result<usize>;
+
+    /// Apply a guest-requested half-close or full shutdown.
+    fn shutdown(&self, how: VsockShutdown) -> io::Result<()>;
+
+    /// Readiness source used by the vsock muxer event loop.
+    ///
+    /// The descriptor must remain open for this stream's lifetime and must be
+    /// independently registerable with epoll (do not share one descriptor
+    /// between concurrently active streams).
+    fn poll_fd(&self) -> RawFd;
+}

--- a/src/devices/src/virtio/vsock/backend.rs
+++ b/src/devices/src/virtio/vsock/backend.rs
@@ -1,5 +1,7 @@
 use std::io;
-use std::os::fd::RawFd;
+use std::sync::Arc;
+
+use utils::eventfd::{EventFd, EFD_NONBLOCK};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -24,21 +26,36 @@ pub enum VsockShutdown {
     Both,
 }
 
+/// Cloneable wake handle for a custom vsock stream.
+///
+/// Call [`notify`](Self::notify) whenever a previously blocked stream read or
+/// write may make progress. libkrun owns the platform event primitive and its
+/// registration with the VMM event loop.
+#[derive(Clone, Debug)]
+pub struct VsockNotifier {
+    event: Arc<EventFd>,
+}
+
 /// Factory for custom, in-process services exposed on one host vsock port.
 ///
 /// The factory is shared between connections and may be called concurrently.
 /// It should return promptly; expensive setup belongs in backend-managed work.
 pub trait VsockPortBackend: Send + Sync {
     /// Accept a guest connection and return its byte-stream endpoint.
-    fn connect(&self, request: VsockConnectRequest) -> io::Result<Box<dyn VsockStreamBackend>>;
+    fn connect(
+        &self,
+        request: VsockConnectRequest,
+        notifier: VsockNotifier,
+    ) -> io::Result<Box<dyn VsockStreamBackend>>;
 }
 
 /// One nonblocking byte stream served by a custom vsock backend.
 ///
 /// Implementations return [`io::ErrorKind::WouldBlock`] when progress is not
-/// currently possible. `poll_fd` must become readable whenever a blocked read
-/// or write may make progress; libkrun continues to own virtio-vsock framing,
-/// credit flow, shutdown, and reset handling around this stream.
+/// currently possible. The [`VsockNotifier`] supplied at connection time must
+/// be signaled whenever a blocked operation may make progress; libkrun
+/// continues to own virtio-vsock framing, credit flow, shutdown, and reset
+/// handling around this stream.
 pub trait VsockStreamBackend: Send {
     /// Read bytes that should be delivered to the guest.
     fn read(&self, buf: &mut [u8]) -> io::Result<usize>;
@@ -48,11 +65,54 @@ pub trait VsockStreamBackend: Send {
 
     /// Apply a guest-requested half-close or full shutdown.
     fn shutdown(&self, how: VsockShutdown) -> io::Result<()>;
+}
 
-    /// Readiness source used by the vsock muxer event loop.
-    ///
-    /// The descriptor must remain open for this stream's lifetime and must be
-    /// independently registerable with epoll (do not share one descriptor
-    /// between concurrently active streams).
-    fn poll_fd(&self) -> RawFd;
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl VsockNotifier {
+    pub(crate) fn new() -> io::Result<Self> {
+        Ok(Self {
+            event: Arc::new(EventFd::new(EFD_NONBLOCK)?),
+        })
+    }
+
+    /// Wake libkrun so it retries this stream's nonblocking operations.
+    pub fn notify(&self) -> io::Result<()> {
+        self.event.write(1)
+    }
+
+    pub(crate) fn event(&self) -> &EventFd {
+        &self.event
+    }
+
+    pub(crate) fn clear(&self) -> io::Result<()> {
+        match self.event.read() {
+            Ok(_) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notifier_clone_wakes_shared_libkrun_event() {
+        let notifier = VsockNotifier::new().unwrap();
+        notifier.clone().notify().unwrap();
+
+        notifier.clear().unwrap();
+        assert_eq!(
+            notifier.event().read().unwrap_err().kind(),
+            io::ErrorKind::WouldBlock
+        );
+    }
 }

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -20,6 +20,7 @@ use super::super::{
 use super::muxer::VsockMuxer;
 use super::packet::VsockPacket;
 use super::TsiFlags;
+use super::VsockPortBackend;
 use super::{defs, defs::uapi};
 use crate::virtio::InterruptTransport;
 
@@ -54,11 +55,18 @@ impl Vsock {
         cid: u64,
         host_port_map: Option<HashMap<u16, u16>>,
         unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
+        custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
         tsi_flags: TsiFlags,
     ) -> super::Result<Vsock> {
         Ok(Vsock {
             cid,
-            muxer: VsockMuxer::new(cid, host_port_map, unix_ipc_port_map, tsi_flags),
+            muxer: VsockMuxer::new(
+                cid,
+                host_port_map,
+                unix_ipc_port_map,
+                custom_port_map,
+                tsi_flags,
+            ),
             queue_rx: None,
             queue_tx: None,
             queue_events: Vec::new(),

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -21,7 +21,9 @@ mod tsi_dgram;
 mod tsi_stream;
 mod unix;
 
-pub use self::backend::{VsockConnectRequest, VsockPortBackend, VsockShutdown, VsockStreamBackend};
+pub use self::backend::{
+    VsockConnectRequest, VsockNotifier, VsockPortBackend, VsockShutdown, VsockStreamBackend,
+};
 pub use self::defs::uapi::VIRTIO_ID_VSOCK as TYPE_VSOCK;
 pub use self::defs::TsiFlags;
 pub use self::device::Vsock;

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -5,6 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+mod backend;
 mod device;
 mod event_handler;
 mod muxer;
@@ -20,6 +21,7 @@ mod tsi_dgram;
 mod tsi_stream;
 mod unix;
 
+pub use self::backend::{VsockConnectRequest, VsockPortBackend, VsockShutdown, VsockStreamBackend};
 pub use self::defs::uapi::VIRTIO_ID_VSOCK as TYPE_VSOCK;
 pub use self::defs::TsiFlags;
 pub use self::device::Vsock;

--- a/src/devices/src/virtio/vsock/muxer.rs
+++ b/src/devices/src/virtio/vsock/muxer.rs
@@ -17,7 +17,7 @@ use super::tsi_dgram::TsiDgramProxy;
 use super::tsi_stream::TsiStreamProxy;
 use super::unix::UnixProxy;
 use super::VsockError;
-use super::{TsiFlags, VsockConnectRequest, VsockPortBackend};
+use super::{TsiFlags, VsockConnectRequest, VsockNotifier, VsockPortBackend};
 use crossbeam_channel::{unbounded, Sender};
 use utils::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 use vm_memory::GuestMemoryMmap;
@@ -179,6 +179,13 @@ impl VsockMuxer {
     pub(crate) fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> super::Result<()> {
         debug!("recv_stream_pkt");
         if self.rxq.lock().unwrap().is_empty() {
+            // A custom backend notification may have arrived before the guest
+            // supplied an RX descriptor. Re-kick streams now that the guest is
+            // explicitly asking us to fill one, without exposing event fds to
+            // backend implementations.
+            for proxy in self.proxy_map.read().unwrap().values() {
+                proxy.lock().unwrap().kick();
+            }
             return Err(VsockError::NoData);
         }
 
@@ -570,7 +577,24 @@ impl VsockMuxer {
                 guest_port: pkt.src_port(),
                 host_port: pkt.dst_port(),
             };
-            match service.connect(request) {
+            let notifier = match VsockNotifier::new() {
+                Ok(notifier) => notifier,
+                Err(err) => {
+                    warn!("failed to create custom vsock notifier: {err}");
+                    push_packet(
+                        self.cid,
+                        MuxerRx::Reset {
+                            local_port: pkt.dst_port(),
+                            peer_port: pkt.src_port(),
+                        },
+                        &self.rxq,
+                        queue,
+                        mem,
+                    );
+                    return;
+                }
+            };
+            match service.connect(request, notifier.clone()) {
                 Ok(backend) => {
                     let proxy = UnixProxy::new_custom(
                         id,
@@ -578,6 +602,7 @@ impl VsockMuxer {
                         pkt.dst_port(),
                         pkt.src_port(),
                         backend,
+                        notifier,
                         mem.clone(),
                         queue.clone(),
                         self.rxq.clone(),

--- a/src/devices/src/virtio/vsock/muxer.rs
+++ b/src/devices/src/virtio/vsock/muxer.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -8,7 +8,7 @@ use super::defs;
 use super::defs::uapi;
 use super::muxer_rxq::{rx_to_pkt, MuxerRxQ};
 use super::muxer_thread::MuxerThread;
-use super::packet::{TsiConnectReq, TsiGetnameRsp, VsockPacket};
+use super::packet::{TsiGetnameRsp, VsockPacket};
 use super::proxy::{Proxy, ProxyRemoval, ProxyUpdate};
 use super::reaper::ReaperThread;
 #[cfg(target_os = "macos")]
@@ -16,8 +16,8 @@ use super::timesync::TimesyncThread;
 use super::tsi_dgram::TsiDgramProxy;
 use super::tsi_stream::TsiStreamProxy;
 use super::unix::UnixProxy;
-use super::TsiFlags;
 use super::VsockError;
+use super::{TsiFlags, VsockConnectRequest, VsockPortBackend};
 use crossbeam_channel::{unbounded, Sender};
 use utils::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 use vm_memory::GuestMemoryMmap;
@@ -107,6 +107,7 @@ pub struct VsockMuxer {
     proxy_map: ProxyMap,
     reaper_sender: Option<Sender<u64>>,
     unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
+    custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
     tsi_flags: TsiFlags,
 }
 
@@ -115,6 +116,7 @@ impl VsockMuxer {
         cid: u64,
         host_port_map: Option<HashMap<u16, u16>>,
         unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
+        custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
         tsi_flags: TsiFlags,
     ) -> Self {
         VsockMuxer {
@@ -128,6 +130,7 @@ impl VsockMuxer {
             proxy_map: Arc::new(RwLock::new(HashMap::new())),
             reaper_sender: None,
             unix_ipc_port_map,
+            custom_port_map,
             tsi_flags,
         }
     }
@@ -539,47 +542,194 @@ impl VsockMuxer {
     fn process_op_request(&mut self, pkt: &VsockPacket) {
         debug!("OP_REQUEST");
         let id: u64 = ((pkt.src_port() as u64) << 32) | (pkt.dst_port() as u64);
-        let mut proxy_map = self.proxy_map.write().unwrap();
 
-        if let Some(proxy) = proxy_map.get(&id) {
+        if let Some(proxy) = self.proxy_map.read().unwrap().get(&id) {
             if let Some(update) = proxy.lock().unwrap().confirm_connect(pkt) {
                 self.process_proxy_update(id, update);
             }
-        } else if let Some(ref mut ipc_map) = &mut self.unix_ipc_port_map {
-            if let Some((path, listen)) = ipc_map.get(&pkt.dst_port()) {
-                let mem = self.mem.as_ref().unwrap();
-                let queue = self.queue.as_ref().unwrap();
-                if *listen {
-                    warn!("Attempting to connect a socket that is listening, sending rst");
-                    let rx = MuxerRx::Reset {
+            return;
+        }
+
+        let Some(mem) = self.mem.as_ref() else {
+            warn!("vsock connection request without guest memory");
+            return;
+        };
+        let Some(queue) = self.queue.as_ref() else {
+            warn!("vsock connection request without receive queue");
+            return;
+        };
+
+        if let Some(service) = self
+            .custom_port_map
+            .as_ref()
+            .and_then(|routes| routes.get(&pkt.dst_port()))
+            .cloned()
+        {
+            let request = VsockConnectRequest {
+                guest_cid: pkt.src_cid(),
+                guest_port: pkt.src_port(),
+                host_port: pkt.dst_port(),
+            };
+            match service.connect(request) {
+                Ok(backend) => {
+                    let proxy = UnixProxy::new_custom(
+                        id,
+                        self.cid,
+                        pkt.dst_port(),
+                        pkt.src_port(),
+                        backend,
+                        mem.clone(),
+                        queue.clone(),
+                        self.rxq.clone(),
+                    );
+                    let poll_fd = proxy.as_raw_fd();
+                    if poll_fd < 0 {
+                        warn!(
+                            "custom vsock service for port {} returned an invalid poll fd",
+                            pkt.dst_port()
+                        );
+                        push_packet(
+                            self.cid,
+                            MuxerRx::Reset {
+                                local_port: pkt.dst_port(),
+                                peer_port: pkt.src_port(),
+                            },
+                            &self.rxq,
+                            queue,
+                            mem,
+                        );
+                        return;
+                    }
+                    self.proxy_map
+                        .write()
+                        .unwrap()
+                        .insert(id, Mutex::new(Box::new(proxy)));
+                    if let Err(err) = self.epoll.ctl(
+                        ControlOperation::Add,
+                        poll_fd,
+                        &EpollEvent::new(EventSet::IN, id),
+                    ) {
+                        self.proxy_map.write().unwrap().remove(&id);
+                        warn!(
+                            "custom vsock service for port {} returned an unusable poll fd: {err}",
+                            pkt.dst_port()
+                        );
+                        push_packet(
+                            self.cid,
+                            MuxerRx::Reset {
+                                local_port: pkt.dst_port(),
+                                peer_port: pkt.src_port(),
+                            },
+                            &self.rxq,
+                            queue,
+                            mem,
+                        );
+                        return;
+                    }
+                    if let Some(proxy) = self.proxy_map.read().unwrap().get(&id) {
+                        proxy.lock().unwrap().confirm_connect(pkt);
+                    }
+                }
+                Err(err) => {
+                    warn!(
+                        "custom vsock service rejected port {}: {err}",
+                        pkt.dst_port()
+                    );
+                    push_packet(
+                        self.cid,
+                        MuxerRx::Reset {
+                            local_port: pkt.dst_port(),
+                            peer_port: pkt.src_port(),
+                        },
+                        &self.rxq,
+                        queue,
+                        mem,
+                    );
+                }
+            }
+            return;
+        }
+
+        if let Some((path, listen)) = self
+            .unix_ipc_port_map
+            .as_ref()
+            .and_then(|routes| routes.get(&pkt.dst_port()))
+        {
+            if *listen {
+                warn!("attempting to connect a vsock port configured for Unix listen mode");
+                push_packet(
+                    self.cid,
+                    MuxerRx::Reset {
                         local_port: pkt.dst_port(),
                         peer_port: pkt.src_port(),
-                    };
-                    push_packet(self.cid, rx, &self.rxq, queue, mem);
+                    },
+                    &self.rxq,
+                    queue,
+                    mem,
+                );
+                return;
+            }
+
+            let mut unix = match UnixProxy::new(
+                id,
+                self.cid,
+                pkt.dst_port(),
+                pkt.src_port(),
+                mem.clone(),
+                queue.clone(),
+                self.rxq.clone(),
+                path.to_path_buf(),
+            ) {
+                Ok(proxy) => proxy,
+                Err(err) => {
+                    warn!(
+                        "failed to create Unix proxy for host port {}: {err}",
+                        pkt.dst_port()
+                    );
+                    push_packet(
+                        self.cid,
+                        MuxerRx::Reset {
+                            local_port: pkt.dst_port(),
+                            peer_port: pkt.src_port(),
+                        },
+                        &self.rxq,
+                        queue,
+                        mem,
+                    );
                     return;
                 }
-                let rxq = self.rxq.clone();
-
-                let mut unix = UnixProxy::new(
-                    id,
-                    self.cid,
-                    pkt.dst_port(),
-                    pkt.src_port(),
-                    mem.clone(),
-                    queue.clone(),
-                    rxq,
-                    path.to_path_buf(),
-                )
-                .unwrap();
-                let tsi = TsiConnectReq {
-                    peer_port: 0,
-                    addr: SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0).into(),
-                };
-                let update = unix.connect(pkt, tsi);
-                unix.confirm_connect(pkt);
-                proxy_map.insert(id, Mutex::new(Box::new(unix)));
-                self.process_proxy_update(id, update);
+            };
+            let update = match unix.connect_vsock() {
+                Ok(update) => update,
+                Err(errno) => {
+                    warn!(
+                        "failed to connect Unix route for host port {}: errno {}",
+                        pkt.dst_port(),
+                        errno
+                    );
+                    push_packet(
+                        self.cid,
+                        MuxerRx::Reset {
+                            local_port: pkt.dst_port(),
+                            peer_port: pkt.src_port(),
+                        },
+                        &self.rxq,
+                        queue,
+                        mem,
+                    );
+                    return;
+                }
+            };
+            if unix.status == super::proxy::ProxyStatus::Connected {
+                unix.confirm_vsock_connect(pkt);
+            } else {
+                unix.prepare_vsock_connect(pkt);
             }
+            self.proxy_map
+                .write()
+                .unwrap()
+                .insert(id, Mutex::new(Box::new(unix)));
+            self.process_proxy_update(id, update);
         }
     }
 

--- a/src/devices/src/virtio/vsock/proxy.rs
+++ b/src/devices/src/virtio/vsock/proxy.rs
@@ -95,4 +95,6 @@ pub trait Proxy: Send + AsRawFd {
     fn shutdown(&mut self, _pkt: &VsockPacket) {}
     fn release(&mut self) -> ProxyUpdate;
     fn process_event(&mut self, evset: EventSet) -> ProxyUpdate;
+    /// Retry backend work after the guest makes receive capacity available.
+    fn kick(&self) {}
 }

--- a/src/devices/src/virtio/vsock/unix.rs
+++ b/src/devices/src/virtio/vsock/unix.rs
@@ -6,10 +6,12 @@ use super::{
 use nix::errno::Errno;
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::sys::socket::{
-    accept, bind, connect, listen, recv, send, shutdown, socket, AddressFamily, Backlog, MsgFlags,
-    Shutdown, SockFlag, SockType, UnixAddr,
+    accept, bind, connect, getsockopt, listen, recv, send, shutdown, socket, sockopt,
+    AddressFamily, Backlog, MsgFlags, Shutdown, SockFlag, SockType, UnixAddr,
 };
 use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::io;
 use std::num::Wrapping;
 use std::os::fd::{FromRawFd, OwnedFd};
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -23,6 +25,7 @@ use super::muxer::{push_packet, MuxerRx};
 use super::muxer_rxq::MuxerRxQ;
 use super::packet::{TsiAcceptReq, TsiConnectReq, TsiListenReq, TsiSendtoAddr, VsockPacket};
 use super::proxy::{NewProxyType, Proxy, ProxyError, ProxyStatus, ProxyUpdate};
+use super::{VsockShutdown, VsockStreamBackend};
 use utils::epoll::EventSet;
 
 use vm_memory::GuestMemoryMmap;
@@ -30,7 +33,7 @@ use vm_memory::GuestMemoryMmap;
 pub struct UnixProxy {
     id: u64,
     cid: u64,
-    fd: OwnedFd,
+    endpoint: StreamEndpoint,
     pub status: ProxyStatus,
     mem: GuestMemoryMmap,
     queue: Arc<Mutex<VirtQueue>>,
@@ -45,6 +48,61 @@ pub struct UnixProxy {
     last_tx_cnt_sent: Wrapping<u32>,
     push_cnt: Wrapping<u32>,
     rx_cnt: Wrapping<u32>,
+    pending_write: VecDeque<u8>,
+}
+
+enum StreamEndpoint {
+    Unix(OwnedFd),
+    Custom(Box<dyn VsockStreamBackend>),
+}
+
+impl StreamEndpoint {
+    fn is_custom(&self) -> bool {
+        matches!(self, Self::Custom(_))
+    }
+
+    fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Self::Unix(fd) => recv(fd.as_raw_fd(), buf, MsgFlags::MSG_DONTWAIT)
+                .map_err(|err| io::Error::from_raw_os_error(err as i32)),
+            Self::Custom(backend) => backend.read(buf),
+        }
+    }
+
+    fn write(&self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::Unix(fd) => {
+                #[cfg(target_os = "macos")]
+                let flags = MsgFlags::empty();
+                #[cfg(target_os = "linux")]
+                let flags = MsgFlags::MSG_NOSIGNAL;
+                send(fd.as_raw_fd(), buf, flags)
+                    .map_err(|err| io::Error::from_raw_os_error(err as i32))
+            }
+            Self::Custom(backend) => backend.write(buf),
+        }
+    }
+
+    fn shutdown(&self, how: Shutdown) -> io::Result<()> {
+        match self {
+            Self::Unix(fd) => shutdown(fd.as_raw_fd(), how)
+                .map_err(|err| io::Error::from_raw_os_error(err as i32)),
+            Self::Custom(backend) => backend.shutdown(match how {
+                Shutdown::Read => VsockShutdown::Read,
+                Shutdown::Write => VsockShutdown::Write,
+                Shutdown::Both => VsockShutdown::Both,
+            }),
+        }
+    }
+}
+
+impl AsRawFd for StreamEndpoint {
+    fn as_raw_fd(&self) -> RawFd {
+        match self {
+            Self::Unix(fd) => fd.as_raw_fd(),
+            Self::Custom(backend) => backend.poll_fd(),
+        }
+    }
 }
 
 fn proxy_fd_create(id: u64) -> Result<OwnedFd, ProxyError> {
@@ -107,7 +165,7 @@ impl UnixProxy {
             local_port,
             peer_port: 0,
             control_port,
-            fd,
+            endpoint: StreamEndpoint::Unix(fd),
             status: ProxyStatus::Idle,
             mem,
             queue,
@@ -119,7 +177,41 @@ impl UnixProxy {
             last_tx_cnt_sent: Wrapping(0),
             push_cnt: Wrapping(0),
             rx_cnt: Wrapping(0),
+            pending_write: VecDeque::new(),
         })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_custom(
+        id: u64,
+        cid: u64,
+        local_port: u32,
+        peer_port: u32,
+        backend: Box<dyn VsockStreamBackend>,
+        mem: GuestMemoryMmap,
+        queue: Arc<Mutex<VirtQueue>>,
+        rxq: Arc<Mutex<MuxerRxQ>>,
+    ) -> Self {
+        UnixProxy {
+            id,
+            cid,
+            local_port,
+            peer_port,
+            control_port: 0,
+            endpoint: StreamEndpoint::Custom(backend),
+            status: ProxyStatus::Connected,
+            mem,
+            queue,
+            rxq,
+            peer_buf_alloc: 0,
+            peer_fwd_cnt: Wrapping(0),
+            path: PathBuf::new(),
+            tx_cnt: Wrapping(0),
+            last_tx_cnt_sent: Wrapping(0),
+            push_cnt: Wrapping(0),
+            rx_cnt: Wrapping(0),
+            pending_write: VecDeque::new(),
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -134,13 +226,22 @@ impl UnixProxy {
         rxq: Arc<Mutex<MuxerRxQ>>,
     ) -> Self {
         debug!("new_reverse: id={id} local_port={local_port} peer_port={peer_port}");
+        // Accepted sockets are not guaranteed to inherit O_NONBLOCK. Keeping
+        // them nonblocking prevents a slow peer from stalling the muxer.
+        if let Ok(flags) = fcntl(&fd, FcntlArg::F_GETFL) {
+            if let Some(flags) = OFlag::from_bits(flags) {
+                if let Err(err) = fcntl(&fd, FcntlArg::F_SETFL(flags | OFlag::O_NONBLOCK)) {
+                    warn!("failed to make reverse Unix vsock nonblocking: {err}");
+                }
+            }
+        }
         UnixProxy {
             id,
             cid,
             local_port,
             peer_port,
             control_port: 0,
-            fd,
+            endpoint: StreamEndpoint::Unix(fd),
             status: ProxyStatus::ReverseInit,
             mem,
             queue,
@@ -152,22 +253,62 @@ impl UnixProxy {
             peer_fwd_cnt: Wrapping(0),
             push_cnt: Wrapping(0),
             path: Default::default(),
+            pending_write: VecDeque::new(),
         }
     }
 
     fn switch_to_connected(&mut self) {
         self.status = ProxyStatus::Connected;
-        match fcntl(&self.fd, FcntlArg::F_GETFL) {
-            Ok(flags) => match OFlag::from_bits(flags) {
-                Some(flags) => {
-                    if let Err(e) = fcntl(&self.fd, FcntlArg::F_SETFL(flags & !OFlag::O_NONBLOCK)) {
-                        warn!("error switching to blocking: id={}, err={}", self.id, e);
-                    }
-                }
-                None => error!("invalid fd flags id={}", self.id),
+    }
+
+    /// Connect a typed AF_VSOCK route without emitting TSI control packets.
+    pub fn connect_vsock(&mut self) -> Result<ProxyUpdate, i32> {
+        let addr = UnixAddr::new(&self.path).map_err(|_| -libc::EINVAL)?;
+        let mut update = ProxyUpdate::default();
+
+        match connect(self.endpoint.as_raw_fd(), &addr) {
+            Ok(()) => self.switch_to_connected(),
+            Err(Errno::EINPROGRESS) => self.status = ProxyStatus::Connecting,
+            Err(err) => {
+                #[cfg(target_os = "macos")]
+                return Err(-linux_errno_raw(err as i32));
+                #[cfg(target_os = "linux")]
+                return Err(-(err as i32));
+            }
+        }
+
+        update.polling = Some((
+            self.id,
+            self.endpoint.as_raw_fd(),
+            if self.status == ProxyStatus::Connecting {
+                EventSet::IN | EventSet::OUT
+            } else {
+                EventSet::IN
             },
-            Err(e) => error!("couldn't obtain fd flags id={}, err={}", self.id, e),
+        ));
+        Ok(update)
+    }
+
+    /// Record peer flow-control state while a nonblocking route connect is pending.
+    pub fn prepare_vsock_connect(&mut self, pkt: &VsockPacket) {
+        self.peer_buf_alloc = pkt.buf_alloc();
+        self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
+        self.local_port = pkt.dst_port();
+        self.peer_port = pkt.src_port();
+    }
+
+    /// Confirm a completed route connection to the guest.
+    pub fn confirm_vsock_connect(&mut self, pkt: &VsockPacket) {
+        self.prepare_vsock_connect(pkt);
+        self.push_vsock_connect_response();
+    }
+
+    fn push_vsock_connect_response(&self) {
+        let rx = MuxerRx::OpResponse {
+            local_port: self.local_port,
+            peer_port: self.peer_port,
         };
+        push_packet(self.cid, rx, &self.rxq, &self.queue, &self.mem);
     }
 
     fn push_connect_rsp(&self, result: i32) {
@@ -219,12 +360,14 @@ impl UnixProxy {
                 return RecvPkt::WaitForCredit;
             }
 
-            match recv(
-                self.fd.as_raw_fd(),
-                &mut buf[..max_len],
-                MsgFlags::MSG_DONTWAIT,
-            ) {
+            match self.endpoint.read(&mut buf[..max_len]) {
                 Ok(cnt) => {
+                    if cnt > max_len {
+                        warn!(
+                            "vsock backend returned invalid read length: count={cnt}, capacity={max_len}"
+                        );
+                        return RecvPkt::Error;
+                    }
                     debug!("recv cnt={cnt}");
                     if cnt > 0 {
                         debug!("recv rx_cnt={}", self.rx_cnt);
@@ -233,6 +376,7 @@ impl UnixProxy {
                         RecvPkt::Close
                     }
                 }
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => RecvPkt::Error,
                 Err(e) => {
                     debug!("recv_pkt: recv error: {e:?}");
                     RecvPkt::Error
@@ -294,6 +438,36 @@ impl UnixProxy {
         (have_used, wait_credit)
     }
 
+    fn flush_pending_write(&mut self) -> io::Result<()> {
+        while !self.pending_write.is_empty() {
+            let (front, back) = self.pending_write.as_slices();
+            let buf = if front.is_empty() { back } else { front };
+            match self.endpoint.write(buf) {
+                Ok(0) => return Err(io::Error::from(io::ErrorKind::WriteZero)),
+                Ok(written) => {
+                    if written > buf.len() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "vsock backend returned a write length larger than its input",
+                        ));
+                    }
+                    self.pending_write.drain(..written);
+                }
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(())
+    }
+
+    fn connected_poll_events(&self) -> EventSet {
+        if self.endpoint.is_custom() || self.pending_write.is_empty() {
+            EventSet::IN
+        } else {
+            EventSet::IN | EventSet::OUT
+        }
+    }
+
     fn init_data_pkt(&self, pkt: &mut VsockPacket) {
         debug!(
             "init_data_pkt: id={}, local_port={}, peer_port={}",
@@ -323,9 +497,21 @@ impl Proxy for UnixProxy {
     fn connect(&mut self, _pkt: &VsockPacket, _req: TsiConnectReq) -> ProxyUpdate {
         let mut update = ProxyUpdate::default();
 
-        let addr = UnixAddr::new(&self.path).unwrap();
+        let addr = match UnixAddr::new(&self.path) {
+            Ok(addr) => addr,
+            Err(err) => {
+                warn!(
+                    "invalid Unix socket path for vsock route {:?}: {err}",
+                    self.path
+                );
+                self.push_connect_rsp(-libc::EINVAL);
+                update.signal_queue = true;
+                update.remove_proxy = ProxyRemoval::Immediate;
+                return update;
+            }
+        };
 
-        let result = match connect(self.fd.as_raw_fd(), &addr) {
+        let result = match connect(self.endpoint.as_raw_fd(), &addr) {
             Ok(()) => {
                 debug!("connect: Connected");
                 self.switch_to_connected();
@@ -347,10 +533,14 @@ impl Proxy for UnixProxy {
         };
 
         if self.status == ProxyStatus::Connecting {
-            update.polling = Some((self.id, self.fd.as_raw_fd(), EventSet::IN | EventSet::OUT));
+            update.polling = Some((
+                self.id,
+                self.endpoint.as_raw_fd(),
+                EventSet::IN | EventSet::OUT,
+            ));
         } else {
             if self.status == ProxyStatus::Connected {
-                update.polling = Some((self.id, self.fd.as_raw_fd(), EventSet::IN));
+                update.polling = Some((self.id, self.endpoint.as_raw_fd(), EventSet::IN));
             }
             self.push_connect_rsp(result);
         }
@@ -367,18 +557,7 @@ impl Proxy for UnixProxy {
             self.peer_port,
         );
 
-        self.peer_buf_alloc = pkt.buf_alloc();
-        self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
-
-        self.local_port = pkt.dst_port();
-        self.peer_port = pkt.src_port();
-
-        // This response goes to the connection.
-        let rx = MuxerRx::OpResponse {
-            local_port: pkt.dst_port(),
-            peer_port: pkt.src_port(),
-        };
-        push_packet(self.cid, rx, &self.rxq, &self.queue, &self.mem);
+        self.confirm_vsock_connect(pkt);
 
         None
     }
@@ -391,29 +570,23 @@ impl Proxy for UnixProxy {
         let mut update = ProxyUpdate::default();
 
         let ret = if let Some(buf) = pkt.buf() {
-            #[cfg(target_os = "macos")]
-            let flags = MsgFlags::empty();
-
-            #[cfg(target_os = "linux")]
-            let flags = MsgFlags::MSG_NOSIGNAL;
-
-            match send(self.fd.as_raw_fd(), buf, flags) {
-                Ok(sent) => {
-                    if sent != buf.len() {
-                        error!("couldn't set everything: buf={}, sent={}", buf.len(), sent);
-                    }
-                    self.tx_cnt += Wrapping(sent as u32);
-                    sent as i32
-                }
-                Err(err) => {
-                    #[cfg(target_os = "macos")]
-                    let errno = -linux_errno_raw(err as i32);
-
-                    #[cfg(target_os = "linux")]
-                    let errno = -(err as i32);
-                    errno
-                }
+            // Credit is returned when bytes enter this bounded proxy queue;
+            // readiness drives later partial flushes without blocking a VMM thread.
+            self.pending_write.extend(buf);
+            self.tx_cnt += Wrapping(buf.len() as u32);
+            if let Err(err) = self.flush_pending_write() {
+                warn!("vsock backend write failed: {err}");
+                self.push_reset();
+                self.status = ProxyStatus::Closed;
+                update.signal_queue = true;
+                update.remove_proxy = ProxyRemoval::Deferred;
             }
+            update.polling = Some((
+                self.id,
+                self.endpoint.as_raw_fd(),
+                self.connected_poll_events(),
+            ));
+            buf.len() as i32
         } else {
             -libc::EINVAL
         };
@@ -472,7 +645,11 @@ impl Proxy for UnixProxy {
         self.status = ProxyStatus::Connected;
 
         ProxyUpdate {
-            polling: Some((self.id, self.fd.as_raw_fd(), EventSet::IN)),
+            polling: Some((
+                self.id,
+                self.endpoint.as_raw_fd(),
+                self.connected_poll_events(),
+            )),
             ..Default::default()
         }
     }
@@ -505,7 +682,11 @@ impl Proxy for UnixProxy {
         self.switch_to_connected();
 
         ProxyUpdate {
-            polling: Some((self.id, self.fd.as_raw_fd(), EventSet::IN)),
+            polling: Some((
+                self.id,
+                self.endpoint.as_raw_fd(),
+                self.connected_poll_events(),
+            )),
             ..Default::default()
         }
     }
@@ -526,7 +707,7 @@ impl Proxy for UnixProxy {
             Shutdown::Write
         };
 
-        if let Err(e) = shutdown(self.fd.as_raw_fd(), how) {
+        if let Err(e) = self.endpoint.shutdown(how) {
             warn!("error sending shutdown to socket: {e}");
         }
     }
@@ -550,14 +731,10 @@ impl Proxy for UnixProxy {
         if evset.contains(EventSet::HANG_UP) {
             debug!("process_event: HANG_UP");
 
-            if self.status == ProxyStatus::Connecting {
-                self.push_connect_rsp(-libc::ECONNREFUSED);
-            } else {
-                self.push_reset();
-            }
+            self.push_reset();
 
             self.status = ProxyStatus::Closed;
-            update.polling = Some((self.id, self.fd.as_raw_fd(), EventSet::empty()));
+            update.polling = Some((self.id, self.endpoint.as_raw_fd(), EventSet::empty()));
             update.signal_queue = true;
             update.remove_proxy = ProxyRemoval::Deferred;
 
@@ -567,6 +744,16 @@ impl Proxy for UnixProxy {
         if evset.contains(EventSet::IN) {
             debug!("process_event: IN");
             if self.status == ProxyStatus::Connected {
+                if !self.pending_write.is_empty() {
+                    if let Err(err) = self.flush_pending_write() {
+                        warn!("vsock backend write failed: {err}");
+                        self.push_reset();
+                        self.status = ProxyStatus::Closed;
+                        update.signal_queue = true;
+                        update.remove_proxy = ProxyRemoval::Deferred;
+                        return update;
+                    }
+                }
                 let (signal_queue, wait_credit) = self.recv_pkt();
                 update.signal_queue = signal_queue;
 
@@ -588,11 +775,13 @@ impl Proxy for UnixProxy {
 
                     self.push_reset();
                     update.signal_queue = true;
-                    update.polling = Some((self.id(), self.fd.as_raw_fd(), EventSet::empty()));
+                    update.polling =
+                        Some((self.id(), self.endpoint.as_raw_fd(), EventSet::empty()));
                     return update;
                 } else if self.status == ProxyStatus::WaitingCreditUpdate {
                     debug!("process_event: WaitingCreditUpdate");
-                    update.polling = Some((self.id(), self.fd.as_raw_fd(), EventSet::empty()));
+                    update.polling =
+                        Some((self.id(), self.endpoint.as_raw_fd(), EventSet::empty()));
                 }
             } else {
                 debug!("EventSet::IN while not connected: {:?}", self.status);
@@ -602,12 +791,51 @@ impl Proxy for UnixProxy {
         if evset.contains(EventSet::OUT) {
             debug!("process_event: OUT");
             if self.status == ProxyStatus::Connecting {
+                let connect_error = match &self.endpoint {
+                    StreamEndpoint::Unix(fd) => {
+                        getsockopt(fd, sockopt::SocketError).unwrap_or(libc::EIO)
+                    }
+                    StreamEndpoint::Custom(_) => 0,
+                };
+                if connect_error != 0 {
+                    warn!("Unix vsock connect failed asynchronously: errno {connect_error}");
+                    self.push_reset();
+                    self.status = ProxyStatus::Closed;
+                    update.signal_queue = true;
+                    update.remove_proxy = ProxyRemoval::Deferred;
+                    update.polling =
+                        Some((self.id(), self.endpoint.as_raw_fd(), EventSet::empty()));
+                    return update;
+                }
                 self.switch_to_connected();
-                self.push_connect_rsp(0);
+                self.push_vsock_connect_response();
                 update.signal_queue = true;
-                update.polling = Some((self.id(), self.fd.as_raw_fd(), EventSet::IN));
+                if let Err(err) = self.flush_pending_write() {
+                    warn!("vsock backend write failed after connect: {err}");
+                    self.push_reset();
+                    self.status = ProxyStatus::Closed;
+                    update.remove_proxy = ProxyRemoval::Deferred;
+                }
+                update.polling = Some((
+                    self.id(),
+                    self.endpoint.as_raw_fd(),
+                    self.connected_poll_events(),
+                ));
+            } else if self.status == ProxyStatus::Connected {
+                if let Err(err) = self.flush_pending_write() {
+                    warn!("vsock backend write failed: {err}");
+                    self.push_reset();
+                    self.status = ProxyStatus::Closed;
+                    update.signal_queue = true;
+                    update.remove_proxy = ProxyRemoval::Deferred;
+                }
+                update.polling = Some((
+                    self.id(),
+                    self.endpoint.as_raw_fd(),
+                    self.connected_poll_events(),
+                ));
             } else {
-                error!("EventSet::OUT while not connecting");
+                error!("EventSet::OUT in unexpected state: {:?}", self.status);
             }
         }
 
@@ -617,7 +845,7 @@ impl Proxy for UnixProxy {
 
 impl AsRawFd for UnixProxy {
     fn as_raw_fd(&self) -> RawFd {
-        self.fd.as_raw_fd()
+        self.endpoint.as_raw_fd()
     }
 }
 
@@ -719,5 +947,96 @@ impl Proxy for UnixAcceptorProxy {
 impl AsRawFd for UnixAcceptorProxy {
     fn as_raw_fd(&self) -> RawFd {
         self.fd.as_raw_fd()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use utils::eventfd::{EventFd, EFD_NONBLOCK};
+    use vm_memory::GuestAddress;
+
+    use super::*;
+
+    struct TestStreamState {
+        blocked: AtomicBool,
+        written: Mutex<Vec<u8>>,
+        shutdown: Mutex<Option<VsockShutdown>>,
+    }
+
+    struct TestStream {
+        event: EventFd,
+        state: Arc<TestStreamState>,
+    }
+
+    impl VsockStreamBackend for TestStream {
+        fn read(&self, _buf: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::from(io::ErrorKind::WouldBlock))
+        }
+
+        fn write(&self, buf: &[u8]) -> io::Result<usize> {
+            let mut written = self.state.written.lock().unwrap();
+            if self.state.blocked.load(Ordering::Relaxed) && written.len() >= 2 {
+                return Err(io::Error::from(io::ErrorKind::WouldBlock));
+            }
+            let count = if self.state.blocked.load(Ordering::Relaxed) {
+                buf.len().min(2)
+            } else {
+                buf.len()
+            };
+            written.extend_from_slice(&buf[..count]);
+            Ok(count)
+        }
+
+        fn shutdown(&self, how: VsockShutdown) -> io::Result<()> {
+            *self.state.shutdown.lock().unwrap() = Some(how);
+            Ok(())
+        }
+
+        fn poll_fd(&self) -> RawFd {
+            self.event.as_raw_fd()
+        }
+    }
+
+    #[test]
+    fn custom_stream_buffers_partial_writes_without_losing_bytes() {
+        let state = Arc::new(TestStreamState {
+            blocked: AtomicBool::new(true),
+            written: Mutex::new(Vec::new()),
+            shutdown: Mutex::new(None),
+        });
+        let backend = TestStream {
+            event: EventFd::new(EFD_NONBLOCK).unwrap(),
+            state: Arc::clone(&state),
+        };
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mut proxy = UnixProxy::new_custom(
+            1,
+            3,
+            5000,
+            4000,
+            Box::new(backend),
+            mem,
+            Arc::new(Mutex::new(VirtQueue::new(256))),
+            Arc::new(Mutex::new(MuxerRxQ::new())),
+        );
+
+        proxy.pending_write.extend(b"hello");
+        proxy.flush_pending_write().unwrap();
+        assert_eq!(&*state.written.lock().unwrap(), b"he");
+        assert_eq!(proxy.pending_write.len(), 3);
+
+        state.blocked.store(false, Ordering::Relaxed);
+        proxy.flush_pending_write().unwrap();
+        assert_eq!(&*state.written.lock().unwrap(), b"hello");
+        assert!(proxy.pending_write.is_empty());
+
+        proxy.endpoint.shutdown(Shutdown::Both).unwrap();
+        assert_eq!(*state.shutdown.lock().unwrap(), Some(VsockShutdown::Both));
     }
 }

--- a/src/devices/src/virtio/vsock/unix.rs
+++ b/src/devices/src/virtio/vsock/unix.rs
@@ -25,7 +25,7 @@ use super::muxer::{push_packet, MuxerRx};
 use super::muxer_rxq::MuxerRxQ;
 use super::packet::{TsiAcceptReq, TsiConnectReq, TsiListenReq, TsiSendtoAddr, VsockPacket};
 use super::proxy::{NewProxyType, Proxy, ProxyError, ProxyStatus, ProxyUpdate};
-use super::{VsockShutdown, VsockStreamBackend};
+use super::{VsockNotifier, VsockShutdown, VsockStreamBackend};
 use utils::epoll::EventSet;
 
 use vm_memory::GuestMemoryMmap;
@@ -53,19 +53,22 @@ pub struct UnixProxy {
 
 enum StreamEndpoint {
     Unix(OwnedFd),
-    Custom(Box<dyn VsockStreamBackend>),
+    Custom {
+        backend: Box<dyn VsockStreamBackend>,
+        notifier: VsockNotifier,
+    },
 }
 
 impl StreamEndpoint {
     fn is_custom(&self) -> bool {
-        matches!(self, Self::Custom(_))
+        matches!(self, Self::Custom { .. })
     }
 
     fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
             Self::Unix(fd) => recv(fd.as_raw_fd(), buf, MsgFlags::MSG_DONTWAIT)
                 .map_err(|err| io::Error::from_raw_os_error(err as i32)),
-            Self::Custom(backend) => backend.read(buf),
+            Self::Custom { backend, .. } => backend.read(buf),
         }
     }
 
@@ -79,7 +82,7 @@ impl StreamEndpoint {
                 send(fd.as_raw_fd(), buf, flags)
                     .map_err(|err| io::Error::from_raw_os_error(err as i32))
             }
-            Self::Custom(backend) => backend.write(buf),
+            Self::Custom { backend, .. } => backend.write(buf),
         }
     }
 
@@ -87,7 +90,7 @@ impl StreamEndpoint {
         match self {
             Self::Unix(fd) => shutdown(fd.as_raw_fd(), how)
                 .map_err(|err| io::Error::from_raw_os_error(err as i32)),
-            Self::Custom(backend) => backend.shutdown(match how {
+            Self::Custom { backend, .. } => backend.shutdown(match how {
                 Shutdown::Read => VsockShutdown::Read,
                 Shutdown::Write => VsockShutdown::Write,
                 Shutdown::Both => VsockShutdown::Both,
@@ -100,7 +103,7 @@ impl AsRawFd for StreamEndpoint {
     fn as_raw_fd(&self) -> RawFd {
         match self {
             Self::Unix(fd) => fd.as_raw_fd(),
-            Self::Custom(backend) => backend.poll_fd(),
+            Self::Custom { notifier, .. } => notifier.event().as_raw_fd(),
         }
     }
 }
@@ -188,6 +191,7 @@ impl UnixProxy {
         local_port: u32,
         peer_port: u32,
         backend: Box<dyn VsockStreamBackend>,
+        notifier: VsockNotifier,
         mem: GuestMemoryMmap,
         queue: Arc<Mutex<VirtQueue>>,
         rxq: Arc<Mutex<MuxerRxQ>>,
@@ -198,7 +202,7 @@ impl UnixProxy {
             local_port,
             peer_port,
             control_port: 0,
-            endpoint: StreamEndpoint::Custom(backend),
+            endpoint: StreamEndpoint::Custom { backend, notifier },
             status: ProxyStatus::Connected,
             mem,
             queue,
@@ -468,6 +472,14 @@ impl UnixProxy {
         }
     }
 
+    fn clear_custom_notification(&self) {
+        if let StreamEndpoint::Custom { notifier, .. } = &self.endpoint {
+            if let Err(err) = notifier.clear() {
+                warn!("failed to clear custom vsock notification: {err}");
+            }
+        }
+    }
+
     fn init_data_pkt(&self, pkt: &mut VsockPacket) {
         debug!(
             "init_data_pkt: id={}, local_port={}, peer_port={}",
@@ -643,6 +655,7 @@ impl Proxy for UnixProxy {
         self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
 
         self.status = ProxyStatus::Connected;
+        self.kick();
 
         ProxyUpdate {
             polling: Some((
@@ -744,6 +757,7 @@ impl Proxy for UnixProxy {
         if evset.contains(EventSet::IN) {
             debug!("process_event: IN");
             if self.status == ProxyStatus::Connected {
+                self.clear_custom_notification();
                 if !self.pending_write.is_empty() {
                     if let Err(err) = self.flush_pending_write() {
                         warn!("vsock backend write failed: {err}");
@@ -795,7 +809,7 @@ impl Proxy for UnixProxy {
                     StreamEndpoint::Unix(fd) => {
                         getsockopt(fd, sockopt::SocketError).unwrap_or(libc::EIO)
                     }
-                    StreamEndpoint::Custom(_) => 0,
+                    StreamEndpoint::Custom { .. } => 0,
                 };
                 if connect_error != 0 {
                     warn!("Unix vsock connect failed asynchronously: errno {connect_error}");
@@ -840,6 +854,14 @@ impl Proxy for UnixProxy {
         }
 
         update
+    }
+
+    fn kick(&self) {
+        if let StreamEndpoint::Custom { notifier, .. } = &self.endpoint {
+            if let Err(err) = notifier.notify() {
+                warn!("failed to kick custom vsock backend: {err}");
+            }
+        }
     }
 }
 
@@ -958,7 +980,6 @@ impl AsRawFd for UnixAcceptorProxy {
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
-    use utils::eventfd::{EventFd, EFD_NONBLOCK};
     use vm_memory::GuestAddress;
 
     use super::*;
@@ -970,7 +991,6 @@ mod tests {
     }
 
     struct TestStream {
-        event: EventFd,
         state: Arc<TestStreamState>,
     }
 
@@ -997,10 +1017,6 @@ mod tests {
             *self.state.shutdown.lock().unwrap() = Some(how);
             Ok(())
         }
-
-        fn poll_fd(&self) -> RawFd {
-            self.event.as_raw_fd()
-        }
     }
 
     #[test]
@@ -1011,7 +1027,6 @@ mod tests {
             shutdown: Mutex::new(None),
         });
         let backend = TestStream {
-            event: EventFd::new(EFD_NONBLOCK).unwrap(),
             state: Arc::clone(&state),
         };
         let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
@@ -1021,6 +1036,7 @@ mod tests {
             5000,
             4000,
             Box::new(backend),
+            VsockNotifier::new().unwrap(),
             mem,
             Arc::new(Mutex::new(VirtQueue::new(256))),
             Arc::new(Mutex::new(MuxerRxQ::new())),

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -592,6 +592,8 @@ impl VmBuilder {
             exit_evt,
             exit_code,
             self.machine.enable_inet_hijack,
+            self.machine.vsock_unix_ipc_port_map,
+            self.machine.vsock_host_port_map,
         ))
     }
 }
@@ -716,6 +718,37 @@ mod tests {
             Error::Config(ConfigError::InvalidMaxMemorySize(1024)) => {}
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[test]
+    fn vsock_port_maps_enable_vsock() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+
+        let builder = VmBuilder::new();
+        assert!(!builder.machine.vsock);
+
+        let builder = VmBuilder::new()
+            .machine(|machine| machine.vsock_unix_ipc_port_map(HashMap::new()));
+        assert!(!builder.machine.vsock, "empty map must not enable vsock");
+
+        let mut unix_map = HashMap::new();
+        unix_map.insert(5000, (PathBuf::from("/tmp/ipc.sock"), false));
+        let builder = VmBuilder::new()
+            .machine(|machine| machine.vsock_unix_ipc_port_map(unix_map));
+        assert!(builder.machine.vsock, "non-empty Unix IPC map enables vsock");
+
+        let mut host_map = HashMap::new();
+        host_map.insert(8080, 18080);
+        let builder = VmBuilder::new()
+            .machine(|machine| machine.vsock_host_port_map(host_map));
+        assert!(builder.machine.vsock, "non-empty host port map enables vsock");
+
+        let mut unix_map = HashMap::new();
+        unix_map.insert(5000, (PathBuf::from("/tmp/ipc.sock"), false));
+        let builder = VmBuilder::new()
+            .machine(|machine| machine.vsock_unix_ipc_port_map(unix_map).vsock(false));
+        assert!(!builder.machine.vsock, "later vsock(false) overrides the map");
     }
 
     #[cfg(feature = "blk")]

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -133,8 +133,7 @@ impl VmBuilder {
 
     /// Configure host services exposed through virtio-vsock.
     ///
-    /// Routes imply device attachment; [`MachineBuilder::vsock`] remains an
-    /// independent force-attach request for guests that manage vsock directly.
+    /// A route or enabled TSI transport automatically attaches the device.
     #[cfg(not(target_os = "windows"))]
     pub fn vsock(mut self, f: impl FnOnce(VsockBuilder) -> VsockBuilder) -> Self {
         self.vsock = f(self.vsock);
@@ -363,14 +362,14 @@ impl VmBuilder {
         }
 
         #[cfg(target_os = "windows")]
-        if self.machine.vsock || self.machine.enable_inet_hijack {
+        if self.machine.enable_inet_hijack {
             return Err(Error::Config(ConfigError::Vsock(
                 "virtio-vsock is not supported on Windows".to_string(),
             )));
         }
 
         #[cfg(not(target_os = "windows"))]
-        let (vsock_unix_ipc_port_map, vsock_custom_port_map, vsock_host_port_map, has_vsock_routes) = {
+        let (vsock_unix_ipc_port_map, vsock_custom_port_map, vsock_host_port_map) = {
             let mut occupied_ports = HashSet::new();
             let mut unix_routes = HashMap::new();
             let mut custom_routes = HashMap::new();
@@ -440,12 +439,10 @@ impl VmBuilder {
                 }
             }
 
-            let has_routes = !unix_routes.is_empty() || !custom_routes.is_empty();
             (
                 (!unix_routes.is_empty()).then_some(unix_routes),
                 (!custom_routes.is_empty()).then_some(custom_routes),
                 (!host_map.is_empty()).then_some(host_map),
-                has_routes,
             )
         };
 
@@ -526,14 +523,6 @@ impl VmBuilder {
         }
         vmr.nested_enabled = self.machine.nested_virt;
         vmr.split_irqchip = self.machine.split_irqchip;
-        #[cfg(not(target_os = "windows"))]
-        {
-            vmr.request_vsock = self.machine.vsock || has_vsock_routes;
-        }
-        #[cfg(target_os = "windows")]
-        {
-            vmr.request_vsock = self.machine.vsock;
-        }
         vmr.enable_balloon = self.machine.balloon;
         vmr.balloon_stats_interval = self.machine.balloon_stats_interval;
         vmr.enable_rng = self.machine.rng;

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -1,5 +1,7 @@
 //! VM Builder for creating and configuring microVMs using nested builders.
 
+#[cfg(not(target_os = "windows"))]
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicI32;
 use std::sync::Arc;
 
@@ -23,6 +25,8 @@ use super::builders::FsConfig;
 use super::builders::{ConsoleBuilder, ExecBuilder, KernelBuilder, MachineBuilder};
 #[cfg(feature = "net")]
 use super::builders::{NetBuilder, NetConfig};
+#[cfg(not(target_os = "windows"))]
+use super::builders::{VsockBuilder, VsockRoute};
 
 use super::error::{BuildError, ConfigError, Error, Result};
 use super::vm::Vm;
@@ -63,6 +67,8 @@ use vmm::vmm_config::net::NetworkInterfaceConfig;
 /// ```
 pub struct VmBuilder {
     machine: MachineBuilder,
+    #[cfg(not(target_os = "windows"))]
+    vsock: VsockBuilder,
     kernel: KernelBuilder,
     #[cfg_attr(feature = "tee", allow(dead_code))]
     #[cfg(not(feature = "tee"))]
@@ -91,6 +97,8 @@ impl VmBuilder {
     pub fn new() -> Self {
         Self {
             machine: MachineBuilder::new(),
+            #[cfg(not(target_os = "windows"))]
+            vsock: VsockBuilder::new(),
             kernel: KernelBuilder::new(),
             #[cfg(not(feature = "tee"))]
             fs: FsBuilder::new(),
@@ -120,6 +128,16 @@ impl VmBuilder {
     /// ```
     pub fn machine(mut self, f: impl FnOnce(MachineBuilder) -> MachineBuilder) -> Self {
         self.machine = f(self.machine);
+        self
+    }
+
+    /// Configure host services exposed through virtio-vsock.
+    ///
+    /// Routes imply device attachment; [`MachineBuilder::vsock`] remains an
+    /// independent force-attach request for guests that manage vsock directly.
+    #[cfg(not(target_os = "windows"))]
+    pub fn vsock(mut self, f: impl FnOnce(VsockBuilder) -> VsockBuilder) -> Self {
+        self.vsock = f(self.vsock);
         self
     }
 
@@ -344,6 +362,95 @@ impl VmBuilder {
             return Err(Error::Config(ConfigError::InvalidMemorySize(0)));
         }
 
+        #[cfg(target_os = "windows")]
+        if self.machine.vsock || self.machine.enable_inet_hijack {
+            return Err(Error::Config(ConfigError::Vsock(
+                "virtio-vsock is not supported on Windows".to_string(),
+            )));
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        let (vsock_unix_ipc_port_map, vsock_custom_port_map, vsock_host_port_map, has_vsock_routes) = {
+            let mut occupied_ports = HashSet::new();
+            let mut unix_routes = HashMap::new();
+            let mut custom_routes = HashMap::new();
+
+            for route in self.vsock.routes {
+                let (port, path) = match &route {
+                    VsockRoute::UnixConnect { port, path }
+                    | VsockRoute::UnixListen { port, path } => (*port, Some(path)),
+                    VsockRoute::Custom { port, .. } => (*port, None),
+                };
+
+                if port == 0 {
+                    return Err(Error::Config(ConfigError::Vsock(
+                        "route port must be non-zero".to_string(),
+                    )));
+                }
+                if !occupied_ports.insert(port) {
+                    return Err(Error::Config(ConfigError::Vsock(format!(
+                        "duplicate route for host port {port}"
+                    ))));
+                }
+                if path.is_some_and(|path| path.as_os_str().is_empty()) {
+                    return Err(Error::Config(ConfigError::Vsock(format!(
+                        "Unix socket path for host port {port} is empty"
+                    ))));
+                }
+
+                match route {
+                    VsockRoute::UnixConnect { port, path } => {
+                        unix_routes.insert(port, (path, false));
+                    }
+                    VsockRoute::UnixListen { port, path } => {
+                        unix_routes.insert(port, (path, true));
+                    }
+                    VsockRoute::Custom { port, backend } => {
+                        custom_routes.insert(port, backend);
+                    }
+                }
+            }
+
+            let enable_inet_hijack =
+                self.machine.enable_inet_hijack || self.vsock.enable_inet_hijack;
+            if !self.vsock.tcp_listen_remaps.is_empty() && !enable_inet_hijack {
+                return Err(Error::Config(ConfigError::Vsock(
+                    "TCP listen remaps require TSI INET hijack".to_string(),
+                )));
+            }
+
+            #[cfg(feature = "net")]
+            if !self.vsock.tcp_listen_remaps.is_empty() && !self.net.configs.is_empty() {
+                return Err(Error::Config(ConfigError::Vsock(
+                    "TCP listen remaps cannot be used with a virtio-net device because TSI INET hijack is inactive".to_string(),
+                )));
+            }
+
+            let mut host_map = HashMap::new();
+            for (guest_port, host_port) in self.vsock.tcp_listen_remaps {
+                if guest_port == 0 || host_port == 0 {
+                    return Err(Error::Config(ConfigError::Vsock(
+                        "TCP listen remap ports must be non-zero".to_string(),
+                    )));
+                }
+                if host_map.insert(guest_port, host_port).is_some() {
+                    return Err(Error::Config(ConfigError::Vsock(format!(
+                        "duplicate TCP listen remap for guest port {guest_port}"
+                    ))));
+                }
+            }
+
+            let has_routes = !unix_routes.is_empty() || !custom_routes.is_empty();
+            (
+                (!unix_routes.is_empty()).then_some(unix_routes),
+                (!custom_routes.is_empty()).then_some(custom_routes),
+                (!host_map.is_empty()).then_some(host_map),
+                has_routes,
+            )
+        };
+
+        #[cfg(not(target_os = "windows"))]
+        let enable_inet_hijack = self.machine.enable_inet_hijack || self.vsock.enable_inet_hijack;
         if let Some(affinity) = &self.machine.vcpu_affinity {
             let expected = self.machine.max_vcpus.unwrap_or(self.machine.vcpus) as usize;
             if affinity.len() != expected {
@@ -419,7 +526,14 @@ impl VmBuilder {
         }
         vmr.nested_enabled = self.machine.nested_virt;
         vmr.split_irqchip = self.machine.split_irqchip;
-        vmr.request_vsock = self.machine.vsock;
+        #[cfg(not(target_os = "windows"))]
+        {
+            vmr.request_vsock = self.machine.vsock || has_vsock_routes;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            vmr.request_vsock = self.machine.vsock;
+        }
         vmr.enable_balloon = self.machine.balloon;
         vmr.balloon_stats_interval = self.machine.balloon_stats_interval;
         vmr.enable_rng = self.machine.rng;
@@ -629,9 +743,14 @@ impl VmBuilder {
             self.exit_observers,
             exit_evt,
             exit_code,
-            self.machine.enable_inet_hijack,
-            self.machine.vsock_unix_ipc_port_map,
-            self.machine.vsock_host_port_map,
+            #[cfg(not(target_os = "windows"))]
+            enable_inet_hijack,
+            #[cfg(not(target_os = "windows"))]
+            vsock_unix_ipc_port_map,
+            #[cfg(not(target_os = "windows"))]
+            vsock_custom_port_map,
+            #[cfg(not(target_os = "windows"))]
+            vsock_host_port_map,
         ))
     }
 }
@@ -776,6 +895,42 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn build_rejects_duplicate_vsock_routes() {
+        let err = match VmBuilder::new()
+            .vsock(|vsock| {
+                vsock
+                    .unix_connect(5000, "/tmp/a.sock")
+                    .unix_listen(5000, "/tmp/b.sock")
+            })
+            .build()
+        {
+            Ok(_) => panic!("duplicate routes must fail"),
+            Err(err) => err,
+        };
+
+        assert!(
+            matches!(err, Error::Config(ConfigError::Vsock(message)) if message.contains("duplicate route"))
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn build_rejects_tcp_remap_without_inet_hijack() {
+        let err = match VmBuilder::new()
+            .vsock(|vsock| vsock.tcp_listen_remap(8080, 18080))
+            .build()
+        {
+            Ok(_) => panic!("inactive TSI remap must fail"),
+            Err(err) => err,
+        };
+
+        assert!(
+            matches!(err, Error::Config(ConfigError::Vsock(message)) if message.contains("require TSI INET"))
+        );
+    }
+
     #[test]
     fn validate_cmdline_env_rejects_uncarryable_values() {
         // Ordinary env, including spaces in the value (quoted on the cmdline), is fine.
@@ -847,7 +1002,7 @@ mod tests {
         match err {
             Error::Config(ConfigError::InvalidHostCpuGroup(1)) => {}
             other => panic!("unexpected error: {other:?}"),
-    }
+        }
     }
 
     #[cfg(feature = "blk")]

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -52,7 +52,6 @@ pub struct MachineBuilder {
     pub(crate) hyperthreading: bool,
     pub(crate) nested_virt: bool,
     pub(crate) split_irqchip: bool,
-    pub(crate) vsock: bool,
     pub(crate) balloon: bool,
     pub(crate) balloon_stats_interval: Option<Duration>,
     pub(crate) rng: bool,
@@ -409,7 +408,6 @@ impl MachineBuilder {
             hyperthreading: false,
             nested_virt: false,
             split_irqchip: false,
-            vsock: false,
             balloon: true,
             balloon_stats_interval: Some(Duration::from_secs(1)),
             rng: true,
@@ -484,17 +482,6 @@ impl MachineBuilder {
     /// aarch64 or riscv64.
     pub fn split_irqchip(mut self, enabled: bool) -> Self {
         self.split_irqchip = enabled;
-        self
-    }
-
-    /// Force-attach a virtio-vsock device to the guest.
-    ///
-    /// By default, vsock is only attached when needed as a TSI transport
-    /// (no virtio-net → HIJACK_INET, or single root virtio-fs on Linux →
-    /// HIJACK_UNIX). Set this to `true` when the guest needs a vsock for
-    /// its own purposes even though TSI would not otherwise require one.
-    pub fn vsock(mut self, enabled: bool) -> Self {
-        self.vsock = enabled;
         self
     }
 

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -1,6 +1,5 @@
 //! Sub-builders for VmBuilder nested configuration.
 
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -23,6 +22,8 @@ use std::sync::Arc;
 
 #[cfg(feature = "net")]
 use crate::backends::net::NetBackend;
+#[cfg(not(target_os = "windows"))]
+use crate::backends::vsock::VsockPortBackend;
 
 //--------------------------------------------------------------------------------------------------
 // Types: Machine Builder
@@ -52,14 +53,56 @@ pub struct MachineBuilder {
     pub(crate) nested_virt: bool,
     pub(crate) split_irqchip: bool,
     pub(crate) vsock: bool,
-    pub(crate) vsock_unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
-    pub(crate) vsock_host_port_map: Option<HashMap<u16, u16>>,
     pub(crate) balloon: bool,
     pub(crate) balloon_stats_interval: Option<Duration>,
     pub(crate) rng: bool,
     pub(crate) msb_metrics: bool,
     pub(crate) enable_inet_hijack: bool,
     pub(crate) vcpu_affinity: Option<Vec<HostCpuId>>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Types: Vsock Builder
+//--------------------------------------------------------------------------------------------------
+
+/// Builder for host services exposed through virtio-vsock.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use std::sync::Arc;
+/// use msb_krun::VmBuilder;
+///
+/// VmBuilder::new().vsock(|vsock| {
+///     vsock
+///         .unix_connect(5000, "/run/supervisor.sock")
+///         .unix_listen(5001, "/run/events.sock")
+///         .custom(6000, Arc::new(my_service))
+/// });
+/// ```
+#[cfg(not(target_os = "windows"))]
+#[derive(Default)]
+pub struct VsockBuilder {
+    pub(crate) routes: Vec<VsockRoute>,
+    pub(crate) tcp_listen_remaps: Vec<(u16, u16)>,
+    pub(crate) enable_inet_hijack: bool,
+}
+
+/// One typed host-side route for a guest vsock destination port.
+#[cfg(not(target_os = "windows"))]
+pub(crate) enum VsockRoute {
+    UnixConnect {
+        port: u32,
+        path: PathBuf,
+    },
+    UnixListen {
+        port: u32,
+        path: PathBuf,
+    },
+    Custom {
+        port: u32,
+        backend: Arc<dyn VsockPortBackend>,
+    },
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -367,8 +410,6 @@ impl MachineBuilder {
             nested_virt: false,
             split_irqchip: false,
             vsock: false,
-            vsock_unix_ipc_port_map: None,
-            vsock_host_port_map: None,
             balloon: true,
             balloon_stats_interval: Some(Duration::from_secs(1)),
             rng: true,
@@ -457,41 +498,6 @@ impl MachineBuilder {
         self
     }
 
-    /// Set the vsock Unix IPC port map.
-    ///
-    /// Maps guest vsock ports to host Unix domain sockets. Each entry is
-    /// `(guest_port, (host_uds_path, listen_mode))`:
-    /// - `listen_mode = false`: guest `connect(AF_VSOCK, CID=2, port)` proxies
-    ///   to the host UDS (connect mode — host UDS is the server).
-    /// - `listen_mode = true`: host UDS listens and pushes accepted connections
-    ///   into the guest as incoming vsock connections.
-    ///
-    /// Setting a non-empty map enables vsock attachment, same as calling
-    /// [`vsock(true)`](Self::vsock); a later `vsock(false)` still disables it.
-    pub fn vsock_unix_ipc_port_map(mut self, map: HashMap<u32, (PathBuf, bool)>) -> Self {
-        if !map.is_empty() {
-            self.vsock = true;
-        }
-        self.vsock_unix_ipc_port_map = Some(map);
-        self
-    }
-
-    /// Set the vsock host port map.
-    ///
-    /// Remaps guest TCP listen ports when TSI proxies a guest listen socket:
-    /// an entry `(guest_port, host_port)` makes a guest socket listening on
-    /// `guest_port` bind `host_port` on the host instead.
-    ///
-    /// Setting a non-empty map enables vsock attachment, same as calling
-    /// [`vsock(true)`](Self::vsock); a later `vsock(false)` still disables it.
-    pub fn vsock_host_port_map(mut self, map: HashMap<u16, u16>) -> Self {
-        if !map.is_empty() {
-            self.vsock = true;
-        }
-        self.vsock_host_port_map = Some(map);
-        self
-    }
-
     /// Enable or disable the virtio-balloon device.
     ///
     /// The device is enabled by default for general-purpose VMs. Latency-sensitive
@@ -546,6 +552,61 @@ impl MachineBuilder {
     /// hijack) is gated on `HIJACK_INET` already being set, so leaving
     /// INET hijack off also leaves the UNIX hijack auto-enable path off.
     pub fn enable_inet_hijack(mut self, enabled: bool) -> Self {
+        self.enable_inet_hijack = enabled;
+        self
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: Vsock Builder
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(not(target_os = "windows"))]
+impl VsockBuilder {
+    /// Create an empty vsock service builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Route guest connections to `port` into an existing host Unix socket.
+    pub fn unix_connect(mut self, port: u32, path: impl AsRef<Path>) -> Self {
+        self.routes.push(VsockRoute::UnixConnect {
+            port,
+            path: path.as_ref().to_path_buf(),
+        });
+        self
+    }
+
+    /// Listen on a host Unix socket and inject accepted streams into guest `port`.
+    pub fn unix_listen(mut self, port: u32, path: impl AsRef<Path>) -> Self {
+        self.routes.push(VsockRoute::UnixListen {
+            port,
+            path: path.as_ref().to_path_buf(),
+        });
+        self
+    }
+
+    /// Serve guest connections to `port` with a custom in-process backend.
+    ///
+    /// Unlike a Unix route, this does not ask libkrun to create or map a data
+    /// socket. The backend supplies a nonblocking byte stream and readiness
+    /// source; libkrun retains virtio-vsock framing and flow control.
+    pub fn custom(mut self, port: u32, backend: Arc<dyn VsockPortBackend>) -> Self {
+        self.routes.push(VsockRoute::Custom { port, backend });
+        self
+    }
+
+    /// Remap a guest TCP listen port to a host port through TSI.
+    ///
+    /// This requires [`inet_hijack(true)`](Self::inet_hijack); validation
+    /// rejects remaps that would otherwise be silently ignored.
+    pub fn tcp_listen_remap(mut self, guest_port: u16, host_port: u16) -> Self {
+        self.tcp_listen_remaps.push((guest_port, host_port));
+        self
+    }
+
+    /// Enable or disable TSI interception of guest INET sockets.
+    pub fn inet_hijack(mut self, enabled: bool) -> Self {
         self.enable_inet_hijack = enabled;
         self
     }

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -1,5 +1,6 @@
 //! Sub-builders for VmBuilder nested configuration.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -50,6 +51,8 @@ pub struct MachineBuilder {
     pub(crate) nested_virt: bool,
     pub(crate) split_irqchip: bool,
     pub(crate) vsock: bool,
+    pub(crate) vsock_unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
+    pub(crate) vsock_host_port_map: Option<HashMap<u16, u16>>,
     pub(crate) balloon: bool,
     pub(crate) balloon_stats_interval: Option<Duration>,
     pub(crate) rng: bool,
@@ -362,6 +365,8 @@ impl MachineBuilder {
             nested_virt: false,
             split_irqchip: false,
             vsock: false,
+            vsock_unix_ipc_port_map: None,
+            vsock_host_port_map: None,
             balloon: true,
             balloon_stats_interval: Some(Duration::from_secs(1)),
             rng: true,
@@ -437,6 +442,41 @@ impl MachineBuilder {
     /// its own purposes even though TSI would not otherwise require one.
     pub fn vsock(mut self, enabled: bool) -> Self {
         self.vsock = enabled;
+        self
+    }
+
+    /// Set the vsock Unix IPC port map.
+    ///
+    /// Maps guest vsock ports to host Unix domain sockets. Each entry is
+    /// `(guest_port, (host_uds_path, listen_mode))`:
+    /// - `listen_mode = false`: guest `connect(AF_VSOCK, CID=2, port)` proxies
+    ///   to the host UDS (connect mode — host UDS is the server).
+    /// - `listen_mode = true`: host UDS listens and pushes accepted connections
+    ///   into the guest as incoming vsock connections.
+    ///
+    /// Setting a non-empty map enables vsock attachment, same as calling
+    /// [`vsock(true)`](Self::vsock); a later `vsock(false)` still disables it.
+    pub fn vsock_unix_ipc_port_map(mut self, map: HashMap<u32, (PathBuf, bool)>) -> Self {
+        if !map.is_empty() {
+            self.vsock = true;
+        }
+        self.vsock_unix_ipc_port_map = Some(map);
+        self
+    }
+
+    /// Set the vsock host port map.
+    ///
+    /// Remaps guest TCP listen ports when TSI proxies a guest listen socket:
+    /// an entry `(guest_port, host_port)` makes a guest socket listening on
+    /// `guest_port` bind `host_port` on the host instead.
+    ///
+    /// Setting a non-empty map enables vsock attachment, same as calling
+    /// [`vsock(true)`](Self::vsock); a later `vsock(false)` still disables it.
+    pub fn vsock_host_port_map(mut self, map: HashMap<u16, u16>) -> Self {
+        if !map.is_empty() {
+            self.vsock = true;
+        }
+        self.vsock_host_port_map = Some(map);
         self
     }
 

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -47,6 +47,8 @@ pub use builders::DiskImageFormat;
 pub use builders::FsBuilder;
 #[cfg(feature = "net")]
 pub use builders::NetBuilder;
+#[cfg(not(target_os = "windows"))]
+pub use builders::VsockBuilder;
 pub use builders::{ConsoleBuilder, ExecBuilder, HostCpuId, KernelBuilder, MachineBuilder};
 pub use error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use exit_handle::ExitHandle;

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -406,17 +406,17 @@ impl Vm {
 
     /// Configure the vsock device.
     ///
-    /// The device is only attached when actually needed — either because the
-    /// caller explicitly requested it (`MachineBuilder::vsock(true)`), or
-    /// because the caller opted in to TSI as a transport
-    /// (`MachineBuilder::enable_inet_hijack(true)` with no virtio-net →
-    /// HIJACK_INET; single root virtio-fs on Linux → HIJACK_UNIX). This
-    /// keeps the per-VM IRQ/MMIO budget free when nothing uses vsock.
+    /// The device is only attached when a typed host route exists or the
+    /// caller enabled TSI as a transport. This keeps the per-VM IRQ/MMIO
+    /// budget free when nothing uses vsock.
     #[cfg(not(target_os = "windows"))]
     fn configure_vsock(&mut self) -> Result<()> {
         let tsi_flags = self.compute_tsi_flags();
 
-        if !self.vmr.request_vsock && tsi_flags.is_empty() {
+        if self.vsock_unix_ipc_port_map.is_none()
+            && self.vsock_custom_port_map.is_none()
+            && tsi_flags.is_empty()
+        {
             return Ok(());
         }
 
@@ -769,7 +769,9 @@ mod tests {
     fn typed_vsock_routes_imply_attachment_and_reach_vm_config() {
         use std::io;
 
-        use devices::virtio::vsock::{VsockConnectRequest, VsockPortBackend, VsockStreamBackend};
+        use devices::virtio::vsock::{
+            VsockConnectRequest, VsockNotifier, VsockPortBackend, VsockStreamBackend,
+        };
 
         struct RejectService;
 
@@ -777,6 +779,7 @@ mod tests {
             fn connect(
                 &self,
                 _request: VsockConnectRequest,
+                _notifier: VsockNotifier,
             ) -> io::Result<Box<dyn VsockStreamBackend>> {
                 Err(io::Error::from(io::ErrorKind::ConnectionRefused))
             }
@@ -794,7 +797,6 @@ mod tests {
             .build()
             .expect("typed vsock configuration should build");
 
-        assert!(vm.vmr.request_vsock);
         assert_eq!(
             vm.vsock_unix_ipc_port_map
                 .as_ref()

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -1,5 +1,6 @@
 //! VM handle for entering microVMs.
 
+#[cfg(not(target_os = "windows"))]
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::path::PathBuf;
@@ -13,14 +14,18 @@ use std::env;
 use std::ffi::CString;
 
 use crossbeam_channel::unbounded;
+#[cfg(not(target_os = "windows"))]
+use devices::virtio::vsock::VsockPortBackend;
 use log::error;
 use polly::event_manager::EventManager;
 use utils::eventfd::EventFd;
+#[cfg(not(target_os = "windows"))]
 use vmm::resources::TsiFlags;
 use vmm::resources::VmResources;
 use vmm::vmm_config::kernel_bundle::InitrdBundle;
 use vmm::vmm_config::kernel_bundle::KernelBundle;
 use vmm::vmm_config::kernel_cmdline::KernelCmdlineConfig;
+#[cfg(not(target_os = "windows"))]
 use vmm::vmm_config::vsock::VsockDeviceConfig;
 
 use super::error::{BuildError, Error, Result, RuntimeError};
@@ -60,8 +65,13 @@ pub struct Vm {
     /// bridges guest INET sockets to the host via vsock when no
     /// virtio-net device is configured. Set via
     /// [`MachineBuilder::enable_inet_hijack`](super::builders::MachineBuilder::enable_inet_hijack).
+    #[cfg(not(target_os = "windows"))]
     enable_inet_hijack: bool,
+    #[cfg(not(target_os = "windows"))]
     vsock_unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
+    #[cfg(not(target_os = "windows"))]
+    vsock_custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
+    #[cfg(not(target_os = "windows"))]
     vsock_host_port_map: Option<HashMap<u16, u16>>,
     /// Keeps the libkrunfw library loaded so kernel memory pointers remain valid.
     _krunfw_library: Option<libloading::Library>,
@@ -141,9 +151,14 @@ impl Vm {
         exit_observers: Vec<Box<dyn Fn(i32) + Send + 'static>>,
         exit_evt: EventFd,
         exit_code: Arc<AtomicI32>,
-        enable_inet_hijack: bool,
-        vsock_unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
-        vsock_host_port_map: Option<HashMap<u16, u16>>,
+        #[cfg(not(target_os = "windows"))] enable_inet_hijack: bool,
+        #[cfg(not(target_os = "windows"))] vsock_unix_ipc_port_map: Option<
+            HashMap<u32, (PathBuf, bool)>,
+        >,
+        #[cfg(not(target_os = "windows"))] vsock_custom_port_map: Option<
+            HashMap<u32, Arc<dyn VsockPortBackend>>,
+        >,
+        #[cfg(not(target_os = "windows"))] vsock_host_port_map: Option<HashMap<u16, u16>>,
     ) -> Self {
         Self {
             vmr,
@@ -159,8 +174,13 @@ impl Vm {
             exit_observers,
             exit_evt,
             exit_code,
+            #[cfg(not(target_os = "windows"))]
             enable_inet_hijack,
+            #[cfg(not(target_os = "windows"))]
             vsock_unix_ipc_port_map,
+            #[cfg(not(target_os = "windows"))]
+            vsock_custom_port_map,
+            #[cfg(not(target_os = "windows"))]
             vsock_host_port_map,
             _krunfw_library: None,
             _initramfs_data: None,
@@ -392,6 +412,7 @@ impl Vm {
     /// (`MachineBuilder::enable_inet_hijack(true)` with no virtio-net →
     /// HIJACK_INET; single root virtio-fs on Linux → HIJACK_UNIX). This
     /// keeps the per-VM IRQ/MMIO budget free when nothing uses vsock.
+    #[cfg(not(target_os = "windows"))]
     fn configure_vsock(&mut self) -> Result<()> {
         let tsi_flags = self.compute_tsi_flags();
 
@@ -404,6 +425,7 @@ impl Vm {
             guest_cid: 3,
             host_port_map: self.vsock_host_port_map.take(),
             unix_ipc_port_map: self.vsock_unix_ipc_port_map.take(),
+            custom_port_map: self.vsock_custom_port_map.take(),
             tsi_flags,
         };
 
@@ -414,11 +436,19 @@ impl Vm {
         Ok(())
     }
 
+    #[cfg(target_os = "windows")]
+    fn configure_vsock(&mut self) -> Result<()> {
+        // Unsupported requests are rejected by VmBuilder::build; keep VM
+        // startup free of placeholder devices on Windows.
+        Ok(())
+    }
+
     /// Decide which `TsiFlags` should be enabled for this VM.
     ///
     /// Extracted from [`configure_vsock`](Self::configure_vsock) so the
     /// flag-selection logic can be exercised by unit tests without
     /// touching `VmResources::set_vsock_device`.
+    #[cfg(not(target_os = "windows"))]
     fn compute_tsi_flags(&self) -> TsiFlags {
         let mut tsi_flags = TsiFlags::empty();
 
@@ -611,15 +641,41 @@ fn load_krunfw_library(path: Option<&std::path::Path>) -> Result<KrunfwBindings>
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(target_os = "windows"))]
+    use crate::VmBuilder;
     use utils::eventfd::EFD_NONBLOCK;
+    #[cfg(not(target_os = "windows"))]
     use vmm::resources::TsiFlags;
     #[cfg(all(not(feature = "tee"), not(target_os = "windows")))]
     use vmm::vmm_config::fs::FsDeviceConfig;
 
     fn make_vm() -> Vm {
-        make_vm_with(false)
+        Vm::new(
+            VmResources::default(),
+            Some("debug loglevel=7".to_string()),
+            None,
+            Some("\"--flag\"".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+            EventFd::new(EFD_NONBLOCK).unwrap(),
+            Arc::new(AtomicI32::new(i32::MAX)),
+            #[cfg(not(target_os = "windows"))]
+            false,
+            #[cfg(not(target_os = "windows"))]
+            None,
+            #[cfg(not(target_os = "windows"))]
+            None,
+            #[cfg(not(target_os = "windows"))]
+            None,
+        )
     }
 
+    #[cfg(not(target_os = "windows"))]
     fn make_vm_with(enable_inet_hijack: bool) -> Vm {
         Vm::new(
             VmResources::default(),
@@ -636,6 +692,7 @@ mod tests {
             EventFd::new(EFD_NONBLOCK).unwrap(),
             Arc::new(AtomicI32::new(i32::MAX)),
             enable_inet_hijack,
+            None,
             None,
             None,
         )
@@ -692,6 +749,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn compute_tsi_flags_air_gaps_by_default_with_no_net() {
         let vm = make_vm();
         let flags = vm.compute_tsi_flags();
@@ -699,10 +757,67 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn compute_tsi_flags_enables_inet_hijack_when_opted_in() {
         let vm = make_vm_with(true);
         let flags = vm.compute_tsi_flags();
         assert!(flags.contains(TsiFlags::HIJACK_INET));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn typed_vsock_routes_imply_attachment_and_reach_vm_config() {
+        use std::io;
+
+        use devices::virtio::vsock::{VsockConnectRequest, VsockPortBackend, VsockStreamBackend};
+
+        struct RejectService;
+
+        impl VsockPortBackend for RejectService {
+            fn connect(
+                &self,
+                _request: VsockConnectRequest,
+            ) -> io::Result<Box<dyn VsockStreamBackend>> {
+                Err(io::Error::from(io::ErrorKind::ConnectionRefused))
+            }
+        }
+
+        let vm = VmBuilder::new()
+            .vsock(|vsock| {
+                vsock
+                    .unix_connect(5000, "/tmp/supervisor.sock")
+                    .unix_listen(5001, "/tmp/events.sock")
+                    .custom(6000, Arc::new(RejectService))
+                    .inet_hijack(true)
+                    .tcp_listen_remap(8080, 18080)
+            })
+            .build()
+            .expect("typed vsock configuration should build");
+
+        assert!(vm.vmr.request_vsock);
+        assert_eq!(
+            vm.vsock_unix_ipc_port_map
+                .as_ref()
+                .and_then(|routes| routes.get(&5000)),
+            Some(&(PathBuf::from("/tmp/supervisor.sock"), false))
+        );
+        assert_eq!(
+            vm.vsock_unix_ipc_port_map
+                .as_ref()
+                .and_then(|routes| routes.get(&5001)),
+            Some(&(PathBuf::from("/tmp/events.sock"), true))
+        );
+        assert!(vm
+            .vsock_custom_port_map
+            .as_ref()
+            .is_some_and(|routes| routes.contains_key(&6000)));
+        assert_eq!(
+            vm.vsock_host_port_map
+                .as_ref()
+                .and_then(|routes| routes.get(&8080)),
+            Some(&18080)
+        );
+        assert!(vm.compute_tsi_flags().contains(TsiFlags::HIJACK_INET));
     }
 
     #[cfg(all(

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -1,5 +1,6 @@
 //! VM handle for entering microVMs.
 
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicI32;
@@ -60,6 +61,8 @@ pub struct Vm {
     /// virtio-net device is configured. Set via
     /// [`MachineBuilder::enable_inet_hijack`](super::builders::MachineBuilder::enable_inet_hijack).
     enable_inet_hijack: bool,
+    vsock_unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
+    vsock_host_port_map: Option<HashMap<u16, u16>>,
     /// Keeps the libkrunfw library loaded so kernel memory pointers remain valid.
     _krunfw_library: Option<libloading::Library>,
     /// Keeps an explicit initramfs allocation alive until it is copied to guest memory.
@@ -139,6 +142,8 @@ impl Vm {
         exit_evt: EventFd,
         exit_code: Arc<AtomicI32>,
         enable_inet_hijack: bool,
+        vsock_unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
+        vsock_host_port_map: Option<HashMap<u16, u16>>,
     ) -> Self {
         Self {
             vmr,
@@ -155,6 +160,8 @@ impl Vm {
             exit_evt,
             exit_code,
             enable_inet_hijack,
+            vsock_unix_ipc_port_map,
+            vsock_host_port_map,
             _krunfw_library: None,
             _initramfs_data: None,
         }
@@ -395,8 +402,8 @@ impl Vm {
         let vsock_config = VsockDeviceConfig {
             vsock_id: "vsock0".to_string(),
             guest_cid: 3,
-            host_port_map: None,
-            unix_ipc_port_map: None,
+            host_port_map: self.vsock_host_port_map.take(),
+            unix_ipc_port_map: self.vsock_unix_ipc_port_map.take(),
             tsi_flags,
         };
 
@@ -629,6 +636,8 @@ mod tests {
             EventFd::new(EFD_NONBLOCK).unwrap(),
             Arc::new(AtomicI32::new(i32::MAX)),
             enable_inet_hijack,
+            None,
+            None,
         )
     }
 

--- a/src/krun/src/backends/mod.rs
+++ b/src/krun/src/backends/mod.rs
@@ -32,6 +32,9 @@ pub mod fs;
 #[cfg(feature = "net")]
 pub mod net;
 
+#[cfg(not(target_os = "windows"))]
+pub mod vsock;
+
 //--------------------------------------------------------------------------------------------------
 // Re-Exports
 //--------------------------------------------------------------------------------------------------
@@ -44,3 +47,6 @@ pub use fs::DynFileSystem;
 
 #[cfg(feature = "net")]
 pub use net::NetBackend;
+
+#[cfg(not(target_os = "windows"))]
+pub use vsock::{VsockConnectRequest, VsockPortBackend, VsockShutdown, VsockStreamBackend};

--- a/src/krun/src/backends/mod.rs
+++ b/src/krun/src/backends/mod.rs
@@ -49,4 +49,6 @@ pub use fs::DynFileSystem;
 pub use net::NetBackend;
 
 #[cfg(not(target_os = "windows"))]
-pub use vsock::{VsockConnectRequest, VsockPortBackend, VsockShutdown, VsockStreamBackend};
+pub use vsock::{
+    VsockConnectRequest, VsockNotifier, VsockPortBackend, VsockShutdown, VsockStreamBackend,
+};

--- a/src/krun/src/backends/vsock.rs
+++ b/src/krun/src/backends/vsock.rs
@@ -1,0 +1,8 @@
+//! Custom virtio-vsock service backends.
+//!
+//! These traits expose byte streams rather than virtio packets. libkrun keeps
+//! responsibility for the transport protocol, flow control, and interrupts.
+
+pub use devices::virtio::vsock::{
+    VsockConnectRequest, VsockPortBackend, VsockShutdown, VsockStreamBackend,
+};

--- a/src/krun/src/backends/vsock.rs
+++ b/src/krun/src/backends/vsock.rs
@@ -4,5 +4,5 @@
 //! responsibility for the transport protocol, flow control, and interrupts.
 
 pub use devices::virtio::vsock::{
-    VsockConnectRequest, VsockPortBackend, VsockShutdown, VsockStreamBackend,
+    VsockConnectRequest, VsockNotifier, VsockPortBackend, VsockShutdown, VsockStreamBackend,
 };

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -73,5 +73,5 @@ pub use backends::net::NetBackend;
 
 #[cfg(not(target_os = "windows"))]
 pub use backends::vsock::{
-    VsockConnectRequest, VsockPortBackend, VsockShutdown, VsockStreamBackend,
+    VsockConnectRequest, VsockNotifier, VsockPortBackend, VsockShutdown, VsockStreamBackend,
 };

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -49,6 +49,8 @@ pub use api::builders::FsBuilder;
 pub use api::builders::NetBuilder;
 #[cfg(feature = "blk")]
 pub use api::builders::SyncMode;
+#[cfg(not(target_os = "windows"))]
+pub use api::builders::VsockBuilder;
 pub use api::builders::{ConsoleBuilder, ExecBuilder, HostCpuId, KernelBuilder, MachineBuilder};
 pub use api::error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use api::exit_handle::ExitHandle;
@@ -68,3 +70,8 @@ pub use backends::fs::DynFileSystem;
 
 #[cfg(feature = "net")]
 pub use backends::net::NetBackend;
+
+#[cfg(not(target_os = "windows"))]
+pub use backends::vsock::{
+    VsockConnectRequest, VsockPortBackend, VsockShutdown, VsockStreamBackend,
+};

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -2856,6 +2856,7 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
                 guest_cid: 3,
                 host_port_map: ctx_cfg.tsi_port_map,
                 unix_ipc_port_map: ctx_cfg.unix_ipc_port_map.clone(),
+                custom_port_map: None,
                 tsi_flags: *tsi_flags,
             };
             ctx_cfg.vmr.set_vsock_device(vsock_device_config).unwrap();
@@ -2882,6 +2883,7 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
                     guest_cid: 3,
                     host_port_map,
                     unix_ipc_port_map: ctx_cfg.unix_ipc_port_map.clone(),
+                    custom_port_map: None,
                     tsi_flags,
                 };
                 ctx_cfg.vmr.set_vsock_device(vsock_device_config).unwrap();

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -215,11 +215,6 @@ pub struct VmResources {
     pub split_irqchip: bool,
     /// Shared metrics state for VMM and device counters.
     pub metrics: MetricsWriter,
-    /// Force-enable the virtio-vsock device even when no TSI transport is
-    /// required. When `false`, vsock is only attached if `configure_vsock`
-    /// determines it is needed (HIJACK_INET when there's no virtio-net, or
-    /// HIJACK_UNIX when there's a single root virtio-fs on Linux).
-    pub request_vsock: bool,
     /// Whether to attach the virtio-balloon device.
     pub enable_balloon: bool,
     /// The virtio-mem device backing live memory resize, created by the API
@@ -289,7 +284,6 @@ impl Default for VmResources {
             nested_enabled: false,
             split_irqchip: false,
             metrics: MetricsWriter::default(),
-            request_vsock: false,
             enable_balloon: true,
             #[cfg(not(feature = "tee"))]
             mem_device: None,

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -8,6 +8,8 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 #[cfg(not(target_os = "windows"))]
+use devices::virtio::vsock::VsockPortBackend;
+#[cfg(not(target_os = "windows"))]
 use devices::virtio::{TsiFlags, Vsock, VsockError};
 
 #[cfg(target_os = "windows")]
@@ -79,7 +81,7 @@ type Result<T> = std::result::Result<T, VsockConfigError>;
 
 /// This struct represents the strongly typed equivalent of the json body
 /// from vsock related requests.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone)]
 pub struct VsockDeviceConfig {
     /// ID of the vsock device.
     pub vsock_id: String,
@@ -89,8 +91,31 @@ pub struct VsockDeviceConfig {
     pub host_port_map: Option<HashMap<u16, u16>>,
     /// An optional map of guest port to host UNIX domain sockets for IPC.
     pub unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
+    /// Optional custom in-process services keyed by host vsock port.
+    #[cfg(not(target_os = "windows"))]
+    pub custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
     /// TSI feature flags
     pub tsi_flags: TsiFlags,
+}
+
+impl fmt::Debug for VsockDeviceConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("VsockDeviceConfig");
+        debug
+            .field("vsock_id", &self.vsock_id)
+            .field("guest_cid", &self.guest_cid)
+            .field("host_port_map", &self.host_port_map)
+            .field("unix_ipc_port_map", &self.unix_ipc_port_map);
+        #[cfg(not(target_os = "windows"))]
+        debug.field(
+            "custom_ports",
+            &self
+                .custom_port_map
+                .as_ref()
+                .map(|services| services.keys().collect::<Vec<_>>()),
+        );
+        debug.field("tsi_flags", &self.tsi_flags).finish()
+    }
 }
 
 struct VsockWrapper {
@@ -148,6 +173,7 @@ impl VsockBuilder {
             u64::from(cfg.guest_cid),
             cfg.host_port_map,
             cfg.unix_ipc_port_map,
+            cfg.custom_port_map,
             cfg.tsi_flags,
         )
         .map_err(VsockConfigError::CreateVsockDevice)
@@ -186,6 +212,7 @@ pub(crate) mod tests {
             guest_cid: 3,
             host_port_map: None,
             unix_ipc_port_map: None,
+            custom_port_map: None,
             tsi_flags: TsiFlags::empty(),
         }
     }


### PR DESCRIPTION
## What

Adds two builder methods to `MachineBuilder`:

- `vsock_unix_ipc_port_map(HashMap<u32, (PathBuf, bool)>)` — maps guest vsock ports to host Unix domain sockets; each entry is `(guest_port, (uds_path, listen_mode))`
- `vsock_host_port_map(HashMap<u16, u16>)` — remaps guest TCP listen ports to host bind ports when TSI proxies a guest listen socket

and plumbs them through `Vm` into `configure_vsock()`, which currently hardcodes `host_port_map: None, unix_ipc_port_map: None`.

Setting a non-empty map enables vsock attachment (same as `vsock(true)`); a later `vsock(false)` still disables it.

## Why

The vsock muxer already implements Unix-socket proxying and listen-port remapping — `VsockDeviceConfig` accepts both fields — but neither is reachable through the public builder API since `configure_vsock()` pins them to `None`. This exposes the existing capability; no muxer changes.

## API shape note

The map types mirror the internal `VsockDeviceConfig` fields verbatim to keep the change minimal. Happy to wrap the `(PathBuf, bool)` tuple in a typed mode enum (`Connect`/`Listen`) if you'd prefer a more explicit public API.

## Behavior

Purely additive: both fields default to `None`, so existing callers see identical behavior. Includes a unit test covering implicit enablement, the empty-map no-op, and `vsock(false)` override ordering.

## Testing

- `cargo test -p msb_krun`: 19 passed, 0 failed (includes the new `vsock_port_maps_enable_vsock`)
- Hardware-validated on macOS aarch64 (Apple Silicon/HVF): guest `connect(AF_VSOCK, CID=2, port)` proxied to a host UDS via `unix_ipc_port_map` (connect mode; listen mode not exercised); bidirectional traffic with an application-level handshake; multiple concurrent guest→host streams established dynamically post-boot

Context: we currently vendor `msb_krun` 0.1.25 with exactly this patch to use vsock as a host↔guest supervisor transport, and would like to drop the vendored copy for the crates.io release once this lands.
