### PR TITLE
feat(vmm): add cross-platform vCPU affinity

### DIFF
--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -344,6 +344,24 @@ impl VmBuilder {
             return Err(Error::Config(ConfigError::InvalidMemorySize(0)));
         }
 
+        if let Some(affinity) = &self.machine.vcpu_affinity {
+            let expected = self.machine.max_vcpus.unwrap_or(self.machine.vcpus) as usize;
+            if affinity.len() != expected {
+                return Err(Error::Config(ConfigError::InvalidVcpuAffinityLength {
+                    expected,
+                    actual: affinity.len(),
+                }));
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            return Err(Error::Config(ConfigError::VcpuAffinityUnsupported));
+
+            #[cfg(target_os = "linux")]
+            if let Some(cpu) = affinity.iter().find(|cpu| cpu.group != 0) {
+                return Err(Error::Config(ConfigError::InvalidHostCpuGroup(cpu.group)));
+            }
+        }
+
         // Build VmResources
         let mut vmr = VmResources::default();
 
@@ -358,6 +376,11 @@ impl VmBuilder {
         };
         vmr.set_vm_config(&vm_config)
             .map_err(|err| map_vm_config_error(&self.machine, err))?;
+
+        #[cfg(target_os = "linux")]
+        {
+            vmr.vcpu_affinity = self.machine.vcpu_affinity;
+        }
 
         // Reserved CPU capacity is realized through the private msb-cpu device:
         // the guest driver converges on the requested online count and the
@@ -701,6 +724,7 @@ fn validate_cmdline_env(key: &str, value: &str) -> std::result::Result<(), &'sta
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::builders::HostCpuId;
 
     #[test]
     fn build_rejects_invalid_machine_config() {
@@ -764,6 +788,64 @@ mod tests {
         assert!(validate_cmdline_env("Q", "say \"hi\"").is_err());
         assert!(validate_cmdline_env("BAD KEY", "v").is_err());
         assert!(validate_cmdline_env("NL", "a\nb").is_err());
+    }
+
+    #[test]
+    fn build_rejects_affinity_that_does_not_cover_max_vcpus() {
+        let err = match VmBuilder::new()
+            .machine(|machine| {
+                machine
+                    .vcpus(2)
+                    .max_vcpus(4)
+                    .vcpu_affinity(vec![HostCpuId::new(0), HostCpuId::new(1)])
+            })
+            .build()
+        {
+            Ok(_) => panic!("partial vCPU affinity map should fail"),
+            Err(err) => err,
+        };
+
+        match err {
+            Error::Config(ConfigError::InvalidVcpuAffinityLength {
+                expected: 4,
+                actual: 2,
+            }) => {}
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn build_rejects_vcpu_affinity_on_unsupported_hosts() {
+        let err = match VmBuilder::new()
+            .machine(|machine| machine.vcpu_affinity(vec![HostCpuId::new(0)]))
+            .build()
+        {
+            Ok(_) => panic!("vCPU affinity should fail on unsupported hosts"),
+            Err(err) => err,
+        };
+
+        match err {
+            Error::Config(ConfigError::VcpuAffinityUnsupported) => {}
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn build_rejects_nonzero_processor_group_on_linux() {
+        let err = match VmBuilder::new()
+            .machine(|machine| machine.vcpu_affinity(vec![HostCpuId::in_group(1, 0)]))
+            .build()
+        {
+            Ok(_) => panic!("nonzero processor group should fail on Linux"),
+            Err(err) => err,
+        };
+
+        match err {
+            Error::Config(ConfigError::InvalidHostCpuGroup(1)) => {}
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 
     #[cfg(feature = "blk")]

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -353,7 +353,7 @@ impl VmBuilder {
                 }));
             }
 
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(not(any(target_os = "linux", target_os = "windows")))]
             return Err(Error::Config(ConfigError::VcpuAffinityUnsupported));
 
             #[cfg(target_os = "linux")]
@@ -377,7 +377,7 @@ impl VmBuilder {
         vmr.set_vm_config(&vm_config)
             .map_err(|err| map_vm_config_error(&self.machine, err))?;
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
         {
             vmr.vcpu_affinity = self.machine.vcpu_affinity;
         }
@@ -814,7 +814,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
     #[test]
     fn build_rejects_vcpu_affinity_on_unsupported_hosts() {
         let err = match VmBuilder::new()

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -8,6 +8,7 @@ use devices::virtio::console::port_io::{
     ConsolePortBackend, ConsolePortBackendInputAdapter, ConsolePortBackendOutputAdapter,
 };
 use vmm::resources::PortConfig;
+pub use vmm::vmm_config::machine_config::HostCpuId;
 
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 use crate::backends::fs::DynFileSystem;
@@ -55,6 +56,7 @@ pub struct MachineBuilder {
     pub(crate) rng: bool,
     pub(crate) msb_metrics: bool,
     pub(crate) enable_inet_hijack: bool,
+    pub(crate) vcpu_affinity: Option<Vec<HostCpuId>>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -367,6 +369,7 @@ impl MachineBuilder {
             rng: true,
             msb_metrics: true,
             enable_inet_hijack: false,
+            vcpu_affinity: None,
         }
     }
 
@@ -390,6 +393,15 @@ impl MachineBuilder {
     /// effective vCPU count, which reserves no extra capacity.
     pub fn max_vcpus(mut self, count: u8) -> Self {
         self.max_vcpus = Some(count);
+        self
+    }
+
+    /// Pins each possible vCPU thread to one resolved host logical processor.
+    ///
+    /// The map must contain one entry for every possible vCPU, including reserved capacity declared
+    /// with [`max_vcpus`](Self::max_vcpus). This is currently supported on Linux hosts only.
+    pub fn vcpu_affinity(mut self, affinity: Vec<HostCpuId>) -> Self {
+        self.vcpu_affinity = Some(affinity);
         self
     }
 
@@ -1061,6 +1073,22 @@ impl From<SyncMode> for devices::virtio::block::SyncMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn host_cpu_id_defaults_to_group_zero() {
+        assert_eq!(HostCpuId::new(7), HostCpuId::in_group(0, 7));
+        assert_eq!(HostCpuId::in_group(3, 11).group, 3);
+    }
+
+    #[test]
+    fn machine_builder_records_vcpu_affinity() {
+        let affinity = vec![HostCpuId::new(2), HostCpuId::new(6)];
+        let builder = MachineBuilder::new()
+            .vcpus(2)
+            .vcpu_affinity(affinity.clone());
+
+        assert_eq!(builder.vcpu_affinity, Some(affinity));
+    }
 
     #[test]
     fn machine_builder_msb_metrics_defaults_on_and_can_be_disabled() {

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -399,7 +399,7 @@ impl MachineBuilder {
     /// Pins each possible vCPU thread to one resolved host logical processor.
     ///
     /// The map must contain one entry for every possible vCPU, including reserved capacity declared
-    /// with [`max_vcpus`](Self::max_vcpus). This is currently supported on Linux hosts only.
+    /// with [`max_vcpus`](Self::max_vcpus). This is supported on Linux and Windows hosts.
     pub fn vcpu_affinity(mut self, affinity: Vec<HostCpuId>) -> Self {
         self.vcpu_affinity = Some(affinity);
         self

--- a/src/krun/src/api/error.rs
+++ b/src/krun/src/api/error.rs
@@ -42,6 +42,15 @@ pub enum ConfigError {
     /// Reserving capacity above the initial resources is not supported on this platform.
     MaxCapacityUnsupported,
 
+    /// The vCPU affinity map does not cover the full possible topology.
+    InvalidVcpuAffinityLength { expected: usize, actual: usize },
+
+    /// vCPU affinity is not supported on the current host platform.
+    VcpuAffinityUnsupported,
+
+    /// The selected host processor group is not supported on the current platform.
+    InvalidHostCpuGroup(u16),
+
     /// Missing kernel configuration.
     MissingKernel,
 
@@ -124,6 +133,16 @@ impl fmt::Display for ConfigError {
                 f,
                 "reserving CPU or memory capacity above the initial resources is not supported on this platform"
             ),
+            ConfigError::InvalidVcpuAffinityLength { expected, actual } => write!(
+                f,
+                "invalid vCPU affinity map length: expected {expected}, got {actual}"
+            ),
+            ConfigError::VcpuAffinityUnsupported => {
+                write!(f, "vCPU affinity is not supported on this host platform")
+            }
+            ConfigError::InvalidHostCpuGroup(group) => {
+                write!(f, "host processor group {group} is not supported")
+            }
             ConfigError::MissingKernel => write!(f, "missing kernel configuration"),
             ConfigError::InvalidKernelBundle(s) => write!(f, "invalid kernel bundle: {}", s),
             ConfigError::Network(s) => write!(f, "network: {}", s),

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -47,7 +47,7 @@ pub use builders::DiskImageFormat;
 pub use builders::FsBuilder;
 #[cfg(feature = "net")]
 pub use builders::NetBuilder;
-pub use builders::{ConsoleBuilder, ExecBuilder, KernelBuilder, MachineBuilder};
+pub use builders::{ConsoleBuilder, ExecBuilder, HostCpuId, KernelBuilder, MachineBuilder};
 pub use error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use exit_handle::ExitHandle;
 pub use metrics::{

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -49,7 +49,7 @@ pub use api::builders::FsBuilder;
 pub use api::builders::NetBuilder;
 #[cfg(feature = "blk")]
 pub use api::builders::SyncMode;
-pub use api::builders::{ConsoleBuilder, ExecBuilder, KernelBuilder, MachineBuilder};
+pub use api::builders::{ConsoleBuilder, ExecBuilder, HostCpuId, KernelBuilder, MachineBuilder};
 pub use api::error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use api::exit_handle::ExitHandle;
 pub use api::metrics::{

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -61,7 +61,7 @@ hvf = { package = "msb_krun_hvf", version = "0.1.25", path = "../hvf" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 libloading = "0.8"
-windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_System_Hypervisor", "Win32_System_ProcessStatus", "Win32_System_Threading"] }
+windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_System_Hypervisor", "Win32_System_ProcessStatus", "Win32_System_SystemInformation", "Win32_System_Threading"] }
 
 [dev-dependencies]
 devices = { package = "msb_krun_devices", version = "0.1.25", path = "../devices", features = ["test_utils"] }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1916,7 +1916,7 @@ pub fn build_microvm(
         println!("Starting TEE/microVM.");
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     if let Some(affinity) = &vm_resources.vcpu_affinity {
         // The public builder validates an exact map for the full possible topology.
         for (vcpu, host_cpu) in vcpus.iter_mut().zip(affinity.iter().copied()) {

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1916,6 +1916,14 @@ pub fn build_microvm(
         println!("Starting TEE/microVM.");
     }
 
+    #[cfg(target_os = "linux")]
+    if let Some(affinity) = &vm_resources.vcpu_affinity {
+        // The public builder validates an exact map for the full possible topology.
+        for (vcpu, host_cpu) in vcpus.iter_mut().zip(affinity.iter().copied()) {
+            vcpu.set_host_cpu(host_cpu);
+        }
+    }
+
     vmm.start_vcpus(vcpus)
         .map_err(StartMicrovmError::Internal)?;
     trace.mark("vcpus.started");

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -39,7 +39,7 @@ use kbs_types::Tee;
 
 #[cfg(feature = "tee")]
 use crate::resources::TeeConfig;
-use crate::vmm_config::machine_config::CpuFeaturesTemplate;
+use crate::vmm_config::machine_config::{CpuFeaturesTemplate, HostCpuId};
 #[cfg(target_arch = "x86_64")]
 use cpuid::{c3, filter_cpuid, t2, VmSpec};
 #[cfg(target_arch = "x86_64")]
@@ -226,6 +226,8 @@ pub enum Error {
     VcpuSetXsave(kvm_ioctls::Error),
     /// Cannot spawn a new vCPU thread.
     VcpuSpawn(io::Error),
+    /// Cannot bind a vCPU thread to its resolved host logical processor.
+    VcpuAffinity(io::Error),
     /// Cannot cleanly initialize vcpu TLS.
     VcpuTlsInit,
     /// Vcpu not present in TLS.
@@ -396,6 +398,7 @@ impl Display for Error {
             #[cfg(target_arch = "x86_64")]
             VcpuSetXsave(e) => write!(f, "Failed to set KVM vcpu xsave: {e}"),
             VcpuSpawn(e) => write!(f, "Cannot spawn a new vCPU thread: {e}"),
+            VcpuAffinity(e) => write!(f, "Cannot set vCPU host affinity: {e}"),
             VcpuTlsInit => write!(f, "Cannot clean init vcpu TLS"),
             VcpuTlsNotPresent => write!(f, "Vcpu not present in TLS"),
             VcpuUnhandledKvmExit => write!(f, "Unexpected KVM_RUN exit reason"),
@@ -925,6 +928,8 @@ type VcpuCell = Cell<Option<*mut Vcpu>>;
 pub struct Vcpu {
     fd: VcpuFd,
     id: u8,
+    // Resolved host placement is applied inside the vCPU thread before KVM_RUN.
+    host_cpu: Option<HostCpuId>,
     // Host-authoritative online ceiling; vCPUs at or above it park between
     // emulation steps regardless of guest cooperation.
     enforcement: Option<std::sync::Arc<devices::virtio::CpuEnforcement>>,
@@ -1082,6 +1087,7 @@ impl Vcpu {
         Ok(Vcpu {
             fd: kvm_vcpu,
             id,
+            host_cpu: None,
             enforcement: None,
             kick_slot: None,
             mmio_bus: None,
@@ -1122,6 +1128,7 @@ impl Vcpu {
         Ok(Vcpu {
             fd: kvm_vcpu,
             id,
+            host_cpu: None,
             enforcement: None,
             kick_slot: None,
             mmio_bus: None,
@@ -1157,6 +1164,7 @@ impl Vcpu {
         Ok(Vcpu {
             fd: kvm_vcpu,
             id,
+            host_cpu: None,
             enforcement: None,
             kick_slot: None,
             mmio_bus: None,
@@ -1172,6 +1180,11 @@ impl Vcpu {
     /// Returns the cpu index as seen by the guest OS.
     pub fn cpu_index(&self) -> u8 {
         self.id
+    }
+
+    /// Selects the host logical processor this vCPU thread must run on.
+    pub(crate) fn set_host_cpu(&mut self, host_cpu: HostCpuId) {
+        self.host_cpu = Some(host_cpu);
     }
 
     pub fn set_enforcement(
@@ -1314,26 +1327,59 @@ impl Vcpu {
         let vcpu_thread = thread::Builder::new()
             .name(format!("fc_vcpu {}", self.cpu_index()))
             .spawn(move || {
-                self.init_thread_local_data()
-                    .expect("Cannot cleanly initialize vcpu TLS.");
+                let init_result = self
+                    .apply_host_cpu_affinity()
+                    .and_then(|()| self.init_thread_local_data());
 
+                let initialized = init_result.is_ok();
                 init_tls_sender
-                    .send(true)
-                    .expect("Cannot notify vcpu TLS initialization.");
+                    .send(init_result)
+                    .expect("Cannot notify vcpu initialization.");
 
-                self.run();
+                if initialized {
+                    self.run();
+                }
             })
             .map_err(Error::VcpuSpawn)?;
 
         init_tls_receiver
             .recv()
-            .expect("Error waiting for TLS initialization.");
+            .expect("Error waiting for vcpu initialization.")?;
 
         Ok(VcpuHandle::new(
             event_sender,
             response_receiver,
             vcpu_thread,
         ))
+    }
+
+    /// Applies the resolved affinity from within the vCPU thread itself.
+    fn apply_host_cpu_affinity(&self) -> Result<()> {
+        let Some(host_cpu) = self.host_cpu else {
+            return Ok(());
+        };
+
+        let index = host_cpu.index as usize;
+        if index >= libc::CPU_SETSIZE as usize {
+            return Err(Error::VcpuAffinity(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("host CPU {index} exceeds CPU_SETSIZE"),
+            )));
+        }
+
+        // SAFETY: cpu_set_t is initialized before use, the validated index is in range, and pid 0
+        // asks Linux to bind only the current vCPU thread.
+        let result = unsafe {
+            let mut set: libc::cpu_set_t = std::mem::zeroed();
+            libc::CPU_ZERO(&mut set);
+            libc::CPU_SET(index, &mut set);
+            libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &set)
+        };
+        if result != 0 {
+            return Err(Error::VcpuAffinity(io::Error::last_os_error()));
+        }
+
+        Ok(())
     }
 
     #[allow(unused)]

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -26,6 +26,8 @@ use crate::vmm_config::kernel_bundle::{KernelBundle, KernelBundleError};
 #[cfg(feature = "tee")]
 use crate::vmm_config::kernel_bundle::{QbootBundle, QbootBundleError};
 use crate::vmm_config::kernel_cmdline::{KernelCmdlineConfig, KernelCmdlineConfigError};
+#[cfg(target_os = "linux")]
+use crate::vmm_config::machine_config::HostCpuId;
 use crate::vmm_config::machine_config::{VmConfig, VmConfigError};
 #[cfg(feature = "net")]
 use crate::vmm_config::net::{NetBuilder, NetworkInterfaceConfig, NetworkInterfaceError};
@@ -155,6 +157,9 @@ pub enum VsockConfig {
 pub struct VmResources {
     /// The vCpu and memory configuration for this microVM.
     vm_config: VmConfig,
+    /// Resolved host logical processor for every possible vCPU thread.
+    #[cfg(target_os = "linux")]
+    pub vcpu_affinity: Option<Vec<HostCpuId>>,
     /// The firmware to be loaded into the microVM.
     pub firmware_config: Option<FirmwareConfig>,
     /// The kernel command line for this microVM.
@@ -249,6 +254,8 @@ impl Default for VmResources {
     fn default() -> Self {
         Self {
             vm_config: VmConfig::default(),
+            #[cfg(target_os = "linux")]
+            vcpu_affinity: None,
             firmware_config: None,
             kernel_cmdline: KernelCmdlineConfig::default(),
             kernel_bundle: None,

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -26,7 +26,7 @@ use crate::vmm_config::kernel_bundle::{KernelBundle, KernelBundleError};
 #[cfg(feature = "tee")]
 use crate::vmm_config::kernel_bundle::{QbootBundle, QbootBundleError};
 use crate::vmm_config::kernel_cmdline::{KernelCmdlineConfig, KernelCmdlineConfigError};
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 use crate::vmm_config::machine_config::HostCpuId;
 use crate::vmm_config::machine_config::{VmConfig, VmConfigError};
 #[cfg(feature = "net")]
@@ -158,7 +158,7 @@ pub struct VmResources {
     /// The vCpu and memory configuration for this microVM.
     vm_config: VmConfig,
     /// Resolved host logical processor for every possible vCPU thread.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     pub vcpu_affinity: Option<Vec<HostCpuId>>,
     /// The firmware to be loaded into the microVM.
     pub firmware_config: Option<FirmwareConfig>,
@@ -254,7 +254,7 @@ impl Default for VmResources {
     fn default() -> Self {
         Self {
             vm_config: VmConfig::default(),
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
             vcpu_affinity: None,
             firmware_config: None,
             kernel_cmdline: KernelCmdlineConfig::default(),

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -8,6 +8,38 @@ use std::fmt;
 /// address would silently strand the extra CPUs.
 pub const MAX_SUPPORTED_VCPUS: u8 = 64;
 
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Identifies one logical processor in the host's processor topology.
+///
+/// Linux currently supports processor group zero. The group is explicit so callers do not need a
+/// different public representation when grouped processor topologies are supported on Windows.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HostCpuId {
+    /// Host processor group.
+    pub group: u16,
+    /// Logical processor index within the group.
+    pub index: u16,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl HostCpuId {
+    /// Creates a host CPU identifier in processor group zero.
+    pub const fn new(index: u16) -> Self {
+        Self { group: 0, index }
+    }
+
+    /// Creates a host CPU identifier in the specified processor group.
+    pub const fn in_group(group: u16, index: u16) -> Self {
+        Self { group, index }
+    }
+}
+
 /// Errors associated with configuring the microVM.
 #[derive(Debug, Eq, PartialEq)]
 pub enum VmConfigError {

--- a/src/vmm/src/windows/vstate.rs
+++ b/src/vmm/src/windows/vstate.rs
@@ -54,6 +54,8 @@ use windows_sys::Win32::System::Hypervisor::{
     WHV_X64_SEGMENT_REGISTER, WHV_X64_SEGMENT_REGISTER_0, WHV_X64_TABLE_REGISTER,
 };
 use windows_sys::Win32::System::SystemInformation::GROUP_AFFINITY;
+#[cfg(test)]
+use windows_sys::Win32::System::Threading::GetThreadGroupAffinity;
 use windows_sys::Win32::System::Threading::{
     GetCurrentThread, GetThreadTimes, SetThreadGroupAffinity,
 };
@@ -2707,5 +2709,25 @@ mod tests {
         };
 
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn host_affinity_binds_the_current_thread_to_one_allowed_processor() {
+        let mut inherited = GROUP_AFFINITY::default();
+        let result = unsafe { GetThreadGroupAffinity(GetCurrentThread(), &mut inherited) };
+        assert_ne!(result, 0, "GetThreadGroupAffinity failed");
+        assert_ne!(
+            inherited.Mask, 0,
+            "current thread has an empty affinity mask"
+        );
+
+        let index = inherited.Mask.trailing_zeros() as u16;
+        apply_host_cpu_affinity(Some(HostCpuId::in_group(inherited.Group, index))).unwrap();
+
+        let mut applied = GROUP_AFFINITY::default();
+        let result = unsafe { GetThreadGroupAffinity(GetCurrentThread(), &mut applied) };
+        assert_ne!(result, 0, "GetThreadGroupAffinity failed after binding");
+        assert_eq!(applied.Group, inherited.Group);
+        assert_eq!(applied.Mask, 1usize << index);
     }
 }

--- a/src/vmm/src/windows/vstate.rs
+++ b/src/vmm/src/windows/vstate.rs
@@ -12,7 +12,7 @@ use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 
-use crate::vmm_config::machine_config::CpuFeaturesTemplate;
+use crate::vmm_config::machine_config::{CpuFeaturesTemplate, HostCpuId};
 
 use arch::ArchMemoryInfo;
 #[cfg(target_arch = "x86_64")]
@@ -53,7 +53,10 @@ use windows_sys::Win32::System::Hypervisor::{
     WHV_TRANSLATE_GVA_RESULT_CODE, WHV_X64_CPUID_ACCESS_CONTEXT, WHV_X64_IO_PORT_ACCESS_CONTEXT,
     WHV_X64_SEGMENT_REGISTER, WHV_X64_SEGMENT_REGISTER_0, WHV_X64_TABLE_REGISTER,
 };
-use windows_sys::Win32::System::Threading::{GetCurrentThread, GetThreadTimes};
+use windows_sys::Win32::System::SystemInformation::GROUP_AFFINITY;
+use windows_sys::Win32::System::Threading::{
+    GetCurrentThread, GetThreadTimes, SetThreadGroupAffinity,
+};
 
 #[cfg(target_arch = "aarch64")]
 const AARCH64_PSR_MODE_EL1H: u64 = 0x0000_0005;
@@ -261,6 +264,7 @@ pub enum Error {
         id: u8,
         reason: WHV_RUN_VP_EXIT_REASON,
     },
+    VcpuAffinity(std::io::Error),
     VcpuThreadSpawn(std::io::Error),
     VcpuCountZero,
 }
@@ -398,6 +402,9 @@ impl Display for Error {
             Error::UnhandledExit { id, reason } => {
                 write!(f, "WHP vCPU {id} exited with unhandled reason {reason}")
             }
+            Error::VcpuAffinity(error) => {
+                write!(f, "cannot apply WHP vCPU host affinity: {error}")
+            }
             Error::VcpuThreadSpawn(e) => write!(f, "cannot spawn WHP vCPU thread: {e}"),
             Error::VcpuCountZero => write!(f, "WHP partition requires at least one vCPU"),
         }
@@ -428,6 +435,7 @@ pub struct VcpuConfig {
 
 pub struct Vcpu {
     id: u8,
+    host_cpu: Option<HostCpuId>,
     partition_handle: WHV_PARTITION_HANDLE,
     guest_mem: Option<GuestMemoryMmap>,
     mmio_bus: Option<devices::Bus>,
@@ -846,6 +854,7 @@ impl Vcpu {
 
         Ok(Self {
             id,
+            host_cpu: None,
             partition_handle,
             guest_mem: None,
             mmio_bus: None,
@@ -864,6 +873,11 @@ impl Vcpu {
 
     pub fn set_mmio_bus(&mut self, mmio_bus: devices::Bus) {
         self.mmio_bus = Some(mmio_bus);
+    }
+
+    /// Selects the host processor group and logical processor for this vCPU thread.
+    pub(crate) fn set_host_cpu(&mut self, host_cpu: HostCpuId) {
+        self.host_cpu = Some(host_cpu);
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -917,6 +931,7 @@ impl Vcpu {
             .expect("response receiver missing before vcpu start");
 
         let id = self.id;
+        let host_cpu = self.host_cpu;
         let partition_handle = self.partition_handle;
         let guest_mem = self
             .guest_mem
@@ -930,26 +945,53 @@ impl Vcpu {
         let exit_evt = self.exit_evt.try_clone().map_err(Error::VcpuThreadSpawn)?;
         let metrics = self.metrics.clone();
         self.partition_handle = 0;
+        let (init_sender, init_receiver) = unbounded();
 
         let vcpu_thread = thread::Builder::new()
             .name(format!("whp-vcpu-{id}"))
             .spawn(move || {
-                run_vcpu(
-                    id,
-                    partition_handle,
-                    guest_mem,
-                    mmio_bus,
-                    #[cfg(target_arch = "x86_64")]
-                    pio_bus,
-                    #[cfg(target_arch = "x86_64")]
-                    sipi_router,
-                    exit_evt,
-                    metrics,
-                    event_receiver,
-                    response_sender,
-                )
+                let init_result = apply_host_cpu_affinity(host_cpu);
+                let initialized = init_result.is_ok();
+                init_sender
+                    .send(init_result)
+                    .expect("cannot notify WHP vCPU initialization");
+
+                if initialized {
+                    run_vcpu(
+                        id,
+                        partition_handle,
+                        guest_mem,
+                        mmio_bus,
+                        #[cfg(target_arch = "x86_64")]
+                        pio_bus,
+                        #[cfg(target_arch = "x86_64")]
+                        sipi_router,
+                        exit_evt,
+                        metrics,
+                        event_receiver,
+                        response_sender,
+                    );
+                } else {
+                    // Ownership moved out of `Vcpu` before the thread was spawned. If affinity
+                    // initialization fails, release the WHP processor here instead of leaking it.
+                    let hresult = unsafe {
+                        WHvDeleteVirtualProcessor(partition_handle, id as u32)
+                    };
+                    if hresult < 0 {
+                        error!(
+                            "WHvDeleteVirtualProcessor({id}) after affinity failure returned HRESULT 0x{:08x}",
+                            hresult as u32
+                        );
+                    }
+                }
             })
             .map_err(Error::VcpuThreadSpawn)?;
+
+        // Affinity is part of VM correctness: fail construction before any vCPU can execute if
+        // Windows rejects a processor-group coordinate or the inherited host constraints.
+        init_receiver
+            .recv()
+            .expect("error waiting for WHP vCPU initialization")?;
 
         Ok(VcpuHandle::new(
             id,
@@ -1061,6 +1103,47 @@ impl Vcpu {
 
         set_vcpu_registers(self.partition_handle, self.id, &names, &values)
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Host CPU Affinity
+//--------------------------------------------------------------------------------------------------
+
+fn apply_host_cpu_affinity(host_cpu: Option<HostCpuId>) -> Result<()> {
+    let Some(host_cpu) = host_cpu else {
+        return Ok(());
+    };
+    let affinity = group_affinity(host_cpu).map_err(Error::VcpuAffinity)?;
+
+    // SAFETY: the pseudo-handle refers to this vCPU thread, `affinity` is initialized and remains
+    // live for the call, and a null previous-affinity pointer is explicitly accepted by Windows.
+    let result =
+        unsafe { SetThreadGroupAffinity(GetCurrentThread(), &affinity, std::ptr::null_mut()) };
+    if result == 0 {
+        return Err(Error::VcpuAffinity(std::io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+fn group_affinity(host_cpu: HostCpuId) -> std::io::Result<GROUP_AFFINITY> {
+    let index = u32::from(host_cpu.index);
+    if index >= usize::BITS {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "host CPU {}:{} exceeds the {}-processor group width",
+                host_cpu.group,
+                host_cpu.index,
+                usize::BITS
+            ),
+        ));
+    }
+
+    Ok(GROUP_AFFINITY {
+        Mask: 1usize << index,
+        Group: host_cpu.group,
+        Reserved: [0; 3],
+    })
 }
 
 impl VcpuHandle {
@@ -2597,4 +2680,32 @@ unsafe extern "system" fn emulator_translate_gva_callback(
     }
 
     hresult
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn group_affinity_encodes_processor_group_and_single_cpu_mask() {
+        let affinity = group_affinity(HostCpuId::in_group(3, 7)).unwrap();
+
+        assert_eq!(affinity.Group, 3);
+        assert_eq!(affinity.Mask, 1usize << 7);
+        assert_eq!(affinity.Reserved, [0; 3]);
+    }
+
+    #[test]
+    fn group_affinity_rejects_index_outside_windows_group_width() {
+        let error = match group_affinity(HostCpuId::new(usize::BITS as u16)) {
+            Ok(_) => panic!("processor index outside the group width should fail"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
 }


### PR DESCRIPTION
## TL;DR
Add an opt-in host CPU map that pins each vCPU thread before guest execution on Linux and Windows. VM construction fails explicitly when the map is incomplete, unsupported or cannot be enforced.

## Description
- Add `HostCpuId` and `MachineBuilder::vcpu_affinity` to describe one resolved host processor for every possible vCPU, including capacity reserved with `max_vcpus`.
- Keep affinity disabled by default, so existing VM builders retain their current scheduling behavior.
- Apply Linux affinity inside each vCPU thread before `KVM_RUN` and reject processor groups other than group zero.
- Apply Windows processor-group affinity before `WHvRunVirtualProcessor` and clean up the WHP virtual processor when initialization fails.
- Propagate map-length, unsupported-platform, processor-group and host-syscall failures as configuration or startup errors instead of silently ignoring placement.
- Cover builder validation, Windows group-mask encoding and native Windows affinity read-back.

```rust
use msb_krun::{HostCpuId, VmBuilder};

let vm = VmBuilder::new()
    .machine(|machine| {
        machine
            .vcpus(2)
            .max_vcpus(4)
            .vcpu_affinity(vec![
                HostCpuId::new(2),
                HostCpuId::new(6),
                HostCpuId::new(3),
                HostCpuId::new(7),
            ])
    })
    .build()?;
```

## Test Plan
- [x] `cargo fmt -- --check`
- [x] `cargo test --locked -p msb_krun`
- [x] `BINDGEN_EXTRA_CLANG_ARGS="-isysroot $(xcrun --sdk macosx --show-sdk-path)" cargo test --locked`
- [x] `cargo clippy --locked -p msb_krun -- -D warnings`
- [x] `cargo check --locked --target aarch64-pc-windows-msvc -p msb_krun`
- [ ] `cargo test -p msb_krun_vmm host_affinity_binds_the_current_thread_to_one_allowed_processor` (requires a native Windows host)