### PR TITLE
virtio-gpu venus: fix blob mapping on macOS/HVF and Linux/KVM

### DIFF
--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -17,7 +17,7 @@ efi = ["blk", "net"]
 gpu = ["rutabaga_gfx", "thiserror", "zerocopy", "krun_display"]
 snd = ["pw", "thiserror"]
 input = ["zerocopy", "krun_input"]
-virgl_resource_map2 = []
+virgl_resource_map2 = ["rutabaga_gfx/virgl_resource_map2"]
 aws-nitro = []
 test_utils = []
 

--- a/src/devices/src/virtio/gpu/virtio_gpu.rs
+++ b/src/devices/src/virtio/gpu/virtio_gpu.rs
@@ -273,7 +273,15 @@ impl VirtioGpu {
 
         let fence =
             Self::create_fence_handler(mem, queue_ctl.clone(), fence_state.clone(), interrupt);
-        builder.clone().build(fence.clone(), None).ok()
+        match builder.clone().build(fence.clone(), None) {
+            Ok(r) => Some(r),
+            Err(e) => {
+                // Surface the reason before the venus-less fallback is tried —
+                // a silent fallback strands guests with a dead venus capset.
+                error!("rutabaga init with configured virgl flags failed: {e:?}");
+                None
+            }
+        }
     }
 
     pub fn create_fallback_rutabaga(
@@ -883,7 +891,13 @@ impl VirtioGpu {
 
         if let Ok(export) = self.rutabaga.export_blob(resource_id) {
             if export.handle_type == RUTABAGA_MEM_HANDLE_TYPE_APPLE {
-                if offset + resource.size > shm_region.size as u64 {
+                // hv_vm_map requires host-page-aligned sizes (16 KiB on Apple
+                // Silicon); venus blob sizes are guest-page (4 KiB) granular, so
+                // round up. The host allocation is page-backed, so the tail read
+                // stays within the same allocation's final page.
+                let host_page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u64;
+                let map_len = resource.size.div_ceil(host_page) * host_page;
+                if offset + map_len > shm_region.size as u64 {
                     error!("mapping DOES NOT FIT");
                     return Err(ErrUnspec);
                 }
@@ -900,10 +914,15 @@ impl VirtioGpu {
                         reply_sender,
                         map_ptr,
                         guest_addr,
-                        resource.size,
+                        map_len,
                     ))
                     .unwrap();
-                if !reply_receiver.recv().unwrap() {
+                let mapped = reply_receiver.recv().unwrap();
+                if !mapped {
+                    error!(
+                        "hypervisor mapping failed: res={} host={:#x} guest={:#x} len={:#x}",
+                        resource_id, map_ptr, guest_addr, map_len
+                    );
                     return Err(ErrUnspec);
                 }
             } else {
@@ -979,7 +998,10 @@ impl VirtioGpu {
             .send(WorkerMessage::GpuRemoveMapping(
                 reply_sender,
                 guest_addr,
-                resource.size,
+                {
+                    let host_page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u64;
+                    resource.size.div_ceil(host_page) * host_page
+                },
             ))
             .unwrap();
         if !reply_receiver.recv().unwrap() {

--- a/src/krun/Cargo.toml
+++ b/src/krun/Cargo.toml
@@ -12,6 +12,10 @@ default = []
 net = ["devices/net", "vmm/net"]
 blk = ["devices/blk", "vmm/blk"]
 gpu = ["krun_display", "devices/gpu", "vmm/gpu"]
+# Linux + upstream virglrenderer >= 1.x: venus mappable blobs ride
+# virgl_renderer_resource_map_fixed; enable from Linux consumers only
+# (the macOS krunkit virglrenderer does not export the symbol).
+virgl_resource_map2 = ["devices/virgl_resource_map2"]
 snd = ["devices/snd", "vmm/snd"]
 tee = ["devices/tee", "vmm/tee"]
 aws-nitro = ["dep:aws-nitro", "dep:nitro-enclaves", "devices/aws-nitro", "vmm/aws-nitro"]

--- a/src/rutabaga_gfx/src/generated/virgl_renderer_bindings.rs
+++ b/src/rutabaga_gfx/src/generated/virgl_renderer_bindings.rs
@@ -380,12 +380,12 @@ extern "C" {
 }
 #[cfg(feature = "virgl_resource_map2")]
 extern "C" {
-    pub fn virgl_renderer_resource_map2(
+    // Upstream virglrenderer never took the crosvm-lineage resource_map2 API;
+    // its equivalent is resource_map_fixed (>= 1.1x): size/prot are derived
+    // from the resource itself, the map lands at the caller's fixed addr.
+    pub fn virgl_renderer_resource_map_fixed(
         res_handle: u32,
-        map: *const ::std::os::raw::c_void,
-        size: u64,
-        prot: i32,
-        flags: i32,
+        addr: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {

--- a/src/rutabaga_gfx/src/virgl_renderer.rs
+++ b/src/rutabaga_gfx/src/virgl_renderer.rs
@@ -706,14 +706,11 @@ impl RutabagaComponent for VirglRenderer {
     ) -> RutabagaResult<()> {
         #[cfg(feature = "virgl_resource_map2")]
         {
+            // resource_map_fixed derives size/prot from the resource; the
+            // caller-provided _size/_prot/_flags are validated by the device
+            // layer before this call and are intentionally unused here.
             let ret = unsafe {
-                virgl_renderer_resource_map2(
-                    _resource_id,
-                    _addr as *mut libc::c_void,
-                    _size,
-                    _prot,
-                    _flags,
-                )
+                virgl_renderer_resource_map_fixed(_resource_id, _addr as *mut libc::c_void)
             };
             if ret != 0 {
                 return Err(RutabagaError::MappingFailed(ret));


### PR DESCRIPTION
Companion to superradcompany/microsandbox#291 (the `--gpu` flag PR lands there separately, as discussed). Two mapping fixes plus feature wiring, each found by live debugging Venus inference in microsandbox microVMs:

**1. macOS/HVF: round blob map/unmap sizes to the host page (16K on Apple Silicon).**
`hv_vm_map` requires host-page-aligned sizes, but venus blob sizes are guest-page (4K) granular — every ring mapping failed (`mapped=false`) and surfaced as guest `vkCreateInstance → ERROR_OUT_OF_HOST_MEMORY` with all debug channels silent. Upstream `containers/libkrun` carries the identical unrounded `hv_vm_map`; krunkit guests presumably boot 16K-page kernels and never hit it, so this may be worth forwarding upstream too.

**2. Linux/KVM: rebind `virgl_resource_map2` to upstream's `virgl_renderer_resource_map_fixed`.**
The existing binding targets a crosvm-lineage API that upstream virglrenderer never adopted; the upstream equivalent (>= 1.1x) is `resource_map_fixed(res, addr)` — size/prot derive from the resource, and its opaque-handle path covers Venus blobs. Also: nothing previously enabled `rutabaga_gfx/virgl_resource_map2` from the devices feature of the same name, so the Linux opaque-blob path always returned `Unsupported` — rings (SHM) still mapped, so enumeration *worked* while the first mappable device blob died as `vk*Create*: ErrorOutOfHostMemory`. The feature now propagates, with an `msb_krun` passthrough for Linux consumers. Deliberately **not** enabled from the `gpu` feature: the macOS (krunkit-fork) virglrenderer doesn't export `map_fixed`, and the extern would fail the macOS link.

**Verified end-to-end** (guest mesa venus → virglrenderer → host driver, inside microsandbox microVMs):
- Apple M4 Pro (macOS/HVF, MoltenVK): `vulkaninfo` enumerates `Virtio-GPU Venus (Apple M4 Pro)`; llama.cpp ggml-vulkan generates tokens fully offloaded.
- NVIDIA T4G (Linux/KVM aarch64, AWS g5g.metal, virglrenderer 1.11 render-server): Qwen2.5-7B Q4_K_M fully offloaded — **pp512 647.85 t/s, tg128 29.18 t/s** (native-class for a T4-family part).

Host-setup note that cost us a day and may be worth documenting wherever you land GPU docs: NVIDIA hides `VK_EXT_external_memory_dma_buf` (which venus needs for mappable memory) unless `nvidia_drm` is loaded with KMS modesetting **and** the process can open `/dev/dri/renderD*` (`render` group).

Understood that you have internal work in flight and may reshape this freely — happy to rebase or split further.
