### PR TITLE
feat(block): add per-disk buffered writeback limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,25 +137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,12 +876,11 @@ dependencies = [
 
 [[package]]
 name = "msb-imago"
-version = "0.1.0"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16db000f7280d4c8a78b8b95f64a41006d447fd116ecd69d984d93774cb85d09"
+checksum = "0720fa987e398d5fb5345d575d1a97a74cb0eaf645355088a21285607895422c"
 dependencies = [
  "async-trait",
- "bincode",
  "cfg-if",
  "libc",
  "miniz_oxide",
@@ -1817,12 +1797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,12 +1829,6 @@ name = "virtio-bindings"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f498a26d5a63be7bbb8bdcd3869c3f286c4c4a17108905276454da0caf8cb"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vm-fdt"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -41,7 +41,7 @@ arch = { package = "msb_krun_arch", version = "0.1.25", path = "../arch" }
 utils = { package = "msb_krun_utils", version = "0.1.25", path = "../utils" }
 polly = { package = "msb_krun_polly", version = "0.1.25", path = "../polly" }
 rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.25", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
-imago = { package = "msb-imago", version = "0.1.0", features = ["sync-wrappers", "vm-memory"] }
+imago = { package = "msb-imago", version = "0.1.4", features = ["sync-wrappers", "vm-memory"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 hvf = { package = "msb_krun_hvf", version = "0.1.25", path = "../hvf" }

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -189,22 +189,51 @@ impl DiskProperties {
         Ok(())
     }
 
-    pub(crate) fn record_buffered_write(&self, offset: u64, length: u64) {
+    pub(crate) fn buffered_write_chunk_bytes(&self, requested: u64) -> u64 {
+        #[cfg(target_os = "linux")]
+        if let Some(controller) = &self.writeback_controller {
+            // Never let one large guest request bypass the hard watermark before the controller
+            // gets a chance to account for it and apply backpressure.
+            return requested.min(controller.lock().unwrap().hard_limit_bytes());
+        }
+
+        requested
+    }
+
+    pub(crate) fn prepare_buffered_write(&self, offset: u64, length: u64) -> io::Result<()> {
+        let length = Self::clamp_buffered_write_length(self.nsectors, offset, length);
+
+        #[cfg(target_os = "linux")]
+        if length != 0 {
+            if let Some(controller) = &self.writeback_controller {
+                controller.lock().unwrap().prepare_write(length)?;
+            }
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        let _ = length;
+
+        Ok(())
+    }
+
+    pub(crate) fn record_buffered_write(&self, offset: u64, length: u64) -> io::Result<()> {
         // Imago accepts writes beyond the virtual capacity and clips writes crossing the end. Only
         // account for bytes the guest-visible raw disk could actually have dirtied, so an invalid
         // request cannot amplify the advisory sync range.
         let length = Self::clamp_buffered_write_length(self.nsectors, offset, length);
         if length == 0 {
-            return;
+            return Ok(());
         }
 
         #[cfg(target_os = "linux")]
         if let Some(controller) = &self.writeback_controller {
-            controller.lock().unwrap().record_write(offset, length);
+            controller.lock().unwrap().record_write(offset, length)?;
         }
 
         #[cfg(not(target_os = "linux"))]
         let _ = (offset, length);
+
+        Ok(())
     }
 
     fn clamp_buffered_write_length(nsectors: u64, offset: u64, length: u64) -> u64 {
@@ -235,10 +264,10 @@ impl DiskProperties {
             return raw_file.discard_to_zero(offset, length);
         }
 
-        let mut diskfile = self.file.lock().unwrap();
-        // Raw discard and zero-range operations use filesystem allocation primitives rather than
-        // the buffered data-write path, so they intentionally do not advance the preflush window.
-        diskfile.discard_to_zero(offset, length)
+        self.run_buffered_mutation(offset, length, |chunk_offset, chunk_length| {
+            let mut diskfile = self.file.lock().unwrap();
+            diskfile.discard_to_zero(chunk_offset, chunk_length)
+        })
     }
 
     pub(crate) fn write_zeroes(&self, offset: u64, length: u64) -> io::Result<()> {
@@ -247,9 +276,34 @@ impl DiskProperties {
             return raw_file.write_zeroes(offset, length);
         }
 
-        let diskfile = self.file.lock().unwrap();
-        // See `discard_to_zero`: advisory page-cache writeback tracks ordinary buffered writes.
-        diskfile.write_zeroes(offset, length)
+        self.run_buffered_mutation(offset, length, |chunk_offset, chunk_length| {
+            let diskfile = self.file.lock().unwrap();
+            diskfile.write_zeroes(chunk_offset, chunk_length)
+        })
+    }
+
+    fn run_buffered_mutation<F>(&self, offset: u64, length: u64, mut operation: F) -> io::Result<()>
+    where
+        F: FnMut(u64, u64) -> io::Result<()>,
+    {
+        let mut chunk_offset = offset;
+        let mut remaining = length;
+
+        while remaining != 0 {
+            let chunk_length = self.buffered_write_chunk_bytes(remaining);
+            self.prepare_buffered_write(chunk_offset, chunk_length)?;
+            operation(chunk_offset, chunk_length)?;
+            self.record_buffered_write(chunk_offset, chunk_length)?;
+
+            remaining -= chunk_length;
+            if remaining != 0 {
+                chunk_offset = chunk_offset.checked_add(chunk_length).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "block mutation range overflow")
+                })?;
+            }
+        }
+
+        Ok(())
     }
 
     #[cfg(windows)]
@@ -465,9 +519,11 @@ impl Block {
     /// Create a virtio block device with an optional buffered-writeback preflush threshold.
     ///
     /// Preflush is supported on Linux for writable raw disks using writeback caching, buffered I/O
-    /// and an active sync mode. It starts at most one advisory background writeback range between
-    /// successful guest flushes, but does not replace the full sync that completes a guest flush or
-    /// provide a dirty-memory containment boundary. A zero threshold disables the option.
+    /// and an active sync mode. The configured soft threshold starts rolling asynchronous range
+    /// writeback. Twice that threshold is a per-device hard watermark where the block worker
+    /// synchronously drains accumulated writes before accepting more, even without a guest flush.
+    /// Neither action replaces the full sync that completes a guest flush. A zero threshold
+    /// disables the option.
     #[allow(clippy::too_many_arguments)]
     pub fn new_with_writeback_preflush(
         id: String,
@@ -499,6 +555,14 @@ impl Block {
                     format!(
                         "writeback preflush threshold must be at least {MINIMUM_RANGE_BYTES} bytes"
                     ),
+                ));
+            }
+
+            #[cfg(target_os = "linux")]
+            if _trigger_bytes.checked_mul(2).is_none() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "writeback preflush threshold is too large to derive its hard watermark",
                 ));
             }
 
@@ -907,6 +971,30 @@ mod tests {
         };
         assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
         assert!(error.to_string().contains("at least"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn writeback_preflush_rejects_threshold_without_a_hard_watermark() {
+        let result = Block::new_with_writeback_preflush(
+            "raw".to_string(),
+            None,
+            CacheType::Writeback,
+            "missing.raw".to_string(),
+            ImageType::Raw,
+            false,
+            false,
+            SyncMode::Full,
+            Some(u64::MAX),
+            MetricsWriter::default().register_block_device("raw".to_string()),
+        );
+
+        let error = match result {
+            Ok(_) => panic!("overflowing hard watermark should fail"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("too large"));
     }
 
     #[cfg(target_os = "linux")]

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -5,6 +5,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+#[cfg(target_os = "linux")]
+use std::cell::RefCell;
 use std::cmp;
 use std::convert::From;
 use std::fs::{File, OpenOptions};
@@ -40,7 +42,10 @@ use super::windows::{
 };
 use super::worker::BlockWorker;
 #[cfg(target_os = "linux")]
-use super::writeback::{BufferedWritebackConfig, BufferedWritebackController, MINIMUM_RANGE_BYTES};
+use super::writeback::{
+    BufferedWritebackConfig, BufferedWritebackController, WritebackOutcome, WritebackReservation,
+    MINIMUM_WRITEBACK_BUDGET_BYTES,
+};
 use super::{
     super::{ActivateResult, DeviceQueue, DeviceState, QueueConfig, VirtioDevice, TYPE_BLOCK},
     Error, NUM_QUEUES, QUEUE_CONFIG, SECTOR_SHIFT, SECTOR_SIZE,
@@ -50,6 +55,9 @@ use crate::virtio::{
     block::{ImageType, SyncMode},
     ActivateError, InterruptTransport,
 };
+
+#[cfg(target_os = "linux")]
+const EXPLICIT_ZERO_BUFFER_BYTES: usize = 1024 * 1024;
 
 /// Configuration options for disk caching.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -81,13 +89,37 @@ pub(crate) struct DiskProperties {
     cache_type: CacheType,
     pub(crate) file: Arc<Mutex<SyncFormatAccess<Box<dyn DynStorage>>>>,
     #[cfg(target_os = "linux")]
-    writeback_controller: Option<Mutex<BufferedWritebackController>>,
+    // One block worker owns each DiskProperties instance. RefCell preserves the `&self` volatile
+    // I/O trait while avoiding mutex atomics on every guest write; this must be revisited before
+    // increasing NUM_QUEUES or sharing one DiskProperties between workers.
+    writeback_controller: Option<RefCell<BufferedWritebackController>>,
+    #[cfg(target_os = "linux")]
+    // Keep the shared configuration handle so teardown sync results survive the per-activation
+    // controller and can fail a later activation closed.
+    writeback_config: Option<BufferedWritebackConfig>,
+    #[cfg(target_os = "linux")]
+    // Bounded mode must account real dirty data, so WRITE_ZEROES reuses this buffer instead of
+    // invoking a filesystem hole-punch or metadata-only zeroing operation.
+    explicit_zero_buffer: Option<Box<[u8]>>,
     #[cfg(windows)]
     windows_raw_file: Option<Arc<WindowsRawFile>>,
     #[cfg(windows)]
     pub(crate) windows_formatted_io_runtime: tokio::runtime::Runtime,
     nsectors: u64,
     image_id: Vec<u8>,
+}
+
+/// An exact mutation chunk paired with an optional Linux writeback reservation.
+pub(crate) struct BufferedMutationPlan {
+    length: u64,
+    #[cfg(target_os = "linux")]
+    reservation: Option<WritebackReservation>,
+}
+
+impl BufferedMutationPlan {
+    pub(crate) fn len(&self) -> u64 {
+        self.length
+    }
 }
 
 impl DiskProperties {
@@ -114,6 +146,10 @@ impl DiskProperties {
             file: disk_image,
             #[cfg(target_os = "linux")]
             writeback_controller: None,
+            #[cfg(target_os = "linux")]
+            writeback_config: None,
+            #[cfg(target_os = "linux")]
+            explicit_zero_buffer: None,
             #[cfg(windows)]
             windows_raw_file: None,
             #[cfg(windows)]
@@ -172,83 +208,209 @@ impl DiskProperties {
     }
 
     pub(crate) fn flush_to_disk(&self) -> io::Result<()> {
+        #[cfg(target_os = "linux")]
+        let quiesce_error = self
+            .writeback_controller
+            .as_ref()
+            .and_then(|controller| controller.borrow_mut().quiesce().err());
+
         #[cfg(windows)]
         if let Some(raw_file) = &self.windows_raw_file {
             raw_file.flush()?;
         }
 
-        let diskfile = self.file.lock().unwrap();
-        diskfile.flush()?;
-        diskfile.sync()?;
+        // The full Imago flush remains the guest-visible durability fence, so run it even after
+        // the background controller fails. A successful later sync cannot erase a writeback error
+        // already reported through the file description; that controller remains failed closed.
+        let sync_result = {
+            let diskfile = self.file.lock().unwrap();
+            diskfile.flush().and_then(|_| diskfile.sync())
+        };
 
         #[cfg(target_os = "linux")]
-        if let Some(controller) = &self.writeback_controller {
-            controller.lock().unwrap().complete_flush();
-        }
+        match &sync_result {
+            Ok(()) => {
+                let config_healthy = self
+                    .writeback_config
+                    .as_ref()
+                    .is_none_or(BufferedWritebackConfig::record_full_sync_success);
+                let controller_healthy = self
+                    .writeback_controller
+                    .as_ref()
+                    .is_none_or(|controller| controller.borrow_mut().reset_after_flush());
 
-        Ok(())
-    }
-
-    pub(crate) fn buffered_write_chunk_bytes(&self, requested: u64) -> u64 {
-        #[cfg(target_os = "linux")]
-        if let Some(controller) = &self.writeback_controller {
-            // Never let one large guest request bypass the hard watermark before the controller
-            // gets a chance to account for it and apply backpressure.
-            return requested.min(controller.lock().unwrap().hard_limit_bytes());
-        }
-
-        requested
-    }
-
-    pub(crate) fn prepare_buffered_write(&self, offset: u64, length: u64) -> io::Result<()> {
-        let length = Self::clamp_buffered_write_length(self.nsectors, offset, length);
-
-        #[cfg(target_os = "linux")]
-        if length != 0 {
-            if let Some(controller) = &self.writeback_controller {
-                controller.lock().unwrap().prepare_write(length)?;
+                if let Some(error) = quiesce_error {
+                    warn!(
+                        "Buffered writeback remains permanently failed after the full disk sync: \
+                         {error}"
+                    );
+                    return Err(error);
+                }
+                if !config_healthy || !controller_healthy {
+                    return Err(io::Error::other(
+                        "buffered writeback remains permanently failed after the full disk sync",
+                    ));
+                }
+            }
+            Err(error) => {
+                if let Some(config) = &self.writeback_config {
+                    config.record_full_sync_failure(error);
+                }
             }
         }
 
-        #[cfg(not(target_os = "linux"))]
-        let _ = length;
-
-        Ok(())
+        sync_result
     }
 
-    pub(crate) fn record_buffered_write(&self, offset: u64, length: u64) -> io::Result<()> {
-        // Imago accepts writes beyond the virtual capacity and clips writes crossing the end. Only
-        // account for bytes the guest-visible raw disk could actually have dirtied, so an invalid
-        // request cannot amplify the advisory sync range.
-        let length = Self::clamp_buffered_write_length(self.nsectors, offset, length);
-        if length == 0 {
-            return Ok(());
-        }
+    pub(crate) fn plan_buffered_mutation(
+        &self,
+        offset: u64,
+        requested: u64,
+    ) -> io::Result<BufferedMutationPlan> {
+        #[cfg(not(target_os = "linux"))]
+        let _ = offset;
 
         #[cfg(target_os = "linux")]
-        if let Some(controller) = &self.writeback_controller {
-            controller.lock().unwrap().record_write(offset, length)?;
+        {
+            if requested != 0 {
+                if let Some(controller) = &self.writeback_controller {
+                    let reservation = controller.borrow_mut().plan_write(offset, requested)?;
+                    return Ok(BufferedMutationPlan {
+                        length: reservation.len(),
+                        reservation: Some(reservation),
+                    });
+                }
+            }
+        }
+
+        Ok(BufferedMutationPlan {
+            length: requested,
+            #[cfg(target_os = "linux")]
+            reservation: None,
+        })
+    }
+
+    pub(crate) fn finish_buffered_mutation(
+        &self,
+        plan: BufferedMutationPlan,
+        operation_result: io::Result<()>,
+    ) -> io::Result<()> {
+        #[cfg(target_os = "linux")]
+        let accounting_result = match plan.reservation {
+            Some(reservation) => {
+                let outcome = if operation_result.is_ok() {
+                    WritebackOutcome::Written(plan.length)
+                } else {
+                    // Imago may have completed a prefix before returning an error. Charge the
+                    // entire reservation conservatively so repeated failing writes cannot bypass
+                    // the hard budget.
+                    WritebackOutcome::Failed
+                };
+                self.writeback_controller
+                    .as_ref()
+                    .expect("reservation requires an active writeback controller")
+                    .borrow_mut()
+                    .finish_write(reservation, outcome)
+            }
+            None => Ok(()),
+        };
+
+        #[cfg(not(target_os = "linux"))]
+        let accounting_result: io::Result<()> = {
+            let _ = plan;
+            Ok(())
+        };
+
+        match operation_result {
+            Ok(()) => accounting_result,
+            Err(operation_error) => {
+                if let Err(accounting_error) = accounting_result {
+                    warn!(
+                        "Buffered mutation failed and writeback accounting also failed: {accounting_error}"
+                    );
+                }
+                Err(operation_error)
+            }
+        }
+    }
+
+    pub(crate) fn has_writeback_limit(&self) -> bool {
+        #[cfg(target_os = "linux")]
+        {
+            self.writeback_config.is_some()
         }
 
         #[cfg(not(target_os = "linux"))]
-        let _ = (offset, length);
+        {
+            false
+        }
+    }
 
+    /// Rejects a complete bounded mutation before any prefix can reach the backing image.
+    ///
+    /// Legacy disks retain Imago's existing range behavior. Bounded mode is stricter because
+    /// truncating a request at the visible edge would violate its all-or-error range contract and
+    /// let controller accounting describe a different mutation from the one the guest submitted.
+    pub(crate) fn validate_mutation_range(&self, offset: u64, length: u64) -> io::Result<()> {
+        if self.has_writeback_limit() {
+            Self::validate_range_against_capacity(self.nsectors, offset, length)?;
+        }
         Ok(())
     }
 
-    fn clamp_buffered_write_length(nsectors: u64, offset: u64, length: u64) -> u64 {
-        let visible_size = nsectors.saturating_mul(SECTOR_SIZE);
-        length.min(visible_size.saturating_sub(offset))
+    fn validate_range_against_capacity(nsectors: u64, offset: u64, length: u64) -> io::Result<()> {
+        let visible_size = nsectors.checked_mul(SECTOR_SIZE).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "visible block capacity overflow",
+            )
+        })?;
+        let end = offset.checked_add(length).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "block mutation range overflow")
+        })?;
+        if end > visible_size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "block mutation extends beyond visible capacity",
+            ));
+        }
+        Ok(())
     }
 
     #[cfg(target_os = "linux")]
-    fn set_writeback_config(&mut self, config: Option<&BufferedWritebackConfig>) {
-        self.writeback_controller = config
+    fn set_writeback_config(&mut self, config: Option<&BufferedWritebackConfig>) -> io::Result<()> {
+        // Retain the shared health handle before any fallible setup. If controller recovery or
+        // buffer allocation fails, DiskProperties::drop can still report its final sync result.
+        self.writeback_config = config.cloned();
+        let controller = config
             .map(BufferedWritebackConfig::controller)
-            .map(Mutex::new);
+            .transpose()?
+            .map(RefCell::new);
+        let explicit_zero_buffer = if config.is_some() {
+            let mut buffer = Vec::new();
+            buffer
+                .try_reserve_exact(EXPLICIT_ZERO_BUFFER_BYTES)
+                .map_err(io::Error::other)?;
+            buffer.resize(EXPLICIT_ZERO_BUFFER_BYTES, 0);
+            Some(buffer.into_boxed_slice())
+        } else {
+            None
+        };
+
+        self.explicit_zero_buffer = explicit_zero_buffer;
+        self.writeback_controller = controller;
+        Ok(())
     }
 
     pub(crate) fn discard_to_any(&self, offset: u64, length: u64) -> io::Result<()> {
+        if self.has_writeback_limit() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "discard is disabled by the bounded writeback policy",
+            ));
+        }
+        self.validate_mutation_range(offset, length)?;
+
         #[cfg(windows)]
         if let Some(raw_file) = &self.windows_raw_file {
             return raw_file.discard_to_any(offset, length);
@@ -259,41 +421,75 @@ impl DiskProperties {
     }
 
     pub(crate) fn discard_to_zero(&self, offset: u64, length: u64) -> io::Result<()> {
+        if self.has_writeback_limit() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "unmapping zero writes are disabled by the bounded writeback policy",
+            ));
+        }
+        self.validate_mutation_range(offset, length)?;
+
         #[cfg(windows)]
         if let Some(raw_file) = &self.windows_raw_file {
             return raw_file.discard_to_zero(offset, length);
         }
 
-        self.run_buffered_mutation(offset, length, |chunk_offset, chunk_length| {
+        self.run_buffered_mutation(offset, length, None, |chunk_offset, chunk_length| {
             let mut diskfile = self.file.lock().unwrap();
             diskfile.discard_to_zero(chunk_offset, chunk_length)
         })
     }
 
     pub(crate) fn write_zeroes(&self, offset: u64, length: u64) -> io::Result<()> {
+        self.validate_mutation_range(offset, length)?;
+
+        #[cfg(target_os = "linux")]
+        if let Some(zero_buffer) = &self.explicit_zero_buffer {
+            return self.run_buffered_mutation(
+                offset,
+                length,
+                Some(zero_buffer.len() as u64),
+                |chunk_offset, chunk_length| {
+                    let chunk_length = usize::try_from(chunk_length)
+                        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
+                    let diskfile = self.file.lock().unwrap();
+                    diskfile.write(&zero_buffer[..chunk_length], chunk_offset)
+                },
+            );
+        }
+
         #[cfg(windows)]
         if let Some(raw_file) = &self.windows_raw_file {
             return raw_file.write_zeroes(offset, length);
         }
 
-        self.run_buffered_mutation(offset, length, |chunk_offset, chunk_length| {
+        self.run_buffered_mutation(offset, length, None, |chunk_offset, chunk_length| {
             let diskfile = self.file.lock().unwrap();
             diskfile.write_zeroes(chunk_offset, chunk_length)
         })
     }
 
-    fn run_buffered_mutation<F>(&self, offset: u64, length: u64, mut operation: F) -> io::Result<()>
+    fn run_buffered_mutation<F>(
+        &self,
+        offset: u64,
+        length: u64,
+        maximum_chunk: Option<u64>,
+        mut operation: F,
+    ) -> io::Result<()>
     where
         F: FnMut(u64, u64) -> io::Result<()>,
     {
+        self.validate_mutation_range(offset, length)?;
+
         let mut chunk_offset = offset;
         let mut remaining = length;
 
         while remaining != 0 {
-            let chunk_length = self.buffered_write_chunk_bytes(remaining);
-            self.prepare_buffered_write(chunk_offset, chunk_length)?;
-            operation(chunk_offset, chunk_length)?;
-            self.record_buffered_write(chunk_offset, chunk_length)?;
+            let requested = maximum_chunk.map_or(remaining, |maximum| remaining.min(maximum));
+            let plan = self.plan_buffered_mutation(chunk_offset, requested)?;
+            let chunk_length = plan.len();
+            let operation_result = operation(chunk_offset, chunk_length);
+            self.finish_buffered_mutation(plan, operation_result)?;
 
             remaining -= chunk_length;
             if remaining != 0 {
@@ -502,7 +698,7 @@ impl Block {
         sync_mode: SyncMode,
         metrics: BlockMetricsWriter,
     ) -> io::Result<Block> {
-        Self::new_with_writeback_preflush(
+        Self::new_with_writeback_limit(
             id,
             partuuid,
             cache_type,
@@ -516,16 +712,15 @@ impl Block {
         )
     }
 
-    /// Create a virtio block device with an optional buffered-writeback preflush threshold.
+    /// Create a virtio block device with an optional hard buffered-writeback budget.
     ///
-    /// Preflush is supported on Linux for writable raw disks using writeback caching, buffered I/O
-    /// and an active sync mode. The configured soft threshold starts rolling asynchronous range
-    /// writeback. Twice that threshold is a per-device hard watermark where the block worker
-    /// synchronously drains accumulated writes before accepting more, even without a guest flush.
-    /// Neither action replaces the full sync that completes a guest flush. A zero threshold
-    /// disables the option.
+    /// Bounded writeback is supported on Linux for writable raw disks using writeback caching,
+    /// buffered I/O and an active sync mode. The configured value is the per-device hard budget;
+    /// libkrun derives smaller background batches and releases their credits only after completed
+    /// range writeback. This does not replace the full sync that completes a guest flush. A zero
+    /// value disables the policy.
     #[allow(clippy::too_many_arguments)]
-    pub fn new_with_writeback_preflush(
+    pub fn new_with_writeback_limit(
         id: String,
         partuuid: Option<String>,
         cache_type: CacheType,
@@ -534,11 +729,11 @@ impl Block {
         is_disk_read_only: bool,
         direct_io: bool,
         sync_mode: SyncMode,
-        writeback_preflush_bytes: Option<u64>,
+        writeback_limit_bytes: Option<u64>,
         metrics: BlockMetricsWriter,
     ) -> io::Result<Block> {
         // Keep zero equivalent to the builder's disabled state for callers of this lower-level API.
-        let writeback_preflush_bytes = writeback_preflush_bytes.filter(|bytes| *bytes != 0);
+        let writeback_limit_bytes = writeback_limit_bytes.filter(|bytes| *bytes != 0);
 
         if matches!(disk_image_format, ImageType::Vmdk) && !is_disk_read_only {
             return Err(io::Error::new(
@@ -547,29 +742,21 @@ impl Block {
             ));
         }
 
-        if let Some(_trigger_bytes) = writeback_preflush_bytes {
+        if let Some(_hard_budget_bytes) = writeback_limit_bytes {
             #[cfg(target_os = "linux")]
-            if _trigger_bytes < MINIMUM_RANGE_BYTES {
+            if _hard_budget_bytes < MINIMUM_WRITEBACK_BUDGET_BYTES {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     format!(
-                        "writeback preflush threshold must be at least {MINIMUM_RANGE_BYTES} bytes"
+                        "writeback hard budget must be at least {MINIMUM_WRITEBACK_BUDGET_BYTES} bytes"
                     ),
-                ));
-            }
-
-            #[cfg(target_os = "linux")]
-            if _trigger_bytes.checked_mul(2).is_none() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "writeback preflush threshold is too large to derive its hard watermark",
                 ));
             }
 
             #[cfg(not(target_os = "linux"))]
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
-                "writeback preflush is only supported on Linux hosts",
+                "bounded writeback is only supported on Linux hosts",
             ));
 
             #[cfg(target_os = "linux")]
@@ -581,7 +768,7 @@ impl Block {
             {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    "writeback preflush requires a writable raw disk with writeback caching, buffered I/O and an active sync mode",
+                    "bounded writeback requires a writable raw disk with writeback caching, buffered I/O and an active sync mode",
                 ));
             }
         }
@@ -617,11 +804,11 @@ impl Block {
         };
 
         #[cfg(target_os = "linux")]
-        let writeback_config = match writeback_preflush_bytes {
-            Some(trigger_bytes) => Some(BufferedWritebackConfig::new(
+        let writeback_config = match writeback_limit_bytes {
+            Some(hard_budget_bytes) => Some(BufferedWritebackConfig::new(
                 Arc::new(disk_image.try_clone()?),
-                trigger_bytes,
-            )),
+                hard_budget_bytes,
+            )?),
             None => None,
         };
 
@@ -640,6 +827,13 @@ impl Block {
             .write(!is_disk_read_only)
             .filename(&imago_path)
             .direct(direct_io);
+
+        // Ask Imago to keep completed buffered writes from lingering in the host page cache when
+        // the hard writeback budget is active. Linux treats RWF_DONTCACHE as a best-effort cache
+        // pressure hint, so correctness and containment continue to come from the controller's
+        // reservation accounting and sync barriers rather than this optimization.
+        #[cfg(all(target_os = "linux", any(target_env = "gnu", target_env = "musl")))]
+        let file_opts = file_opts.write_dontcache(writeback_config.is_some());
 
         #[cfg(target_os = "macos")]
         let file_opts = file_opts.relaxed_sync(sync_mode == SyncMode::Relaxed);
@@ -678,12 +872,6 @@ impl Block {
         let disk_properties = {
             let disk_properties =
                 DiskProperties::new(disk_image.clone(), disk_image_id.clone(), cache_type)?;
-            #[cfg(target_os = "linux")]
-            let disk_properties = {
-                let mut disk_properties = disk_properties;
-                disk_properties.set_writeback_config(writeback_config.as_ref());
-                disk_properties
-            };
             #[cfg(windows)]
             {
                 let mut disk_properties = disk_properties;
@@ -696,11 +884,22 @@ impl Block {
             }
         };
 
+        #[cfg(target_os = "linux")]
+        let bounded_writeback_enabled = writeback_config.is_some();
+        #[cfg(not(target_os = "linux"))]
+        let bounded_writeback_enabled = false;
+
         let mut avail_features = (1u64 << VIRTIO_F_VERSION_1)
             | (1u64 << VIRTIO_BLK_F_SEG_MAX)
-            | (1u64 << VIRTIO_BLK_F_DISCARD)
             | (1u64 << VIRTIO_BLK_F_WRITE_ZEROES)
             | (1u64 << VIRTIO_RING_F_EVENT_IDX);
+
+        // DISCARD and WRITE_ZEROES|UNMAP can create metadata-only holes that are invisible to
+        // sync_file_range() accounting. Keep ordinary WRITE_ZEROES, but force it through explicit
+        // zero-data writes while the hard writeback budget is active.
+        if !bounded_writeback_enabled {
+            avail_features |= 1u64 << VIRTIO_BLK_F_DISCARD;
+        }
 
         if sync_mode != SyncMode::None {
             avail_features |= 1u64 << VIRTIO_BLK_F_FLUSH;
@@ -715,12 +914,20 @@ impl Block {
             size_max: 0,
             // QUEUE_SIZE - 2
             seg_max: 254,
-            max_discard_sectors: u32::MAX,
-            max_discard_seg: 1,
-            discard_sector_alignment: discard_alignment as u32 / 512,
+            max_discard_sectors: if bounded_writeback_enabled {
+                0
+            } else {
+                u32::MAX
+            },
+            max_discard_seg: u32::from(!bounded_writeback_enabled),
+            discard_sector_alignment: if bounded_writeback_enabled {
+                0
+            } else {
+                discard_alignment as u32 / 512
+            },
             max_write_zeroes_sectors: u32::MAX,
             max_write_zeroes_seg: 1,
-            write_zeroes_may_unmap: 1,
+            write_zeroes_may_unmap: u8::from(!bounded_writeback_enabled),
             ..Default::default()
         };
 
@@ -758,6 +965,28 @@ impl Block {
     /// Specifies if this block device is read only.
     pub fn is_read_only(&self) -> bool {
         self.avail_features & (1u64 << VIRTIO_BLK_F_RO) != 0
+    }
+
+    fn stop_worker(&mut self) {
+        if let Some(worker) = self.worker_thread.take() {
+            if let Err(error) = self.worker_stopfd.write(1) {
+                error!("error signaling block worker to stop: {error}");
+            }
+            if let Err(error) = worker.join() {
+                error!("error waiting for block worker thread: {error:?}");
+            }
+        }
+    }
+}
+
+impl Drop for Block {
+    fn drop(&mut self) {
+        #[cfg(target_os = "linux")]
+        if self.writeback_config.is_some() {
+            // Dropping a JoinHandle detaches it. A detached bounded-writeback worker would retain
+            // DiskProperties indefinitely, skipping its final sync and shared health update.
+            self.stop_worker();
+        }
     }
 }
 
@@ -832,12 +1061,6 @@ impl VirtioDevice for Block {
                     self.cache_type,
                 )
                 .map_err(|_| ActivateError::BadActivate)?;
-                #[cfg(target_os = "linux")]
-                let disk = {
-                    let mut disk = disk;
-                    disk.set_writeback_config(self.writeback_config.as_ref());
-                    disk
-                };
                 #[cfg(windows)]
                 {
                     let mut disk = disk;
@@ -849,6 +1072,17 @@ impl VirtioDevice for Block {
                     disk
                 }
             }
+        };
+
+        #[cfg(target_os = "linux")]
+        let disk = {
+            let mut disk = disk;
+            disk.set_writeback_config(self.writeback_config.as_ref())
+                .map_err(|error| {
+                    error!("Cannot start bounded block writeback: {error}");
+                    ActivateError::BadActivate
+                })?;
+            disk
         };
 
         let worker = BlockWorker::new(
@@ -866,12 +1100,7 @@ impl VirtioDevice for Block {
     }
 
     fn reset(&mut self) -> bool {
-        if let Some(worker) = self.worker_thread.take() {
-            let _ = self.worker_stopfd.write(1);
-            if let Err(e) = worker.join() {
-                error!("error waiting for worker thread: {e:?}");
-            }
-        }
+        self.stop_worker();
         self.device_state = DeviceState::Inactive;
         true
     }
@@ -884,6 +1113,8 @@ impl VirtioDevice for Block {
 #[cfg(test)]
 mod tests {
     use utils::metrics::MetricsWriter;
+    #[cfg(target_os = "linux")]
+    use utils::tempfile::TempFile;
 
     use super::*;
 
@@ -911,8 +1142,8 @@ mod tests {
     }
 
     #[test]
-    fn zero_writeback_preflush_threshold_disables_the_option() {
-        let result = Block::new_with_writeback_preflush(
+    fn zero_writeback_limit_disables_the_policy() {
+        let result = Block::new_with_writeback_limit(
             "raw".to_string(),
             None,
             CacheType::Unsafe,
@@ -933,26 +1164,79 @@ mod tests {
     }
 
     #[test]
-    fn buffered_write_accounting_is_clamped_to_visible_capacity() {
+    fn bounded_mutation_range_requires_full_visible_capacity() {
         let nsectors = 8;
-        assert_eq!(
-            DiskProperties::clamp_buffered_write_length(nsectors, 512, 4096),
-            3584
-        );
-        assert_eq!(
-            DiskProperties::clamp_buffered_write_length(nsectors, 4096, 512),
-            0
-        );
-        assert_eq!(
-            DiskProperties::clamp_buffered_write_length(nsectors, u64::MAX, u64::MAX),
-            0
-        );
+        assert!(DiskProperties::validate_range_against_capacity(nsectors, 512, 3584).is_ok());
+
+        let crossing_end =
+            DiskProperties::validate_range_against_capacity(nsectors, 512, 4096).unwrap_err();
+        assert_eq!(crossing_end.kind(), io::ErrorKind::InvalidInput);
+        assert!(crossing_end.to_string().contains("visible capacity"));
+
+        let past_end =
+            DiskProperties::validate_range_against_capacity(nsectors, 4096, 512).unwrap_err();
+        assert_eq!(past_end.kind(), io::ErrorKind::InvalidInput);
+
+        let overflow =
+            DiskProperties::validate_range_against_capacity(nsectors, u64::MAX, 1).unwrap_err();
+        assert_eq!(overflow.kind(), io::ErrorKind::InvalidInput);
+        assert!(overflow.to_string().contains("range overflow"));
     }
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn writeback_preflush_rejects_too_small_threshold() {
-        let result = Block::new_with_writeback_preflush(
+    fn bounded_writeback_advertises_only_accountable_zeroing() {
+        let backing = TempFile::new().unwrap();
+        backing.as_file().set_len(4 * 1024 * 1024).unwrap();
+        let block = Block::new_with_writeback_limit(
+            "bounded".to_string(),
+            None,
+            CacheType::Writeback,
+            backing.as_path().to_string_lossy().into_owned(),
+            ImageType::Raw,
+            false,
+            false,
+            SyncMode::Full,
+            Some(MINIMUM_WRITEBACK_BUDGET_BYTES),
+            MetricsWriter::default().register_block_device("bounded".to_string()),
+        )
+        .unwrap();
+
+        assert_eq!(block.avail_features & (1u64 << VIRTIO_BLK_F_DISCARD), 0);
+        assert_ne!(
+            block.avail_features & (1u64 << VIRTIO_BLK_F_WRITE_ZEROES),
+            0
+        );
+        let max_discard_sectors = block.config.max_discard_sectors;
+        let max_discard_seg = block.config.max_discard_seg;
+        let discard_sector_alignment = block.config.discard_sector_alignment;
+        let write_zeroes_may_unmap = block.config.write_zeroes_may_unmap;
+        assert_eq!(max_discard_sectors, 0);
+        assert_eq!(max_discard_seg, 0);
+        assert_eq!(discard_sector_alignment, 0);
+        assert_eq!(write_zeroes_may_unmap, 0);
+
+        let legacy = Block::new(
+            "legacy".to_string(),
+            None,
+            CacheType::Writeback,
+            backing.as_path().to_string_lossy().into_owned(),
+            ImageType::Raw,
+            false,
+            false,
+            SyncMode::Full,
+            MetricsWriter::default().register_block_device("legacy".to_string()),
+        )
+        .unwrap();
+        let legacy_may_unmap = legacy.config.write_zeroes_may_unmap;
+        assert_ne!(legacy.avail_features & (1u64 << VIRTIO_BLK_F_DISCARD), 0);
+        assert_eq!(legacy_may_unmap, 1);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn bounded_writeback_rejects_too_small_budget() {
+        let result = Block::new_with_writeback_limit(
             "raw".to_string(),
             None,
             CacheType::Writeback,
@@ -961,12 +1245,12 @@ mod tests {
             false,
             false,
             SyncMode::Full,
-            Some(MINIMUM_RANGE_BYTES - 1),
+            Some(MINIMUM_WRITEBACK_BUDGET_BYTES - 1),
             MetricsWriter::default().register_block_device("raw".to_string()),
         );
 
         let error = match result {
-            Ok(_) => panic!("too-small preflush threshold should fail"),
+            Ok(_) => panic!("too-small writeback budget should fail"),
             Err(error) => error,
         };
         assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
@@ -975,32 +1259,8 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn writeback_preflush_rejects_threshold_without_a_hard_watermark() {
-        let result = Block::new_with_writeback_preflush(
-            "raw".to_string(),
-            None,
-            CacheType::Writeback,
-            "missing.raw".to_string(),
-            ImageType::Raw,
-            false,
-            false,
-            SyncMode::Full,
-            Some(u64::MAX),
-            MetricsWriter::default().register_block_device("raw".to_string()),
-        );
-
-        let error = match result {
-            Ok(_) => panic!("overflowing hard watermark should fail"),
-            Err(error) => error,
-        };
-        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
-        assert!(error.to_string().contains("too large"));
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn writeback_preflush_rejects_incompatible_disk_settings() {
-        let result = Block::new_with_writeback_preflush(
+    fn bounded_writeback_rejects_incompatible_disk_settings() {
+        let result = Block::new_with_writeback_limit(
             "raw".to_string(),
             None,
             CacheType::Writeback,
@@ -1014,7 +1274,7 @@ mod tests {
         );
 
         let error = match result {
-            Ok(_) => panic!("preflush with direct I/O should fail"),
+            Ok(_) => panic!("bounded writeback with direct I/O should fail"),
             Err(error) => error,
         };
         assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
@@ -1023,8 +1283,8 @@ mod tests {
 
     #[cfg(not(target_os = "linux"))]
     #[test]
-    fn writeback_preflush_is_rejected_on_unsupported_hosts() {
-        let result = Block::new_with_writeback_preflush(
+    fn bounded_writeback_is_rejected_on_unsupported_hosts() {
+        let result = Block::new_with_writeback_limit(
             "raw".to_string(),
             None,
             CacheType::Writeback,
@@ -1038,7 +1298,7 @@ mod tests {
         );
 
         let error = match result {
-            Ok(_) => panic!("preflush should fail on unsupported hosts"),
+            Ok(_) => panic!("bounded writeback should fail on unsupported hosts"),
             Err(error) => error,
         };
         assert_eq!(error.kind(), io::ErrorKind::Unsupported);

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -828,12 +828,10 @@ impl Block {
             .filename(&imago_path)
             .direct(direct_io);
 
-        // Ask Imago to keep completed buffered writes from lingering in the host page cache when
-        // the hard writeback budget is active. Linux treats RWF_DONTCACHE as a best-effort cache
-        // pressure hint, so correctness and containment continue to come from the controller's
-        // reservation accounting and sync barriers rather than this optimization.
-        #[cfg(all(target_os = "linux", any(target_env = "gnu", target_env = "musl")))]
-        let file_opts = file_opts.write_dontcache(writeback_config.is_some());
+        // Do not attach `RWF_DONTCACHE` to bounded writes. The controller already reserves every
+        // dirty page before mutation and returns that credit only after verified writeback, while
+        // the per-write hint would start eager writeback and collapse the finite cache window that
+        // the hard budget is intended to bound.
 
         #[cfg(target_os = "macos")]
         let file_opts = file_opts.relaxed_sync(sync_mode == SyncMode::Relaxed);

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -40,7 +40,7 @@ use super::windows::{
 };
 use super::worker::BlockWorker;
 #[cfg(target_os = "linux")]
-use super::writeback::{BufferedWritebackConfig, BufferedWritebackController};
+use super::writeback::{BufferedWritebackConfig, BufferedWritebackController, MINIMUM_RANGE_BYTES};
 use super::{
     super::{ActivateResult, DeviceQueue, DeviceState, QueueConfig, VirtioDevice, TYPE_BLOCK},
     Error, NUM_QUEUES, QUEUE_CONFIG, SECTOR_SHIFT, SECTOR_SIZE,
@@ -432,11 +432,81 @@ impl Block {
         sync_mode: SyncMode,
         metrics: BlockMetricsWriter,
     ) -> io::Result<Block> {
+        Self::new_with_writeback_preflush(
+            id,
+            partuuid,
+            cache_type,
+            disk_image_path,
+            disk_image_format,
+            is_disk_read_only,
+            direct_io,
+            sync_mode,
+            None,
+            metrics,
+        )
+    }
+
+    /// Create a virtio block device with an optional buffered-writeback preflush threshold.
+    ///
+    /// Preflush is supported on Linux for writable raw disks using writeback caching, buffered I/O
+    /// and an active sync mode. It starts advisory background writeback but does not replace the
+    /// full sync that completes a guest flush.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_writeback_preflush(
+        id: String,
+        partuuid: Option<String>,
+        cache_type: CacheType,
+        disk_image_path: String,
+        disk_image_format: ImageType,
+        is_disk_read_only: bool,
+        direct_io: bool,
+        sync_mode: SyncMode,
+        writeback_preflush_bytes: Option<u64>,
+        metrics: BlockMetricsWriter,
+    ) -> io::Result<Block> {
         if matches!(disk_image_format, ImageType::Vmdk) && !is_disk_read_only {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
                 "VMDK write support is not available; configure the disk as read-only",
             ));
+        }
+
+        if let Some(trigger_bytes) = writeback_preflush_bytes {
+            if trigger_bytes == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "writeback preflush threshold must be greater than zero",
+                ));
+            }
+
+            #[cfg(target_os = "linux")]
+            if trigger_bytes < MINIMUM_RANGE_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "writeback preflush threshold must be at least {MINIMUM_RANGE_BYTES} bytes"
+                    ),
+                ));
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "writeback preflush is only supported on Linux hosts",
+            ));
+
+            #[cfg(target_os = "linux")]
+            if !matches!(disk_image_format, ImageType::Raw)
+                || is_disk_read_only
+                || direct_io
+                || cache_type != CacheType::Writeback
+                || sync_mode == SyncMode::None
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "writeback preflush requires a writable raw disk with writeback caching, buffered I/O and an active sync mode",
+                ));
+            }
         }
 
         let disk_image = OpenOptions::new()
@@ -470,15 +540,12 @@ impl Block {
         };
 
         #[cfg(target_os = "linux")]
-        let writeback_config = if matches!(disk_image_format, ImageType::Raw)
-            && !is_disk_read_only
-            && !direct_io
-            && cache_type == CacheType::Writeback
-            && sync_mode != SyncMode::None
-        {
-            BufferedWritebackConfig::from_environment(Arc::new(disk_image.try_clone()?))
-        } else {
-            None
+        let writeback_config = match writeback_preflush_bytes {
+            Some(trigger_bytes) => Some(BufferedWritebackConfig::new(
+                Arc::new(disk_image.try_clone()?),
+                trigger_bytes,
+            )),
+            None => None,
         };
 
         // Keep Imago on its established open path. When advisory writeback is active, procfs
@@ -764,5 +831,98 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::Unsupported);
         assert!(error.to_string().contains("VMDK write support"));
+    }
+
+    #[test]
+    fn zero_writeback_preflush_threshold_is_rejected() {
+        let result = Block::new_with_writeback_preflush(
+            "raw".to_string(),
+            None,
+            CacheType::Writeback,
+            "missing.raw".to_string(),
+            ImageType::Raw,
+            false,
+            false,
+            SyncMode::Full,
+            Some(0),
+            MetricsWriter::default().register_block_device("raw".to_string()),
+        );
+
+        let error = match result {
+            Ok(_) => panic!("zero preflush threshold should fail"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn writeback_preflush_rejects_too_small_threshold() {
+        let result = Block::new_with_writeback_preflush(
+            "raw".to_string(),
+            None,
+            CacheType::Writeback,
+            "missing.raw".to_string(),
+            ImageType::Raw,
+            false,
+            false,
+            SyncMode::Full,
+            Some(MINIMUM_RANGE_BYTES - 1),
+            MetricsWriter::default().register_block_device("raw".to_string()),
+        );
+
+        let error = match result {
+            Ok(_) => panic!("too-small preflush threshold should fail"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("at least"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn writeback_preflush_rejects_incompatible_disk_settings() {
+        let result = Block::new_with_writeback_preflush(
+            "raw".to_string(),
+            None,
+            CacheType::Writeback,
+            "missing.raw".to_string(),
+            ImageType::Raw,
+            false,
+            true,
+            SyncMode::Full,
+            Some(128 * 1024 * 1024),
+            MetricsWriter::default().register_block_device("raw".to_string()),
+        );
+
+        let error = match result {
+            Ok(_) => panic!("preflush with direct I/O should fail"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("buffered I/O"));
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn writeback_preflush_is_rejected_on_unsupported_hosts() {
+        let result = Block::new_with_writeback_preflush(
+            "raw".to_string(),
+            None,
+            CacheType::Writeback,
+            "missing.raw".to_string(),
+            ImageType::Raw,
+            false,
+            false,
+            SyncMode::Full,
+            Some(128 * 1024 * 1024),
+            MetricsWriter::default().register_block_device("raw".to_string()),
+        );
+
+        let error = match result {
+            Ok(_) => panic!("preflush should fail on unsupported hosts"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::Unsupported);
     }
 }

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -13,6 +13,8 @@ use std::io::{self, Write};
 use std::os::linux::fs::MetadataExt;
 #[cfg(target_os = "macos")]
 use std::os::macos::fs::MetadataExt;
+#[cfg(target_os = "linux")]
+use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::result;
 use std::sync::{Arc, Mutex};
@@ -38,7 +40,7 @@ use super::windows::{
 };
 use super::worker::BlockWorker;
 #[cfg(target_os = "linux")]
-use super::writeback::BufferedWritebackController;
+use super::writeback::{BufferedWritebackConfig, BufferedWritebackController};
 use super::{
     super::{ActivateResult, DeviceQueue, DeviceState, QueueConfig, VirtioDevice, TYPE_BLOCK},
     Error, NUM_QUEUES, QUEUE_CONFIG, SECTOR_SHIFT, SECTOR_SIZE,
@@ -170,13 +172,6 @@ impl DiskProperties {
     }
 
     pub(crate) fn flush_to_disk(&self) -> io::Result<()> {
-        #[cfg(target_os = "linux")]
-        if let Some(controller) = &self.writeback_controller {
-            // Advisory writeout only moves data toward the device. The full sync below remains the
-            // durability boundary and the worker does not acknowledge the guest before it returns.
-            controller.lock().unwrap().prepare_flush();
-        }
-
         #[cfg(windows)]
         if let Some(raw_file) = &self.windows_raw_file {
             raw_file.flush()?;
@@ -205,9 +200,9 @@ impl DiskProperties {
     }
 
     #[cfg(target_os = "linux")]
-    fn set_writeback_file(&mut self, file: Option<Arc<File>>) {
-        self.writeback_controller = file
-            .and_then(BufferedWritebackController::from_environment)
+    fn set_writeback_config(&mut self, config: Option<&BufferedWritebackConfig>) {
+        self.writeback_controller = config
+            .map(BufferedWritebackConfig::controller)
             .map(Mutex::new);
     }
 
@@ -401,7 +396,7 @@ pub struct Block {
     disk_image: Arc<Mutex<SyncFormatAccess<Box<dyn DynStorage>>>>,
     disk_image_id: Vec<u8>,
     #[cfg(target_os = "linux")]
-    writeback_file: Option<Arc<File>>,
+    writeback_config: Option<BufferedWritebackConfig>,
     #[cfg(windows)]
     windows_raw_file: Option<Arc<WindowsRawFile>>,
     metrics: BlockMetricsWriter,
@@ -474,30 +469,37 @@ impl Block {
             padded
         };
 
-        let file_opts = StorageOpenOptions::new()
-            .write(!is_disk_read_only)
-            .filename(&disk_image_path)
-            .direct(direct_io);
-
-        #[cfg(target_os = "macos")]
-        let file_opts = file_opts.relaxed_sync(sync_mode == SyncMode::Relaxed);
-
         #[cfg(target_os = "linux")]
-        let (file, writeback_file) = if matches!(disk_image_format, ImageType::Raw)
+        let writeback_config = if matches!(disk_image_format, ImageType::Raw)
             && !is_disk_read_only
             && !direct_io
             && cache_type == CacheType::Writeback
             && sync_mode != SyncMode::None
         {
-            // Use one opened object for both Imago I/O and advisory writeback. Reopening the path
-            // for either side could race with replacement and target different inodes.
-            let writeback_file = Arc::new(disk_image.try_clone()?);
-            (ImagoFile::try_from(disk_image)?, Some(writeback_file))
+            BufferedWritebackConfig::from_environment(Arc::new(disk_image.try_clone()?))
         } else {
-            (ImagoFile::open_sync(file_opts)?, None)
+            None
         };
 
+        // Keep Imago on its established open path. When advisory writeback is active, procfs
+        // provides a race-free name for the already-verified inode without giving Imago the
+        // controller's file description or changing its storage implementation.
+        #[cfg(target_os = "linux")]
+        let imago_path = writeback_config
+            .as_ref()
+            .map(|_| format!("/proc/self/fd/{}", disk_image.as_raw_fd()))
+            .unwrap_or_else(|| disk_image_path.clone());
         #[cfg(not(target_os = "linux"))]
+        let imago_path = disk_image_path.clone();
+
+        let file_opts = StorageOpenOptions::new()
+            .write(!is_disk_read_only)
+            .filename(&imago_path)
+            .direct(direct_io);
+
+        #[cfg(target_os = "macos")]
+        let file_opts = file_opts.relaxed_sync(sync_mode == SyncMode::Relaxed);
+
         let file = ImagoFile::open_sync(file_opts)?;
         let discard_alignment = file.discard_align();
 
@@ -535,7 +537,7 @@ impl Block {
             #[cfg(target_os = "linux")]
             let disk_properties = {
                 let mut disk_properties = disk_properties;
-                disk_properties.set_writeback_file(writeback_file.clone());
+                disk_properties.set_writeback_config(writeback_config.as_ref());
                 disk_properties
             };
             #[cfg(windows)]
@@ -587,7 +589,7 @@ impl Block {
             disk_image,
             disk_image_id,
             #[cfg(target_os = "linux")]
-            writeback_file,
+            writeback_config,
             #[cfg(windows)]
             windows_raw_file,
             metrics,
@@ -689,7 +691,7 @@ impl VirtioDevice for Block {
                 #[cfg(target_os = "linux")]
                 let disk = {
                     let mut disk = disk;
-                    disk.set_writeback_file(self.writeback_file.clone());
+                    disk.set_writeback_config(self.writeback_config.as_ref());
                     disk
                 };
                 #[cfg(windows)]

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -190,6 +190,14 @@ impl DiskProperties {
     }
 
     pub(crate) fn record_buffered_write(&self, offset: u64, length: u64) {
+        // Imago accepts writes beyond the virtual capacity and clips writes crossing the end. Only
+        // account for bytes the guest-visible raw disk could actually have dirtied, so an invalid
+        // request cannot amplify the advisory sync range.
+        let length = Self::clamp_buffered_write_length(self.nsectors, offset, length);
+        if length == 0 {
+            return;
+        }
+
         #[cfg(target_os = "linux")]
         if let Some(controller) = &self.writeback_controller {
             controller.lock().unwrap().record_write(offset, length);
@@ -197,6 +205,11 @@ impl DiskProperties {
 
         #[cfg(not(target_os = "linux"))]
         let _ = (offset, length);
+    }
+
+    fn clamp_buffered_write_length(nsectors: u64, offset: u64, length: u64) -> u64 {
+        let visible_size = nsectors.saturating_mul(SECTOR_SIZE);
+        length.min(visible_size.saturating_sub(offset))
     }
 
     #[cfg(target_os = "linux")]
@@ -223,6 +236,8 @@ impl DiskProperties {
         }
 
         let mut diskfile = self.file.lock().unwrap();
+        // Raw discard and zero-range operations use filesystem allocation primitives rather than
+        // the buffered data-write path, so they intentionally do not advance the preflush window.
         diskfile.discard_to_zero(offset, length)
     }
 
@@ -233,6 +248,7 @@ impl DiskProperties {
         }
 
         let diskfile = self.file.lock().unwrap();
+        // See `discard_to_zero`: advisory page-cache writeback tracks ordinary buffered writes.
         diskfile.write_zeroes(offset, length)
     }
 
@@ -449,8 +465,9 @@ impl Block {
     /// Create a virtio block device with an optional buffered-writeback preflush threshold.
     ///
     /// Preflush is supported on Linux for writable raw disks using writeback caching, buffered I/O
-    /// and an active sync mode. It starts advisory background writeback but does not replace the
-    /// full sync that completes a guest flush.
+    /// and an active sync mode. It starts at most one advisory background writeback range between
+    /// successful guest flushes, but does not replace the full sync that completes a guest flush or
+    /// provide a dirty-memory containment boundary. A zero threshold disables the option.
     #[allow(clippy::too_many_arguments)]
     pub fn new_with_writeback_preflush(
         id: String,
@@ -464,6 +481,9 @@ impl Block {
         writeback_preflush_bytes: Option<u64>,
         metrics: BlockMetricsWriter,
     ) -> io::Result<Block> {
+        // Keep zero equivalent to the builder's disabled state for callers of this lower-level API.
+        let writeback_preflush_bytes = writeback_preflush_bytes.filter(|bytes| *bytes != 0);
+
         if matches!(disk_image_format, ImageType::Vmdk) && !is_disk_read_only {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
@@ -471,16 +491,9 @@ impl Block {
             ));
         }
 
-        if let Some(trigger_bytes) = writeback_preflush_bytes {
-            if trigger_bytes == 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "writeback preflush threshold must be greater than zero",
-                ));
-            }
-
+        if let Some(_trigger_bytes) = writeback_preflush_bytes {
             #[cfg(target_os = "linux")]
-            if trigger_bytes < MINIMUM_RANGE_BYTES {
+            if _trigger_bytes < MINIMUM_RANGE_BYTES {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     format!(
@@ -834,25 +847,42 @@ mod tests {
     }
 
     #[test]
-    fn zero_writeback_preflush_threshold_is_rejected() {
+    fn zero_writeback_preflush_threshold_disables_the_option() {
         let result = Block::new_with_writeback_preflush(
             "raw".to_string(),
             None,
-            CacheType::Writeback,
+            CacheType::Unsafe,
             "missing.raw".to_string(),
             ImageType::Raw,
             false,
-            false,
-            SyncMode::Full,
+            true,
+            SyncMode::None,
             Some(0),
             MetricsWriter::default().register_block_device("raw".to_string()),
         );
 
         let error = match result {
-            Ok(_) => panic!("zero preflush threshold should fail"),
+            Ok(_) => panic!("missing raw disk should fail"),
             Err(error) => error,
         };
-        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn buffered_write_accounting_is_clamped_to_visible_capacity() {
+        let nsectors = 8;
+        assert_eq!(
+            DiskProperties::clamp_buffered_write_length(nsectors, 512, 4096),
+            3584
+        );
+        assert_eq!(
+            DiskProperties::clamp_buffered_write_length(nsectors, 4096, 512),
+            0
+        );
+        assert_eq!(
+            DiskProperties::clamp_buffered_write_length(nsectors, u64::MAX, u64::MAX),
+            0
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -37,6 +37,8 @@ use super::windows::{
     PendingWindowsRawFileOperation, WindowsRawFile, WindowsRawFileBuffer, WindowsRawFileCompletion,
 };
 use super::worker::BlockWorker;
+#[cfg(target_os = "linux")]
+use super::writeback::BufferedWritebackController;
 use super::{
     super::{ActivateResult, DeviceQueue, DeviceState, QueueConfig, VirtioDevice, TYPE_BLOCK},
     Error, NUM_QUEUES, QUEUE_CONFIG, SECTOR_SHIFT, SECTOR_SIZE,
@@ -76,6 +78,8 @@ impl CacheType {
 pub(crate) struct DiskProperties {
     cache_type: CacheType,
     pub(crate) file: Arc<Mutex<SyncFormatAccess<Box<dyn DynStorage>>>>,
+    #[cfg(target_os = "linux")]
+    writeback_controller: Option<Mutex<BufferedWritebackController>>,
     #[cfg(windows)]
     windows_raw_file: Option<Arc<WindowsRawFile>>,
     #[cfg(windows)]
@@ -106,6 +110,8 @@ impl DiskProperties {
             nsectors: disk_size >> SECTOR_SHIFT,
             image_id: disk_image_id,
             file: disk_image,
+            #[cfg(target_os = "linux")]
+            writeback_controller: None,
             #[cfg(windows)]
             windows_raw_file: None,
             #[cfg(windows)]
@@ -164,6 +170,13 @@ impl DiskProperties {
     }
 
     pub(crate) fn flush_to_disk(&self) -> io::Result<()> {
+        #[cfg(target_os = "linux")]
+        if let Some(controller) = &self.writeback_controller {
+            // Advisory writeout only moves data toward the device. The full sync below remains the
+            // durability boundary and the worker does not acknowledge the guest before it returns.
+            controller.lock().unwrap().prepare_flush();
+        }
+
         #[cfg(windows)]
         if let Some(raw_file) = &self.windows_raw_file {
             raw_file.flush()?;
@@ -171,7 +184,31 @@ impl DiskProperties {
 
         let diskfile = self.file.lock().unwrap();
         diskfile.flush()?;
-        diskfile.sync()
+        diskfile.sync()?;
+
+        #[cfg(target_os = "linux")]
+        if let Some(controller) = &self.writeback_controller {
+            controller.lock().unwrap().complete_flush();
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn record_buffered_write(&self, offset: u64, length: u64) {
+        #[cfg(target_os = "linux")]
+        if let Some(controller) = &self.writeback_controller {
+            controller.lock().unwrap().record_write(offset, length);
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        let _ = (offset, length);
+    }
+
+    #[cfg(target_os = "linux")]
+    fn set_writeback_file(&mut self, file: Option<Arc<File>>) {
+        self.writeback_controller = file
+            .and_then(BufferedWritebackController::from_environment)
+            .map(Mutex::new);
     }
 
     pub(crate) fn discard_to_any(&self, offset: u64, length: u64) -> io::Result<()> {
@@ -363,6 +400,8 @@ pub struct Block {
     cache_type: CacheType,
     disk_image: Arc<Mutex<SyncFormatAccess<Box<dyn DynStorage>>>>,
     disk_image_id: Vec<u8>,
+    #[cfg(target_os = "linux")]
+    writeback_file: Option<Arc<File>>,
     #[cfg(windows)]
     windows_raw_file: Option<Arc<WindowsRawFile>>,
     metrics: BlockMetricsWriter,
@@ -437,11 +476,28 @@ impl Block {
 
         let file_opts = StorageOpenOptions::new()
             .write(!is_disk_read_only)
-            .filename(disk_image_path)
+            .filename(&disk_image_path)
             .direct(direct_io);
 
         #[cfg(target_os = "macos")]
         let file_opts = file_opts.relaxed_sync(sync_mode == SyncMode::Relaxed);
+
+        #[cfg(target_os = "linux")]
+        let (file, writeback_file) = if matches!(disk_image_format, ImageType::Raw)
+            && !is_disk_read_only
+            && !direct_io
+            && cache_type == CacheType::Writeback
+            && sync_mode != SyncMode::None
+        {
+            // Use one opened object for both Imago I/O and advisory writeback. Reopening the path
+            // for either side could race with replacement and target different inodes.
+            let writeback_file = Arc::new(disk_image.try_clone()?);
+            (ImagoFile::try_from(disk_image)?, Some(writeback_file))
+        } else {
+            (ImagoFile::open_sync(file_opts)?, None)
+        };
+
+        #[cfg(not(target_os = "linux"))]
         let file = ImagoFile::open_sync(file_opts)?;
         let discard_alignment = file.discard_align();
 
@@ -476,6 +532,12 @@ impl Block {
         let disk_properties = {
             let disk_properties =
                 DiskProperties::new(disk_image.clone(), disk_image_id.clone(), cache_type)?;
+            #[cfg(target_os = "linux")]
+            let disk_properties = {
+                let mut disk_properties = disk_properties;
+                disk_properties.set_writeback_file(writeback_file.clone());
+                disk_properties
+            };
             #[cfg(windows)]
             {
                 let mut disk_properties = disk_properties;
@@ -524,6 +586,8 @@ impl Block {
             cache_type,
             disk_image,
             disk_image_id,
+            #[cfg(target_os = "linux")]
+            writeback_file,
             #[cfg(windows)]
             windows_raw_file,
             metrics,
@@ -622,6 +686,12 @@ impl VirtioDevice for Block {
                     self.cache_type,
                 )
                 .map_err(|_| ActivateError::BadActivate)?;
+                #[cfg(target_os = "linux")]
+                let disk = {
+                    let mut disk = disk;
+                    disk.set_writeback_file(self.writeback_file.clone());
+                    disk
+                };
                 #[cfg(windows)]
                 {
                     let mut disk = disk;

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -5,7 +5,7 @@ pub mod device;
 #[cfg(windows)]
 mod windows;
 mod worker;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 mod writeback;
 
 pub use self::device::{Block, CacheType};

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -5,6 +5,8 @@ pub mod device;
 #[cfg(windows)]
 mod windows;
 mod worker;
+#[cfg(target_os = "linux")]
+mod writeback;
 
 pub use self::device::{Block, CacheType};
 

--- a/src/devices/src/virtio/block/worker.rs
+++ b/src/devices/src/virtio/block/worker.rs
@@ -46,7 +46,9 @@ pub enum RequestError {
     DiscardingToZero(io::Error),
     FlushingToDisk(io::Error),
     InvalidDataLength,
+    InvalidMutationRange(io::Error),
     ReadingFromDescriptor(io::Error),
+    UnsupportedMutation,
     WritingToDescriptor(io::Error),
     WritingZeroes(io::Error),
     UnknownRequest,
@@ -832,6 +834,11 @@ impl BlockWorker {
                     Err(RequestError::InvalidDataLength)
                 } else {
                     let offset = sector_offset(request_header.sector)?;
+                    // Validate the complete descriptor payload before allowing the first backing
+                    // write. Bounded mode must never partially apply an out-of-capacity request.
+                    self.disk
+                        .validate_mutation_range(offset, data_len as u64)
+                        .map_err(RequestError::InvalidMutationRange)?;
                     let len = reader
                         .read_to_at(&self.disk, data_len, offset)
                         .map_err(RequestError::ReadingFromDescriptor)?;
@@ -861,14 +868,21 @@ impl BlockWorker {
                 }
             }
             VIRTIO_BLK_T_DISCARD => {
+                if self.disk.has_writeback_limit() {
+                    // Bounded writeback deliberately does not advertise DISCARD. Reject a guest
+                    // that sends it anyway rather than admitting unaccounted metadata mutation.
+                    return Err(RequestError::UnsupportedMutation);
+                }
                 let discard_write_data: DiscardWriteData = reader
                     .read_obj()
                     .map_err(RequestError::ReadingFromDescriptor)?;
+                let offset = sector_offset(discard_write_data.sector)?;
+                let length = sector_count_bytes(discard_write_data.num_sectors)?;
                 self.disk
-                    .discard_to_any(
-                        sector_offset(discard_write_data.sector)?,
-                        sector_count_bytes(discard_write_data.num_sectors)?,
-                    )
+                    .validate_mutation_range(offset, length)
+                    .map_err(RequestError::InvalidMutationRange)?;
+                self.disk
+                    .discard_to_any(offset, length)
                     .map_err(RequestError::Discarding)?;
                 Ok(0)
             }
@@ -877,19 +891,23 @@ impl BlockWorker {
                     .read_obj()
                     .map_err(RequestError::ReadingFromDescriptor)?;
                 let unmap = (discard_write_data.flags & VIRTIO_BLK_WRITE_ZEROES_FLAG_UNMAP) != 0;
+                if self.disk.has_writeback_limit() && unmap {
+                    // The bounded device advertises write_zeroes_may_unmap=0. Fail closed if a
+                    // non-conforming guest still requests a hole-punching zero operation.
+                    return Err(RequestError::UnsupportedMutation);
+                }
+                let offset = sector_offset(discard_write_data.sector)?;
+                let length = sector_count_bytes(discard_write_data.num_sectors)?;
+                self.disk
+                    .validate_mutation_range(offset, length)
+                    .map_err(RequestError::InvalidMutationRange)?;
                 if unmap {
                     self.disk
-                        .discard_to_zero(
-                            sector_offset(discard_write_data.sector)?,
-                            sector_count_bytes(discard_write_data.num_sectors)?,
-                        )
+                        .discard_to_zero(offset, length)
                         .map_err(RequestError::DiscardingToZero)?;
                 } else {
                     self.disk
-                        .write_zeroes(
-                            sector_offset(discard_write_data.sector)?,
-                            sector_count_bytes(discard_write_data.num_sectors)?,
-                        )
+                        .write_zeroes(offset, length)
                         .map_err(RequestError::WritingZeroes)?;
                 }
                 Ok(0)

--- a/src/devices/src/virtio/block/writeback.rs
+++ b/src/devices/src/virtio/block/writeback.rs
@@ -117,11 +117,13 @@ impl BufferedWritebackConfig {
     }
 }
 
-/// Schedules bounded advisory data writeback for one buffered raw-file block device.
+/// Schedules one advisory data-writeback range per guest durability epoch.
 ///
 /// `sync_file_range(..., SYNC_FILE_RANGE_WRITE)` does not claim durability. Guest flush
 /// completion still depends on the existing full file sync after every earlier write has been
-/// processed by the block worker.
+/// processed by the block worker. This controller is a latency hint rather than a dirty-memory
+/// containment boundary: after the first submission, later writes wait for the mandatory guest
+/// flush. Hosts running untrusted guests must enforce memory and dirty-page limits independently.
 pub(crate) struct BufferedWritebackController {
     file: Arc<File>,
     window: WritebackWindow,

--- a/src/devices/src/virtio/block/writeback.rs
+++ b/src/devices/src/virtio/block/writeback.rs
@@ -1,15 +1,41 @@
 // Copyright 2026 The Microsandbox Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::VecDeque;
+#[cfg(target_os = "linux")]
 use std::fs::File;
 use std::io;
+#[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::thread::{self, JoinHandle};
 
+use crossbeam_channel::{bounded, Receiver, Sender, TryRecvError};
 use log::warn;
 
-pub(crate) const MINIMUM_RANGE_BYTES: u64 = 64 * 1024 * 1024;
-const HARD_LIMIT_MULTIPLIER: u64 = 2;
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Smallest supported per-device hard writeback budget.
+pub(crate) const MINIMUM_WRITEBACK_BUDGET_BYTES: u64 = 128 * 1024 * 1024;
+
+const MINIMUM_BATCH_BYTES: u64 = 32 * 1024 * 1024;
+const MAXIMUM_BATCH_BYTES: u64 = 256 * 1024 * 1024;
+const BATCH_BUDGET_DIVISOR: u64 = 4;
+/// Maximum exact disjoint ranges retained in one generation before it is submitted early.
+///
+/// This bounds both controller metadata and the number of `sync_file_range` calls in one job
+/// independently of the caller-supplied hard byte budget. At 4 KiB per page, 8192 extents cover
+/// the full 32 MiB minimum batch while limiting one job's range vector to roughly 128 KiB.
+const MAX_EXTENTS_PER_GENERATION: usize = 8192;
+const MAX_QUEUED_BATCHES: usize = 64;
+const WORKER_THREAD_NAME: &str = "virtio-blk-writeback";
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct DirtyRange {
@@ -17,226 +43,1016 @@ struct DirtyRange {
     end: u64,
 }
 
-impl DirtyRange {
-    fn new(offset: u64, length: u64) -> Option<Self> {
-        if length == 0 {
-            return None;
-        }
-
-        Some(Self {
-            start: offset,
-            end: offset.saturating_add(length),
-        })
-    }
-
-    fn merge(self, other: Self) -> Self {
-        Self {
-            start: self.start.min(other.start),
-            end: self.end.max(other.end),
-        }
-    }
-
-    fn len(self) -> u64 {
-        self.end.saturating_sub(self.start)
-    }
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct ExtentSet {
+    bytes: u64,
+    ranges: Vec<DirtyRange>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum WritebackAction {
-    Advisory(DirtyRange),
-    Drain(DirtyRange),
+enum GenerationStatus {
+    InFlight,
+    Failed,
 }
 
 #[derive(Debug)]
-struct WritebackWindow {
-    trigger_bytes: u64,
-    hard_limit_bytes: u64,
-    batch_logical_bytes: u64,
-    batch_range: Option<DirtyRange>,
-    outstanding_logical_bytes: u64,
-    outstanding_range: Option<DirtyRange>,
+struct SharedHealth {
+    healthy: AtomicBool,
 }
 
-impl WritebackWindow {
-    fn new(trigger_bytes: u64) -> Self {
-        Self {
-            trigger_bytes,
-            hard_limit_bytes: trigger_bytes.saturating_mul(HARD_LIMIT_MULTIPLIER),
-            batch_logical_bytes: 0,
-            batch_range: None,
-            outstanding_logical_bytes: 0,
-            outstanding_range: None,
-        }
-    }
+#[derive(Debug)]
+struct Generation {
+    id: u64,
+    extents: ExtentSet,
+    status: GenerationStatus,
+}
 
-    fn prepare_write(&self, length: u64) -> Option<DirtyRange> {
-        let projected_bytes = self.outstanding_logical_bytes.saturating_add(length);
-        (projected_bytes > self.hard_limit_bytes)
-            .then_some(self.outstanding_range)
-            .flatten()
-    }
+#[derive(Debug)]
+struct WritebackJob {
+    generation: u64,
+    ranges: Vec<DirtyRange>,
+}
 
-    fn record_write(&mut self, offset: u64, length: u64) -> Option<WritebackAction> {
-        let range = DirtyRange::new(offset, length)?;
+#[derive(Debug)]
+struct WritebackCompletion {
+    generation: u64,
+    result: Result<(), WritebackFailure>,
+}
 
-        self.batch_logical_bytes = self.batch_logical_bytes.saturating_add(length);
-        self.batch_range = Some(
-            self.batch_range
-                .map_or(range, |existing| existing.merge(range)),
-        );
+#[derive(Clone, Debug)]
+struct WritebackFailure {
+    error: Arc<io::Error>,
+}
 
-        self.outstanding_logical_bytes = self.outstanding_logical_bytes.saturating_add(length);
-        self.outstanding_range = Some(
-            self.outstanding_range
-                .map_or(range, |existing| existing.merge(range)),
-        );
+#[derive(Clone, Debug)]
+struct LatchedError {
+    kind: io::ErrorKind,
+    raw_os_error: Option<i32>,
+    message: String,
+}
 
-        if self.outstanding_logical_bytes >= self.hard_limit_bytes {
-            return self.outstanding_range.map(WritebackAction::Drain);
-        }
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PendingReservation {
+    id: u64,
+    offset: u64,
+    length: u64,
+    range: DirtyRange,
+}
 
-        let batch_range = self.batch_range?;
-        if self.batch_logical_bytes >= self.trigger_bytes
-            && batch_range.len() >= MINIMUM_RANGE_BYTES
-        {
-            return Some(WritebackAction::Advisory(batch_range));
-        }
+/// A single write admitted by the writeback budget.
+///
+/// The token is deliberately owned and does not borrow the controller, so callers can release
+/// interior mutability before performing the backing-file mutation.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct WritebackReservation {
+    id: u64,
+    offset: u64,
+    length: u64,
+}
 
-        None
-    }
+/// What the backing mutation did after a [`WritebackReservation`] was issued.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum WritebackOutcome {
+    /// The mutation succeeded and dirtied exactly this prefix of the reservation.
+    Written(u64),
+    /// The mutation failed and may have dirtied any part of the reservation.
+    Failed,
+}
 
-    fn complete_advisory(&mut self) {
-        self.batch_logical_bytes = 0;
-        self.batch_range = None;
-    }
+trait WritebackBackend: Send + Sync + 'static {
+    fn writeback(&self, ranges: &[DirtyRange]) -> io::Result<()>;
+    fn sync_data(&self) -> io::Result<()>;
+}
 
-    fn complete_drain(&mut self) {
-        self.complete_advisory();
-        self.outstanding_logical_bytes = 0;
-        self.outstanding_range = None;
-    }
-
-    fn complete_flush(&mut self) {
-        self.complete_drain();
-    }
+#[cfg(target_os = "linux")]
+struct SyncFileRangeBackend {
+    file: Arc<File>,
 }
 
 /// Immutable inputs used to create a fresh controller when a block device is reactivated.
+#[cfg(target_os = "linux")]
 #[derive(Clone)]
 pub(crate) struct BufferedWritebackConfig {
     file: Arc<File>,
-    trigger_bytes: u64,
+    hard_budget_bytes: u64,
+    page_size: u64,
+    health: Arc<SharedHealth>,
 }
 
-impl BufferedWritebackConfig {
-    pub(crate) fn new(file: Arc<File>, trigger_bytes: u64) -> Self {
-        Self {
-            file,
-            trigger_bytes,
-        }
-    }
-
-    pub(crate) fn controller(&self) -> BufferedWritebackController {
-        BufferedWritebackController {
-            file: Arc::clone(&self.file),
-            window: WritebackWindow::new(self.trigger_bytes),
-        }
-    }
-}
-
-/// Applies rolling advisory writeback and hard backpressure to one buffered raw-file block device.
+/// Bounds buffered dirty data and moves range writeback off the virtio block worker.
 ///
-/// The configured threshold starts asynchronous range writeback. Twice that threshold is the hard
-/// logical-byte watermark: the device worker synchronously drains the accumulated range before it
-/// accepts more dirtying writes. The hard drain constrains host page-cache exposure even when the
-/// guest never issues `FLUSH`.
-///
-/// Neither operation acknowledges guest durability. Guest `FLUSH` completion still depends on the
-/// existing full Imago sync after every earlier write has been processed by the block worker.
+/// The configured value is the single hard budget. A smaller batch target is derived internally
+/// to provide completion jitter headroom. Credits represent unique page-aligned extents and are
+/// released only after the background worker completes exact range writeback followed by a
+/// same-inode data-and-allocation-metadata barrier. Guest `FLUSH` remains governed by the existing
+/// full backing-image sync.
 pub(crate) struct BufferedWritebackController {
-    file: Arc<File>,
-    window: WritebackWindow,
+    hard_budget_bytes: u64,
+    batch_bytes: u64,
+    page_size: u64,
+    tracked: ExtentSet,
+    current_generation: u64,
+    current_extents: ExtentSet,
+    submitted: VecDeque<Generation>,
+    next_reservation: u64,
+    pending: Option<PendingReservation>,
+    latched_error: Option<LatchedError>,
+    health: Arc<SharedHealth>,
+    job_sender: Sender<WritebackJob>,
+    completion_receiver: Receiver<WritebackCompletion>,
+    shutdown_sender: Sender<()>,
+    worker: Option<JoinHandle<()>>,
 }
 
-impl BufferedWritebackController {
-    pub(crate) fn hard_limit_bytes(&self) -> u64 {
-        self.window.hard_limit_bytes
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl DirtyRange {
+    fn for_write(offset: u64, length: u64, page_size: u64) -> io::Result<Option<Self>> {
+        if length == 0 {
+            return Ok(None);
+        }
+
+        let end = offset.checked_add(length).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "writeback range overflow")
+        })?;
+        let start = offset - offset % page_size;
+        let end = align_up(end, page_size).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "writeback page-aligned range overflow",
+            )
+        })?;
+        Ok(Some(Self { start, end }))
     }
 
-    pub(crate) fn prepare_write(&mut self, length: u64) -> io::Result<()> {
-        if length > self.window.hard_limit_bytes {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "buffered block write exceeds the hard writeback watermark",
-            ));
+    fn len(self) -> u64 {
+        self.end - self.start
+    }
+
+    fn intersection_len(self, other: Self) -> u64 {
+        self.end
+            .min(other.end)
+            .saturating_sub(self.start.max(other.start))
+    }
+}
+
+impl ExtentSet {
+    fn is_empty(&self) -> bool {
+        self.ranges.is_empty()
+    }
+
+    fn additional_bytes(&self, range: DirtyRange) -> u64 {
+        let first = self
+            .ranges
+            .partition_point(|existing| existing.end <= range.start);
+        let covered = self.ranges[first..]
+            .iter()
+            .take_while(|existing| existing.start < range.end)
+            .map(|existing| existing.intersection_len(range))
+            .sum::<u64>();
+        range.len() - covered
+    }
+
+    fn extent_count_after_insert(&self, mut range: DirtyRange) -> usize {
+        let first = self
+            .ranges
+            .partition_point(|existing| existing.end < range.start);
+        let mut last = first;
+
+        while let Some(existing) = self.ranges.get(last).copied() {
+            if existing.start > range.end {
+                break;
+            }
+            range.end = range.end.max(existing.end);
+            last += 1;
         }
 
-        if let Some(range) = self.window.prepare_write(length) {
-            self.drain(range)?;
-            self.window.complete_drain();
+        self.ranges.len() - (last - first) + 1
+    }
+
+    fn insert(&mut self, mut range: DirtyRange) -> u64 {
+        let first = self
+            .ranges
+            .partition_point(|existing| existing.end < range.start);
+        let mut last = first;
+        let mut removed_bytes = 0;
+
+        while let Some(existing) = self.ranges.get(last).copied() {
+            if existing.start > range.end {
+                break;
+            }
+            range.start = range.start.min(existing.start);
+            range.end = range.end.max(existing.end);
+            removed_bytes += existing.len();
+            last += 1;
         }
+
+        let added_bytes = range.len() - removed_bytes;
+        self.ranges.splice(first..last, [range]);
+        self.bytes += added_bytes;
+        added_bytes
+    }
+
+    fn remove(&mut self, range: DirtyRange) -> u64 {
+        let first = self
+            .ranges
+            .partition_point(|existing| existing.end <= range.start);
+        let mut last = first;
+        let mut removed_bytes = 0;
+        let mut replacements = Vec::with_capacity(2);
+
+        while let Some(existing) = self.ranges.get(last).copied() {
+            if existing.start >= range.end {
+                break;
+            }
+
+            removed_bytes += existing.intersection_len(range);
+            if existing.start < range.start {
+                replacements.push(DirtyRange {
+                    start: existing.start,
+                    end: range.start,
+                });
+            }
+            if existing.end > range.end {
+                replacements.push(DirtyRange {
+                    start: range.end,
+                    end: existing.end,
+                });
+            }
+            last += 1;
+        }
+
+        self.ranges.splice(first..last, replacements);
+        self.bytes -= removed_bytes;
+        removed_bytes
+    }
+}
+
+impl SharedHealth {
+    fn new() -> Self {
+        Self {
+            healthy: AtomicBool::new(true),
+        }
+    }
+
+    fn is_healthy(&self) -> bool {
+        self.healthy.load(Ordering::Acquire)
+    }
+
+    fn mark_permanent_failure(&self) {
+        self.healthy.store(false, Ordering::Release);
+    }
+
+    fn mark_full_sync_success(&self) -> bool {
+        // A later success on the same file description does not prove that bytes associated with
+        // an earlier reported writeback error were recovered; errseq_t has already advanced.
+        self.is_healthy()
+    }
+}
+
+impl LatchedError {
+    fn capture(error: &io::Error) -> Self {
+        Self {
+            kind: error.kind(),
+            raw_os_error: error.raw_os_error(),
+            message: error.to_string(),
+        }
+    }
+
+    fn to_io_error(&self) -> io::Error {
+        match self.raw_os_error {
+            Some(code) => io::Error::new(self.kind, format!("{} (os error {code})", self.message)),
+            None => io::Error::new(self.kind, self.message.clone()),
+        }
+    }
+}
+
+impl WritebackReservation {
+    /// Number of bytes the caller may pass to the backing mutation.
+    pub(crate) fn len(&self) -> u64 {
+        self.length
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl WritebackBackend for SyncFileRangeBackend {
+    fn writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
+        let flags = libc::SYNC_FILE_RANGE_WRITE;
+
+        for range in ranges {
+            let offset = libc::off64_t::try_from(range.start).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "writeback range offset exceeds sync_file_range limits",
+                )
+            })?;
+            let length = libc::off64_t::try_from(range.len()).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "writeback range length exceeds sync_file_range limits",
+                )
+            })?;
+
+            // Safe: the backend owns a live descriptor for the exact backing inode. Ranges are
+            // validated, page-aligned integers and the flag is a Linux-defined constant. Do not
+            // use either WAIT flag here: file_fdatawait_range advances the file description's
+            // writeback-error cursor and could hide EIO/ENOSPC from the authoritative fdatasync.
+            let result =
+                unsafe { libc::sync_file_range(self.file.as_raw_fd(), offset, length, flags) };
+            if result != 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+
         Ok(())
     }
 
-    pub(crate) fn record_write(&mut self, offset: u64, length: u64) -> io::Result<()> {
-        match self.window.record_write(offset, length) {
-            Some(WritebackAction::Advisory(range)) => {
-                match self.sync_range(range, libc::SYNC_FILE_RANGE_WRITE) {
-                    Ok(()) => self.window.complete_advisory(),
-                    Err(error) => {
-                        // Keep the range and counters intact. A later write retries the advisory
-                        // operation, while the hard watermark still prevents unbounded dirtying.
-                        warn!(
-                            "Buffered block advisory writeback failed; retaining hard backpressure: {error}"
-                        );
-                    }
-                }
-                Ok(())
-            }
-            Some(WritebackAction::Drain(range)) => {
-                self.drain(range)?;
-                self.window.complete_drain();
-                Ok(())
-            }
-            None => Ok(()),
-        }
+    fn sync_data(&self) -> io::Result<()> {
+        // Unlike sync_file_range, fdatasync also orders the allocation and copy-on-write metadata
+        // needed to retrieve the written bytes. Credits are not reusable until this succeeds.
+        self.file.sync_data()
     }
+}
 
-    pub(crate) fn complete_flush(&mut self) {
-        self.window.complete_flush();
-    }
-
-    fn drain(&self, range: DirtyRange) -> io::Result<()> {
-        let flags = libc::SYNC_FILE_RANGE_WAIT_BEFORE
-            | libc::SYNC_FILE_RANGE_WRITE
-            | libc::SYNC_FILE_RANGE_WAIT_AFTER;
-        self.sync_range(range, flags).map_err(|error| {
-            warn!("Buffered block hard writeback drain failed; blocking further writes: {error}");
-            error
+#[cfg(target_os = "linux")]
+impl BufferedWritebackConfig {
+    pub(crate) fn new(file: Arc<File>, hard_budget_bytes: u64) -> io::Result<Self> {
+        let page_size = host_page_size()?;
+        validate_policy(hard_budget_bytes, page_size)?;
+        Ok(Self {
+            file,
+            hard_budget_bytes,
+            page_size,
+            health: Arc::new(SharedHealth::new()),
         })
     }
 
-    fn sync_range(&self, range: DirtyRange, flags: libc::c_uint) -> io::Result<()> {
-        let offset = libc::off64_t::try_from(range.start).map_err(|_| {
+    pub(crate) fn controller(&self) -> io::Result<BufferedWritebackController> {
+        if !self.health.is_healthy() {
+            return Err(io::Error::other(
+                "buffered writeback is permanently failed for this backing file",
+            ));
+        }
+
+        BufferedWritebackController::spawn_with_health(
+            Arc::new(SyncFileRangeBackend {
+                file: Arc::clone(&self.file),
+            }),
+            self.hard_budget_bytes,
+            self.page_size,
+            Arc::clone(&self.health),
+        )
+    }
+
+    /// Records a successful guest-visible full backing-file sync.
+    ///
+    /// Returns `false` when a permanent range-kick or controller failure must remain latched.
+    pub(crate) fn record_full_sync_success(&self) -> bool {
+        self.health.mark_full_sync_success()
+    }
+
+    /// Keeps future activations failed closed after a guest-visible full sync fails.
+    pub(crate) fn record_full_sync_failure(&self, error: &io::Error) {
+        warn!("Buffered block backing-file sync failed permanently: {error}");
+        self.health.mark_permanent_failure();
+    }
+}
+
+impl BufferedWritebackController {
+    #[cfg(test)]
+    fn spawn(
+        backend: Arc<dyn WritebackBackend>,
+        hard_budget_bytes: u64,
+        page_size: u64,
+    ) -> io::Result<Self> {
+        Self::spawn_with_health(
+            backend,
+            hard_budget_bytes,
+            page_size,
+            Arc::new(SharedHealth::new()),
+        )
+    }
+
+    fn spawn_with_health(
+        backend: Arc<dyn WritebackBackend>,
+        hard_budget_bytes: u64,
+        page_size: u64,
+        health: Arc<SharedHealth>,
+    ) -> io::Result<Self> {
+        validate_policy(hard_budget_bytes, page_size)?;
+        let batch_bytes = derive_batch_bytes(hard_budget_bytes, page_size);
+        let queue_capacity = queue_capacity(hard_budget_bytes, batch_bytes);
+        let (job_sender, job_receiver) = bounded(queue_capacity);
+        let (completion_sender, completion_receiver) = bounded(queue_capacity + 1);
+        let (shutdown_sender, shutdown_receiver) = bounded(1);
+        let worker = thread::Builder::new()
+            .name(WORKER_THREAD_NAME.to_string())
+            .spawn(move || {
+                run_worker(backend, job_receiver, completion_sender, shutdown_receiver)
+            })?;
+
+        Ok(Self {
+            hard_budget_bytes,
+            batch_bytes,
+            page_size,
+            tracked: ExtentSet::default(),
+            current_generation: 0,
+            current_extents: ExtentSet::default(),
+            submitted: VecDeque::new(),
+            next_reservation: 0,
+            pending: None,
+            latched_error: None,
+            health,
+            job_sender,
+            completion_receiver,
+            shutdown_sender,
+            worker: Some(worker),
+        })
+    }
+
+    /// Reserves budget for a prefix of a buffered backing mutation.
+    pub(crate) fn plan_write(
+        &mut self,
+        offset: u64,
+        requested_bytes: u64,
+    ) -> io::Result<WritebackReservation> {
+        if requested_bytes == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "cannot reserve an empty buffered write",
+            ));
+        }
+        offset.checked_add(requested_bytes).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "buffered write range overflow")
+        })?;
+        if self.pending.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "a buffered write reservation is already pending",
+            ));
+        }
+
+        loop {
+            self.reap_completions_while_latching();
+            self.check_error()?;
+
+            if let Some((length, range)) = self.plannable_prefix(offset, requested_bytes)? {
+                let id = self.next_reservation;
+                self.next_reservation = self
+                    .next_reservation
+                    .checked_add(1)
+                    .ok_or_else(|| io::Error::other("writeback reservation id exhausted"))?;
+                self.pending = Some(PendingReservation {
+                    id,
+                    offset,
+                    length,
+                    range,
+                });
+                return Ok(WritebackReservation { id, offset, length });
+            }
+
+            if !self.current_extents.is_empty() {
+                if let Err(error) = self.submit_current_generation() {
+                    self.latch_error(&error);
+                    return Err(self
+                        .latched_error
+                        .as_ref()
+                        .expect("submission failure must latch an error")
+                        .to_io_error());
+                }
+                continue;
+            }
+            if !self.has_in_flight_generations() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "writeback budget cannot admit one page",
+                ));
+            }
+            self.wait_for_completion()?;
+        }
+    }
+
+    /// Finalizes a reservation after the backing mutation returns.
+    pub(crate) fn finish_write(
+        &mut self,
+        reservation: WritebackReservation,
+        outcome: WritebackOutcome,
+    ) -> io::Result<()> {
+        let pending = self.pending.take().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "writeback range offset exceeds sync_file_range limits",
+                "buffered write reservation is not pending",
             )
         })?;
-        let length = libc::off64_t::try_from(range.len()).map_err(|_| {
-            io::Error::new(
+        if pending.id != reservation.id
+            || pending.offset != reservation.offset
+            || pending.length != reservation.length
+        {
+            self.pending = Some(pending);
+            return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "writeback range length exceeds sync_file_range limits",
+                "buffered write reservation does not match the pending plan",
+            ));
+        }
+
+        let committed_length = match outcome {
+            WritebackOutcome::Written(length) if length <= pending.length => length,
+            WritebackOutcome::Written(_) => {
+                self.pending = Some(pending);
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "buffered write exceeded its reservation",
+                ));
+            }
+            WritebackOutcome::Failed => pending.length,
+        };
+
+        self.reap_completions_while_latching();
+        if committed_length != 0 {
+            let range = if committed_length == pending.length {
+                pending.range
+            } else {
+                DirtyRange::for_write(pending.offset, committed_length, self.page_size)?
+                    .expect("non-empty committed write must have a range")
+            };
+            if let Err(error) = self.commit_range(range) {
+                self.latch_error(&error);
+            }
+        }
+
+        if self.current_extents.bytes >= self.batch_bytes {
+            if let Err(error) = self.submit_current_generation() {
+                self.latch_error(&error);
+            }
+        }
+        self.check_error()
+    }
+
+    /// Makes the background worker idle before the guest-visible full sync.
+    pub(crate) fn quiesce(&mut self) -> io::Result<()> {
+        if self.pending.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "cannot quiesce with a buffered write reservation pending",
+            ));
+        }
+
+        self.reap_completions_while_latching();
+        if !self.current_extents.is_empty() {
+            if let Err(error) = self.submit_current_generation() {
+                self.latch_error(&error);
+            }
+        }
+        while self.has_in_flight_generations() {
+            if let Err(error) = self.wait_for_completion_while_latching() {
+                self.mark_in_flight_failed();
+                debug_assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+            }
+        }
+        self.check_error()
+    }
+
+    /// Resets accounting after the existing full backing-image sync succeeds.
+    pub(crate) fn reset_after_flush(&mut self) -> bool {
+        if self.pending.is_some() || self.has_in_flight_generations() {
+            let error = io::Error::other(
+                "cannot reset writeback accounting before the controller is quiescent",
+            );
+            self.latch_error(&error);
+            return false;
+        }
+        self.tracked = ExtentSet::default();
+        self.current_extents = ExtentSet::default();
+        self.submitted.clear();
+        if self.latched_error.is_some() {
+            false
+        } else {
+            self.health.mark_full_sync_success()
+        }
+    }
+
+    fn plannable_prefix(
+        &self,
+        offset: u64,
+        requested_bytes: u64,
+    ) -> io::Result<Option<(u64, DirtyRange)>> {
+        let first_page = DirtyRange::for_write(offset, 1, self.page_size)?
+            .expect("non-empty requested write must have a range");
+        if self.current_extents.extent_count_after_insert(first_page) > MAX_EXTENTS_PER_GENERATION {
+            // Extending a range from a fixed start can only merge more existing extents. Refuse
+            // the first new disjoint page so the caller submits this underfilled generation.
+            return Ok(None);
+        }
+
+        let capped_length = requested_bytes.min(self.batch_bytes);
+        let mut low = 0;
+        let mut high = capped_length;
+
+        while low < high {
+            let candidate = low + (high - low).div_ceil(2);
+            let range = DirtyRange::for_write(offset, candidate, self.page_size)?
+                .expect("positive candidate must have a range");
+            let fits_batch = self
+                .current_extents
+                .bytes
+                .checked_add(self.current_extents.additional_bytes(range))
+                .is_some_and(|bytes| bytes <= self.batch_bytes);
+            let fits_hard = self
+                .tracked
+                .bytes
+                .checked_add(self.tracked.additional_bytes(range))
+                .is_some_and(|bytes| bytes <= self.hard_budget_bytes);
+            if fits_batch && fits_hard {
+                low = candidate;
+            } else {
+                high = candidate - 1;
+            }
+        }
+
+        if low == 0 {
+            Ok(None)
+        } else {
+            let range = DirtyRange::for_write(offset, low, self.page_size)?
+                .expect("positive planned write must have a range");
+            Ok(Some((low, range)))
+        }
+    }
+
+    fn commit_range(&mut self, range: DirtyRange) -> io::Result<()> {
+        let projected_batch = self
+            .current_extents
+            .bytes
+            .checked_add(self.current_extents.additional_bytes(range));
+        let projected_hard = self
+            .tracked
+            .bytes
+            .checked_add(self.tracked.additional_bytes(range));
+        if projected_batch.is_none_or(|bytes| bytes > self.batch_bytes)
+            || projected_hard.is_none_or(|bytes| bytes > self.hard_budget_bytes)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "completed buffered write exceeded its reservation",
+            ));
+        }
+
+        // Keep submitted extents immutable and bounded. Completion subtracts all newer ownership
+        // before releasing credits, so an older job can never release a rewritten page.
+        self.current_extents.insert(range);
+        self.tracked.insert(range);
+        Ok(())
+    }
+
+    fn submit_current_generation(&mut self) -> io::Result<()> {
+        if self.current_extents.is_empty() {
+            return Ok(());
+        }
+
+        let next_generation = self
+            .current_generation
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("writeback generation id exhausted"))?;
+        let job = WritebackJob {
+            generation: self.current_generation,
+            ranges: self.current_extents.ranges.clone(),
+        };
+        self.job_sender.send(job).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "writeback worker stopped accepting jobs",
             )
         })?;
 
-        // Safe: the controller owns a live descriptor for the exact backing inode reopened by
-        // Imago, and the remaining arguments are validated integers plus Linux-defined flags.
-        let result = unsafe { libc::sync_file_range(self.file.as_raw_fd(), offset, length, flags) };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(io::Error::last_os_error())
+        self.submitted.push_back(Generation {
+            id: self.current_generation,
+            extents: std::mem::take(&mut self.current_extents),
+            status: GenerationStatus::InFlight,
+        });
+        self.current_generation = next_generation;
+        Ok(())
+    }
+
+    fn reap_completions(&mut self) -> io::Result<()> {
+        loop {
+            match self.completion_receiver.try_recv() {
+                Ok(completion) => self.apply_completion(completion)?,
+                Err(TryRecvError::Empty) => return Ok(()),
+                Err(TryRecvError::Disconnected) if self.has_in_flight_generations() => {
+                    let error = io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "writeback worker completion channel disconnected",
+                    );
+                    self.latch_error(&error);
+                    return Err(error);
+                }
+                Err(TryRecvError::Disconnected) => return Ok(()),
+            }
+        }
+    }
+
+    fn reap_completions_while_latching(&mut self) {
+        let _ = self.reap_completions();
+    }
+
+    fn wait_for_completion(&mut self) -> io::Result<()> {
+        let completion = match self.completion_receiver.recv() {
+            Ok(completion) => completion,
+            Err(_) => {
+                let error = io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "writeback worker completion channel disconnected",
+                );
+                self.latch_error(&error);
+                return Err(error);
+            }
+        };
+        // Receiving any completion is forward progress. A range error is already latched by
+        // apply_completion, but quiesce must continue waiting for the remaining queued jobs.
+        let _ = self.apply_completion(completion);
+        Ok(())
+    }
+
+    fn wait_for_completion_while_latching(&mut self) -> io::Result<()> {
+        self.wait_for_completion()
+    }
+
+    fn apply_completion(&mut self, completion: WritebackCompletion) -> io::Result<()> {
+        let Some(position) = self
+            .submitted
+            .iter()
+            .position(|generation| generation.id == completion.generation)
+        else {
+            let error = io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "writeback worker completed unknown generation {}",
+                    completion.generation
+                ),
+            );
+            self.latch_error(&error);
+            return Err(error);
+        };
+        if self.submitted[position].status != GenerationStatus::InFlight {
+            let error = io::Error::new(
+                io::ErrorKind::InvalidData,
+                "writeback worker completed a generation more than once",
+            );
+            self.latch_error(&error);
+            return Err(error);
+        }
+
+        match completion.result {
+            Ok(()) => {
+                let generation = self
+                    .submitted
+                    .remove(position)
+                    .expect("located generation must still exist");
+                let mut releasable = generation.extents;
+                for newer_generation in &self.submitted {
+                    for range in &newer_generation.extents.ranges {
+                        releasable.remove(*range);
+                    }
+                }
+                for range in &self.current_extents.ranges {
+                    releasable.remove(*range);
+                }
+                for range in releasable.ranges {
+                    self.tracked.remove(range);
+                }
+                Ok(())
+            }
+            Err(failure) => {
+                self.submitted[position].status = GenerationStatus::Failed;
+                let error = failure.error;
+                let error = io::Error::new(
+                    error.kind(),
+                    format!(
+                        "writeback generation {} failed: {error}",
+                        completion.generation
+                    ),
+                );
+                self.latch_error(&error);
+                Err(error)
+            }
+        }
+    }
+
+    fn has_in_flight_generations(&self) -> bool {
+        self.submitted
+            .iter()
+            .any(|generation| generation.status == GenerationStatus::InFlight)
+    }
+
+    fn mark_in_flight_failed(&mut self) {
+        for generation in &mut self.submitted {
+            if generation.status == GenerationStatus::InFlight {
+                generation.status = GenerationStatus::Failed;
+            }
+        }
+    }
+
+    fn latch_error(&mut self, error: &io::Error) {
+        // The config retains this state after the controller is dropped, so reset/reactivation
+        // cannot erase a reported writeback error after its errseq_t cursor has advanced.
+        self.health.mark_permanent_failure();
+        if self.latched_error.is_none() {
+            warn!("Buffered block writeback failed closed: {error}");
+            self.latched_error = Some(LatchedError::capture(error));
+        }
+    }
+
+    fn check_error(&self) -> io::Result<()> {
+        match &self.latched_error {
+            Some(error) => Err(error.to_io_error()),
+            None if !self.health.is_healthy() => Err(io::Error::other(
+                "buffered writeback is permanently failed for this backing file",
+            )),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for BufferedWritebackController {
+    fn drop(&mut self) {
+        if let Err(error) = self.quiesce() {
+            warn!("Buffered block writeback did not quiesce during drop: {error}");
+        }
+        let _ = self.shutdown_sender.try_send(());
+        if let Some(worker) = self.worker.take() {
+            if worker.join().is_err() {
+                warn!("Buffered block writeback worker panicked");
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn align_down(value: u64, alignment: u64) -> u64 {
+    value - value % alignment
+}
+
+fn align_up(value: u64, alignment: u64) -> Option<u64> {
+    value
+        .checked_add(alignment - 1)
+        .map(|rounded| align_down(rounded, alignment))
+}
+
+#[cfg(target_os = "linux")]
+fn host_page_size() -> io::Result<u64> {
+    // Safe: sysconf has no pointer arguments or caller-owned memory requirements.
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if page_size <= 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(page_size as u64)
+    }
+}
+
+fn validate_policy(hard_budget_bytes: u64, page_size: u64) -> io::Result<()> {
+    if !page_size.is_power_of_two() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "writeback page size must be a non-zero power of two",
+        ));
+    }
+    if page_size > MINIMUM_BATCH_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "writeback page size exceeds the minimum batch size",
+        ));
+    }
+    if hard_budget_bytes < MINIMUM_WRITEBACK_BUDGET_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "writeback hard budget must be at least {MINIMUM_WRITEBACK_BUDGET_BYTES} bytes"
+            ),
+        ));
+    }
+    if align_down(hard_budget_bytes / 2, page_size) < page_size {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "writeback hard budget is too small for one batch",
+        ));
+    }
+    Ok(())
+}
+
+fn derive_batch_bytes(hard_budget_bytes: u64, page_size: u64) -> u64 {
+    let quarter_budget = align_down(hard_budget_bytes / BATCH_BUDGET_DIVISOR, page_size);
+    let target = quarter_budget.clamp(MINIMUM_BATCH_BYTES, MAXIMUM_BATCH_BYTES);
+    align_down(target, page_size).min(align_down(hard_budget_bytes / 2, page_size))
+}
+
+fn queue_capacity(hard_budget_bytes: u64, batch_bytes: u64) -> usize {
+    let batches = hard_budget_bytes.div_ceil(batch_bytes);
+    usize::try_from(batches)
+        .unwrap_or(MAX_QUEUED_BATCHES)
+        .clamp(1, MAX_QUEUED_BATCHES)
+}
+
+fn run_worker(
+    backend: Arc<dyn WritebackBackend>,
+    job_receiver: Receiver<WritebackJob>,
+    completion_sender: Sender<WritebackCompletion>,
+    shutdown_receiver: Receiver<()>,
+) {
+    // The completion channel is one slot larger than the job channel. Limit one coalesced group to
+    // that same size so the worker can always publish every result without deadlocking against a
+    // producer blocked on the bounded job queue.
+    let max_jobs_per_barrier = job_receiver
+        .capacity()
+        .unwrap_or(MAX_QUEUED_BATCHES)
+        .saturating_add(1);
+
+    loop {
+        let first_job = crossbeam_channel::select_biased! {
+            recv(shutdown_receiver) -> _ => return,
+            recv(job_receiver) -> job => {
+                let Ok(job) = job else {
+                    return;
+                };
+                job
+            }
+        };
+
+        let mut generations = Vec::with_capacity(max_jobs_per_barrier);
+        let mut next_job = first_job;
+        let mut first_range_error = None;
+        let mut jobs_disconnected = false;
+
+        loop {
+            if let Err(error) = backend.writeback(&next_job.ranges) {
+                first_range_error.get_or_insert((next_job.generation, error));
+            }
+            generations.push(next_job.generation);
+
+            if generations.len() == max_jobs_per_barrier {
+                break;
+            }
+            match job_receiver.try_recv() {
+                Ok(job) => next_job = job,
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    jobs_disconnected = true;
+                    break;
+                }
+            }
+        }
+
+        // sync_file_range does not guarantee allocation or COW metadata durability. One fdatasync
+        // covers every generation drained above and always runs, even after a failed range kick.
+        // The barrier cannot prove a nonzero kick result harmless, so that failure remains
+        // permanent and prevents every coalesced generation from releasing credit.
+        let barrier_error = backend.sync_data().err();
+        let group_failure = match (first_range_error, barrier_error) {
+            (Some((generation, range_error)), barrier_error) => {
+                if let Some(barrier_error) = barrier_error {
+                    warn!(
+                        "Range writeback kick for generation {generation} failed: {range_error}; \
+                         the containment data barrier also failed: {barrier_error}"
+                    );
+                } else {
+                    warn!(
+                        "Range writeback kick for generation {generation} failed closed after the \
+                         containment data barrier: {range_error}"
+                    );
+                }
+                Some(WritebackFailure {
+                    error: Arc::new(range_error),
+                })
+            }
+            (None, Some(barrier_error)) => Some(WritebackFailure {
+                error: Arc::new(barrier_error),
+            }),
+            (None, None) => None,
+        };
+
+        for generation in generations {
+            let completion = WritebackCompletion {
+                generation,
+                result: match &group_failure {
+                    None => Ok(()),
+                    Some(failure) => Err(failure.clone()),
+                },
+            };
+            crossbeam_channel::select_biased! {
+                recv(shutdown_receiver) -> _ => return,
+                send(completion_sender, completion) -> result => {
+                    if result.is_err() {
+                        return;
+                    }
+                }
+            }
+        }
+
+        if jobs_disconnected {
+            return;
         }
     }
 }
@@ -247,170 +1063,846 @@ impl BufferedWritebackController {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::OpenOptions;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    #[cfg(target_os = "linux")]
+    use std::os::unix::fs::FileExt;
+    use std::sync::{Condvar, Mutex};
+    use std::time::Duration;
+
+    #[cfg(target_os = "linux")]
+    use utils::tempfile::TempFile;
 
     use super::*;
 
-    #[test]
-    fn dirty_range_merges_out_of_order_writes() {
-        let first = DirtyRange::new(128, 64).unwrap();
-        let second = DirtyRange::new(32, 48).unwrap();
-        assert_eq!(
-            first.merge(second),
-            DirtyRange {
-                start: 32,
-                end: 192
+    const TEST_PAGE_SIZE: u64 = 4096;
+
+    #[derive(Default)]
+    struct FakeBackend {
+        calls: Mutex<Vec<Vec<DirtyRange>>>,
+        barrier_calls: Mutex<usize>,
+        barrier_failures: Mutex<VecDeque<io::ErrorKind>>,
+    }
+
+    impl WritebackBackend for FakeBackend {
+        fn writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
+            self.calls.lock().unwrap().push(ranges.to_vec());
+            Ok(())
+        }
+
+        fn sync_data(&self) -> io::Result<()> {
+            *self.barrier_calls.lock().unwrap() += 1;
+            match self.barrier_failures.lock().unwrap().pop_front() {
+                Some(kind) => Err(io::Error::new(kind, "injected data-barrier failure")),
+                None => Ok(()),
             }
-        );
+        }
+    }
+
+    impl FakeBackend {
+        fn fail_next_barrier(&self, kind: io::ErrorKind) {
+            self.barrier_failures.lock().unwrap().push_back(kind);
+        }
+
+        fn barrier_calls(&self) -> usize {
+            *self.barrier_calls.lock().unwrap()
+        }
+    }
+
+    #[derive(Default)]
+    struct GatedBackend {
+        changed: Condvar,
+        state: Mutex<GatedState>,
+    }
+
+    #[derive(Default)]
+    struct GatedState {
+        calls: Vec<Vec<DirtyRange>>,
+        permits: usize,
+    }
+
+    impl WritebackBackend for GatedBackend {
+        fn writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
+            let mut state = self.state.lock().unwrap();
+            state.calls.push(ranges.to_vec());
+            self.changed.notify_all();
+            while state.permits == 0 {
+                state = self.changed.wait(state).unwrap();
+            }
+            state.permits -= 1;
+            Ok(())
+        }
+
+        fn sync_data(&self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl GatedBackend {
+        fn allow(&self, jobs: usize) {
+            let mut state = self.state.lock().unwrap();
+            state.permits += jobs;
+            self.changed.notify_all();
+        }
+
+        fn wait_for_calls(&self, calls: usize) {
+            let mut state = self.state.lock().unwrap();
+            while state.calls.len() < calls {
+                let (new_state, timeout) = self
+                    .changed
+                    .wait_timeout(state, Duration::from_secs(5))
+                    .unwrap();
+                assert!(
+                    !timeout.timed_out(),
+                    "writeback worker did not receive a job"
+                );
+                state = new_state;
+            }
+        }
+
+        fn calls(&self) -> Vec<Vec<DirtyRange>> {
+            self.state.lock().unwrap().calls.clone()
+        }
+    }
+
+    #[derive(Default)]
+    struct BarrierGatedBackend {
+        changed: Condvar,
+        state: Mutex<BarrierGatedState>,
+    }
+
+    #[derive(Default)]
+    struct BarrierGatedState {
+        calls: Vec<Vec<DirtyRange>>,
+        writeback_permits: usize,
+        writeback_failures: VecDeque<io::ErrorKind>,
+        barrier_calls: usize,
+        barrier_permits: usize,
+        barrier_failures: VecDeque<io::ErrorKind>,
+    }
+
+    impl WritebackBackend for BarrierGatedBackend {
+        fn writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
+            let mut state = self.state.lock().unwrap();
+            state.calls.push(ranges.to_vec());
+            self.changed.notify_all();
+            while state.writeback_permits == 0 {
+                state = self.changed.wait(state).unwrap();
+            }
+            state.writeback_permits -= 1;
+            match state.writeback_failures.pop_front() {
+                Some(kind) => Err(io::Error::new(kind, "injected writeback failure")),
+                None => Ok(()),
+            }
+        }
+
+        fn sync_data(&self) -> io::Result<()> {
+            let mut state = self.state.lock().unwrap();
+            state.barrier_calls += 1;
+            self.changed.notify_all();
+            while state.barrier_permits == 0 {
+                state = self.changed.wait(state).unwrap();
+            }
+            state.barrier_permits -= 1;
+            match state.barrier_failures.pop_front() {
+                Some(kind) => Err(io::Error::new(kind, "injected data-barrier failure")),
+                None => Ok(()),
+            }
+        }
+    }
+
+    impl BarrierGatedBackend {
+        fn allow_writebacks(&self, jobs: usize) {
+            let mut state = self.state.lock().unwrap();
+            state.writeback_permits += jobs;
+            self.changed.notify_all();
+        }
+
+        fn allow_barriers(&self, barriers: usize) {
+            let mut state = self.state.lock().unwrap();
+            state.barrier_permits += barriers;
+            self.changed.notify_all();
+        }
+
+        fn fail_next_barrier(&self, kind: io::ErrorKind) {
+            self.state.lock().unwrap().barrier_failures.push_back(kind);
+        }
+
+        fn fail_next_writeback(&self, kind: io::ErrorKind) {
+            self.state
+                .lock()
+                .unwrap()
+                .writeback_failures
+                .push_back(kind);
+        }
+
+        fn wait_for_writebacks(&self, calls: usize) {
+            let mut state = self.state.lock().unwrap();
+            while state.calls.len() < calls {
+                let (new_state, timeout) = self
+                    .changed
+                    .wait_timeout(state, Duration::from_secs(5))
+                    .unwrap();
+                assert!(
+                    !timeout.timed_out(),
+                    "writeback worker did not process the expected ranges"
+                );
+                state = new_state;
+            }
+        }
+
+        fn wait_for_barriers(&self, calls: usize) {
+            let mut state = self.state.lock().unwrap();
+            while state.barrier_calls < calls {
+                let (new_state, timeout) = self
+                    .changed
+                    .wait_timeout(state, Duration::from_secs(5))
+                    .unwrap();
+                assert!(
+                    !timeout.timed_out(),
+                    "writeback worker did not reach the expected data barrier"
+                );
+                state = new_state;
+            }
+        }
+
+        fn calls(&self) -> Vec<Vec<DirtyRange>> {
+            self.state.lock().unwrap().calls.clone()
+        }
+
+        fn barrier_calls(&self) -> usize {
+            self.state.lock().unwrap().barrier_calls
+        }
+    }
+
+    struct PanicBackend;
+
+    impl WritebackBackend for PanicBackend {
+        fn writeback(&self, _ranges: &[DirtyRange]) -> io::Result<()> {
+            panic!("injected writeback worker panic");
+        }
+
+        fn sync_data(&self) -> io::Result<()> {
+            Ok(())
+        }
     }
 
     #[test]
-    fn rolling_window_rearms_without_a_guest_flush() {
-        let trigger = MINIMUM_RANGE_BYTES;
-        let mut window = WritebackWindow::new(trigger);
-
+    fn batch_policy_keeps_quarter_budget_jitter_headroom() {
         assert_eq!(
-            window.record_write(0, trigger),
-            Some(WritebackAction::Advisory(DirtyRange {
-                start: 0,
-                end: trigger,
-            }))
+            derive_batch_bytes(MINIMUM_WRITEBACK_BUDGET_BYTES, TEST_PAGE_SIZE),
+            MINIMUM_BATCH_BYTES
         );
-        window.complete_advisory();
-
         assert_eq!(
-            window.record_write(trigger, trigger),
-            Some(WritebackAction::Drain(DirtyRange {
-                start: 0,
-                end: trigger * 2,
-            }))
+            derive_batch_bytes(512 * 1024 * 1024, TEST_PAGE_SIZE),
+            128 * 1024 * 1024
         );
-        window.complete_drain();
-
         assert_eq!(
-            window.record_write(trigger * 2, trigger),
-            Some(WritebackAction::Advisory(DirtyRange {
-                start: trigger * 2,
-                end: trigger * 3,
-            }))
+            derive_batch_bytes(8 * 1024 * 1024 * 1024, TEST_PAGE_SIZE),
+            MAXIMUM_BATCH_BYTES
         );
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
-    fn projected_hard_limit_drains_before_another_write() {
-        let trigger = MINIMUM_RANGE_BYTES;
-        let mut window = WritebackWindow::new(trigger);
-        assert!(matches!(
-            window.record_write(0, trigger),
-            Some(WritebackAction::Advisory(_))
-        ));
-        window.complete_advisory();
-
-        assert_eq!(
-            window.prepare_write(trigger + 1),
-            Some(DirtyRange {
-                start: 0,
-                end: trigger,
-            })
-        );
-    }
-
-    #[test]
-    fn successful_guest_flush_resets_both_watermarks() {
-        let trigger = MINIMUM_RANGE_BYTES;
-        let mut window = WritebackWindow::new(trigger);
-        assert!(window.record_write(0, trigger).is_some());
-
-        window.complete_flush();
-
-        assert_eq!(window.batch_logical_bytes, 0);
-        assert_eq!(window.batch_range, None);
-        assert_eq!(window.outstanding_logical_bytes, 0);
-        assert_eq!(window.outstanding_range, None);
-        assert_eq!(window.prepare_write(trigger * 2), None);
-    }
-
-    #[test]
-    fn empty_write_does_not_change_the_window() {
-        let mut window = WritebackWindow::new(MINIMUM_RANGE_BYTES);
-        assert_eq!(window.record_write(1024, 0), None);
-        assert_eq!(window.batch_range, None);
-        assert_eq!(window.outstanding_range, None);
-    }
-
-    #[test]
-    fn oversized_request_cannot_bypass_the_hard_watermark() {
-        let path = temporary_file_path("oversized");
-        let file = OpenOptions::new()
-            .create_new(true)
-            .read(true)
-            .write(true)
-            .open(&path)
+    fn linux_backend_writes_back_and_syncs_a_regular_file() {
+        let backing = TempFile::new().unwrap();
+        backing.as_file().set_len(TEST_PAGE_SIZE * 2).unwrap();
+        backing
+            .as_file()
+            .write_all_at(&vec![0xa5; TEST_PAGE_SIZE as usize], 0)
             .unwrap();
-        let mut controller = BufferedWritebackController {
-            file: Arc::new(file),
-            window: WritebackWindow::new(MINIMUM_RANGE_BYTES),
+
+        let backend = SyncFileRangeBackend {
+            file: Arc::new(backing.as_file().try_clone().unwrap()),
         };
-
-        let error = controller
-            .prepare_write(MINIMUM_RANGE_BYTES * HARD_LIMIT_MULTIPLIER + 1)
-            .unwrap_err();
-        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
-
-        drop(controller);
-        std::fs::remove_file(path).unwrap();
+        backend
+            .writeback(&[DirtyRange {
+                start: 0,
+                end: TEST_PAGE_SIZE,
+            }])
+            .unwrap();
+        backend.sync_data().unwrap();
     }
 
     #[test]
-    fn regular_file_supports_advisory_and_hard_writeback() {
-        let path = temporary_file_path("regular");
-        let file = OpenOptions::new()
-            .create_new(true)
-            .read(true)
-            .write(true)
-            .open(&path)
-            .unwrap();
-        file.set_len(MINIMUM_RANGE_BYTES * 2).unwrap();
+    fn extent_set_preserves_holes_and_unique_bytes() {
+        let mut set = ExtentSet::default();
+        set.insert(DirtyRange {
+            start: 0,
+            end: 4096,
+        });
+        set.insert(DirtyRange {
+            start: 8192,
+            end: 12288,
+        });
+        set.insert(DirtyRange {
+            start: 0,
+            end: 4096,
+        });
 
-        let mut controller = BufferedWritebackController {
-            file: Arc::new(file),
-            window: WritebackWindow::new(MINIMUM_RANGE_BYTES),
-        };
-        controller.record_write(0, MINIMUM_RANGE_BYTES).unwrap();
+        assert_eq!(set.bytes, 8192);
+        assert_eq!(set.ranges.len(), 2);
+    }
+
+    #[test]
+    fn extent_removal_splits_without_collapsing_the_gap() {
+        let mut set = ExtentSet::default();
+        set.insert(DirtyRange {
+            start: 0,
+            end: 16384,
+        });
+        assert_eq!(
+            set.remove(DirtyRange {
+                start: 4096,
+                end: 12288
+            }),
+            8192
+        );
+        assert_eq!(
+            set.ranges,
+            vec![
+                DirtyRange {
+                    start: 0,
+                    end: 4096
+                },
+                DirtyRange {
+                    start: 12288,
+                    end: 16384
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn extent_set_matches_a_page_bitmap_under_mixed_updates() {
+        const PAGE_COUNT: usize = 31;
+
+        let mut set = ExtentSet::default();
+        let mut pages = [false; PAGE_COUNT];
+        let mut seed = 0x1234_5678_u64;
+
+        for _ in 0..1000 {
+            seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+            let start = (seed as usize) % PAGE_COUNT;
+            seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+            let end = (start + 1 + (seed as usize % (PAGE_COUNT - start))).min(PAGE_COUNT);
+            let range = DirtyRange {
+                start: start as u64 * TEST_PAGE_SIZE,
+                end: end as u64 * TEST_PAGE_SIZE,
+            };
+
+            if seed & 1 == 0 {
+                set.insert(range);
+                pages[start..end].fill(true);
+            } else {
+                set.remove(range);
+                pages[start..end].fill(false);
+            }
+
+            let expected_bytes =
+                pages.iter().filter(|dirty| **dirty).count() as u64 * TEST_PAGE_SIZE;
+            assert_eq!(set.bytes, expected_bytes);
+            assert_eq!(set.ranges, bitmap_ranges(&pages));
+            assert!(set.ranges.len() as u64 <= set.bytes / TEST_PAGE_SIZE);
+        }
+    }
+
+    #[test]
+    fn planner_caps_a_large_request_at_the_soft_batch() {
+        let backend = Arc::new(FakeBackend::default());
+        let mut controller = BufferedWritebackController::spawn(
+            backend,
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+        let reservation = controller
+            .plan_write(0, MINIMUM_WRITEBACK_BUDGET_BYTES)
+            .unwrap();
+        assert_eq!(reservation.len(), MINIMUM_BATCH_BYTES);
         controller
-            .record_write(MINIMUM_RANGE_BYTES, MINIMUM_RANGE_BYTES)
+            .finish_write(reservation, WritebackOutcome::Written(MINIMUM_BATCH_BYTES))
             .unwrap();
-        assert_eq!(controller.window.outstanding_range, None);
-
-        drop(controller);
-        std::fs::remove_file(path).unwrap();
     }
 
     #[test]
-    fn unsupported_file_cannot_bypass_the_hard_watermark() {
-        let unsupported = OpenOptions::new().write(true).open("/dev/null").unwrap();
-        let mut controller = BufferedWritebackController {
-            file: Arc::new(unsupported),
-            window: WritebackWindow::new(MINIMUM_RANGE_BYTES),
-        };
-
-        // The advisory failure is tolerated, but the accumulated range remains accounted.
-        controller.record_write(0, MINIMUM_RANGE_BYTES).unwrap();
-        assert!(controller
-            .record_write(MINIMUM_RANGE_BYTES, MINIMUM_RANGE_BYTES)
-            .is_err());
-        assert!(controller.prepare_write(1).is_err());
+    fn planner_accounts_for_page_alignment_at_the_batch_edge() {
+        let backend = Arc::new(FakeBackend::default());
+        let mut controller = BufferedWritebackController::spawn(
+            backend,
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+        let reservation = controller
+            .plan_write(512, MINIMUM_WRITEBACK_BUDGET_BYTES)
+            .unwrap();
+        assert_eq!(reservation.len(), MINIMUM_BATCH_BYTES - 512);
+        controller
+            .finish_write(
+                reservation,
+                WritebackOutcome::Written(MINIMUM_BATCH_BYTES - 512),
+            )
+            .unwrap();
+        assert_eq!(controller.tracked.bytes, MINIMUM_BATCH_BYTES);
     }
 
-    fn temporary_file_path(label: &str) -> std::path::PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        std::env::temp_dir().join(format!(
-            "libkrun-writeback-{label}-{}-{nonce}",
-            std::process::id()
-        ))
+    #[test]
+    fn planner_allows_only_one_pending_reservation() {
+        let backend = Arc::new(FakeBackend::default());
+        let mut controller = BufferedWritebackController::spawn(
+            backend,
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+        let reservation = controller.plan_write(0, 512).unwrap();
+        assert_eq!(
+            controller.plan_write(512, 512).unwrap_err().kind(),
+            io::ErrorKind::WouldBlock
+        );
+        controller
+            .finish_write(reservation, WritebackOutcome::Failed)
+            .unwrap();
+    }
+
+    #[test]
+    fn planner_submits_underfilled_generation_at_extent_limit() {
+        let backend = Arc::new(GatedBackend::default());
+        let mut controller = BufferedWritebackController::spawn(
+            backend.clone(),
+            MINIMUM_WRITEBACK_BUDGET_BYTES * 2,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+
+        // Populate a maximally fragmented generation without allocating or dirtying a large file.
+        for page in 0..MAX_EXTENTS_PER_GENERATION as u64 {
+            let range = DirtyRange {
+                start: page * TEST_PAGE_SIZE * 2,
+                end: page * TEST_PAGE_SIZE * 2 + TEST_PAGE_SIZE,
+            };
+            controller.current_extents.insert(range);
+            controller.tracked.insert(range);
+        }
+        assert!(controller.current_extents.bytes < controller.batch_bytes);
+
+        let next_offset = MAX_EXTENTS_PER_GENERATION as u64 * TEST_PAGE_SIZE * 2;
+        let reservation = controller.plan_write(next_offset, 512).unwrap();
+        backend.wait_for_calls(1);
+        controller
+            .finish_write(reservation, WritebackOutcome::Written(512))
+            .unwrap();
+
+        backend.allow(2);
+        controller.quiesce().unwrap();
+        let calls = backend.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].len(), MAX_EXTENTS_PER_GENERATION);
+        assert_eq!(calls[1].len(), 1);
+    }
+
+    #[test]
+    fn failed_mutation_conservatively_commits_the_full_reservation() {
+        let backend = Arc::new(FakeBackend::default());
+        let mut controller = BufferedWritebackController::spawn(
+            backend,
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+        let reservation = controller.plan_write(512, 512).unwrap();
+        controller
+            .finish_write(reservation, WritebackOutcome::Failed)
+            .unwrap();
+        assert_eq!(controller.tracked.bytes, TEST_PAGE_SIZE);
+    }
+
+    #[test]
+    fn successful_partial_write_commits_only_the_actual_prefix() {
+        let backend = Arc::new(FakeBackend::default());
+        let mut controller = BufferedWritebackController::spawn(
+            backend,
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+        let reservation = controller.plan_write(0, 8192).unwrap();
+        controller
+            .finish_write(reservation, WritebackOutcome::Written(4096))
+            .unwrap();
+        assert_eq!(controller.tracked.bytes, 4096);
+    }
+
+    #[test]
+    fn quiesce_sends_exact_disjoint_ranges() {
+        let backend = Arc::new(FakeBackend::default());
+        let mut controller = BufferedWritebackController::spawn(
+            backend.clone(),
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+        for offset in [0, 8192] {
+            let reservation = controller.plan_write(offset, 512).unwrap();
+            controller
+                .finish_write(reservation, WritebackOutcome::Written(512))
+                .unwrap();
+        }
+        controller.quiesce().unwrap();
+
+        assert_eq!(
+            backend.calls.lock().unwrap().as_slice(),
+            &[vec![
+                DirtyRange {
+                    start: 0,
+                    end: 4096
+                },
+                DirtyRange {
+                    start: 8192,
+                    end: 12288
+                },
+            ]]
+        );
+        assert_eq!(controller.tracked.bytes, 0);
+        assert_eq!(backend.barrier_calls(), 1);
+    }
+
+    #[test]
+    fn queued_generations_share_one_barrier_before_releasing_credit() {
+        let backend = Arc::new(BarrierGatedBackend::default());
+        let mut controller = BufferedWritebackController::spawn(
+            backend.clone(),
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+
+        submit_small_generation(&mut controller, 0);
+        backend.wait_for_writebacks(1);
+        submit_small_generation(&mut controller, TEST_PAGE_SIZE * 2);
+
+        backend.allow_writebacks(2);
+        backend.wait_for_writebacks(2);
+        backend.wait_for_barriers(1);
+
+        assert_eq!(backend.barrier_calls(), 1);
+        assert_eq!(backend.calls().len(), 2);
+        assert_eq!(controller.tracked.bytes, TEST_PAGE_SIZE * 2);
+        assert!(controller
+            .submitted
+            .iter()
+            .all(|generation| generation.status == GenerationStatus::InFlight));
+        assert_eq!(
+            controller.completion_receiver.try_recv().unwrap_err(),
+            TryRecvError::Empty
+        );
+
+        backend.allow_barriers(1);
+        controller.quiesce().unwrap();
+        assert_eq!(controller.tracked.bytes, 0);
+        assert!(controller.submitted.is_empty());
+        assert!(controller.health.is_healthy());
+    }
+
+    #[test]
+    fn barrier_failure_fails_every_coalesced_generation() {
+        let backend = Arc::new(BarrierGatedBackend::default());
+        backend.fail_next_barrier(io::ErrorKind::Other);
+        let mut controller = BufferedWritebackController::spawn(
+            backend.clone(),
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+
+        submit_small_generation(&mut controller, 0);
+        backend.wait_for_writebacks(1);
+        submit_small_generation(&mut controller, TEST_PAGE_SIZE * 2);
+
+        backend.allow_writebacks(2);
+        backend.wait_for_writebacks(2);
+        backend.wait_for_barriers(1);
+        backend.allow_barriers(1);
+
+        assert_eq!(
+            controller.quiesce().unwrap_err().kind(),
+            io::ErrorKind::Other
+        );
+        assert_eq!(controller.tracked.bytes, TEST_PAGE_SIZE * 2);
+        assert_eq!(controller.submitted.len(), 2);
+        assert!(controller
+            .submitted
+            .iter()
+            .all(|generation| generation.status == GenerationStatus::Failed));
+        assert!(controller.latched_error.is_some());
+        assert!(!controller.health.is_healthy());
+    }
+
+    #[test]
+    fn successful_data_barrier_does_not_hide_a_range_kick_failure() {
+        let backend = Arc::new(BarrierGatedBackend::default());
+        backend.fail_next_writeback(io::ErrorKind::Other);
+        let mut controller = BufferedWritebackController::spawn(
+            backend.clone(),
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+
+        submit_small_generation(&mut controller, 0);
+        backend.wait_for_writebacks(1);
+        submit_small_generation(&mut controller, TEST_PAGE_SIZE * 2);
+
+        backend.allow_writebacks(2);
+        backend.wait_for_writebacks(2);
+        backend.wait_for_barriers(1);
+        assert_eq!(controller.tracked.bytes, TEST_PAGE_SIZE * 2);
+        assert_eq!(
+            controller.completion_receiver.try_recv().unwrap_err(),
+            TryRecvError::Empty
+        );
+        backend.allow_barriers(1);
+
+        assert_eq!(
+            controller.quiesce().unwrap_err().kind(),
+            io::ErrorKind::Other
+        );
+
+        assert_eq!(backend.barrier_calls(), 1);
+        assert_eq!(controller.tracked.bytes, TEST_PAGE_SIZE * 2);
+        assert_eq!(controller.submitted.len(), 2);
+        assert!(controller
+            .submitted
+            .iter()
+            .all(|generation| generation.status == GenerationStatus::Failed));
+        assert!(controller.latched_error.is_some());
+        assert!(!controller.health.is_healthy());
+
+        // A later full sync cannot prove a failed range-kick path safe.
+        assert!(!controller.reset_after_flush());
+        assert!(controller.latched_error.is_some());
+        assert!(!controller.health.is_healthy());
+    }
+
+    #[test]
+    fn newer_generation_keeps_rewritten_page_charged() {
+        let backend = Arc::new(GatedBackend::default());
+        let mut controller = BufferedWritebackController::spawn(
+            backend.clone(),
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+
+        let first = controller.plan_write(0, MINIMUM_BATCH_BYTES).unwrap();
+        controller
+            .finish_write(first, WritebackOutcome::Written(MINIMUM_BATCH_BYTES))
+            .unwrap();
+        backend.wait_for_calls(1);
+
+        let rewrite = controller.plan_write(0, TEST_PAGE_SIZE).unwrap();
+        controller
+            .finish_write(rewrite, WritebackOutcome::Written(TEST_PAGE_SIZE))
+            .unwrap();
+        assert_eq!(controller.tracked.bytes, MINIMUM_BATCH_BYTES);
+        assert_eq!(controller.submitted[0].extents.bytes, MINIMUM_BATCH_BYTES);
+        assert_eq!(controller.current_extents.bytes, TEST_PAGE_SIZE);
+
+        backend.allow(2);
+        controller.quiesce().unwrap();
+        assert_eq!(controller.tracked.bytes, 0);
+        assert_eq!(
+            backend.calls(),
+            vec![
+                vec![DirtyRange {
+                    start: 0,
+                    end: MINIMUM_BATCH_BYTES,
+                }],
+                vec![DirtyRange {
+                    start: 0,
+                    end: TEST_PAGE_SIZE,
+                }],
+            ]
+        );
+    }
+
+    #[test]
+    fn worker_error_latches_without_releasing_credits() {
+        let backend = Arc::new(FakeBackend::default());
+        backend.fail_next_barrier(io::ErrorKind::Other);
+        let mut controller = BufferedWritebackController::spawn(
+            backend,
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+        let reservation = controller.plan_write(0, 512).unwrap();
+        controller
+            .finish_write(reservation, WritebackOutcome::Written(512))
+            .unwrap();
+
+        assert_eq!(
+            controller.quiesce().unwrap_err().kind(),
+            io::ErrorKind::Other
+        );
+        assert_eq!(controller.tracked.bytes, TEST_PAGE_SIZE);
+        assert!(controller.latched_error.is_some());
+        assert_eq!(
+            controller
+                .plan_write(TEST_PAGE_SIZE, 512)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::Other
+        );
+
+        // A later sync cannot prove that bytes behind an already-reported barrier error survived.
+        assert!(!controller.reset_after_flush());
+        assert_eq!(controller.tracked.bytes, 0);
+        assert!(controller.latched_error.is_some());
+        assert!(!controller.health.is_healthy());
+    }
+
+    #[test]
+    fn unsupported_backend_error_survives_full_sync_reset() {
+        let backend = Arc::new(FakeBackend::default());
+        backend.fail_next_barrier(io::ErrorKind::Unsupported);
+        let mut controller = BufferedWritebackController::spawn(
+            backend,
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+        let reservation = controller.plan_write(0, 512).unwrap();
+        controller
+            .finish_write(reservation, WritebackOutcome::Written(512))
+            .unwrap();
+
+        assert_eq!(
+            controller.quiesce().unwrap_err().kind(),
+            io::ErrorKind::Unsupported
+        );
+        assert!(controller.latched_error.is_some());
+
+        assert!(!controller.reset_after_flush());
+        assert!(controller.latched_error.is_some());
+        assert_eq!(
+            controller
+                .plan_write(TEST_PAGE_SIZE, 512)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::Unsupported
+        );
+    }
+
+    #[test]
+    fn full_sync_reset_does_not_revive_a_dead_worker() {
+        let mut controller = BufferedWritebackController::spawn(
+            Arc::new(PanicBackend),
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+        let reservation = controller.plan_write(0, 512).unwrap();
+        controller
+            .finish_write(reservation, WritebackOutcome::Written(512))
+            .unwrap();
+
+        assert_eq!(
+            controller.quiesce().unwrap_err().kind(),
+            io::ErrorKind::BrokenPipe
+        );
+        assert!(controller.latched_error.is_some());
+
+        assert!(!controller.reset_after_flush());
+        assert_eq!(controller.tracked.bytes, 0);
+        assert!(controller.latched_error.is_some());
+        assert_eq!(
+            controller
+                .plan_write(TEST_PAGE_SIZE, 512)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::BrokenPipe
+        );
+    }
+
+    #[test]
+    fn reset_after_flush_does_not_clear_a_reported_writeback_error() {
+        let backend = Arc::new(FakeBackend::default());
+        let mut controller = BufferedWritebackController::spawn(
+            backend,
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+        controller.latched_error = Some(LatchedError::capture(&io::Error::other("failed")));
+        controller.health.mark_permanent_failure();
+        assert!(!controller.reset_after_flush());
+        assert!(controller.latched_error.is_some());
+    }
+
+    #[test]
+    fn shared_full_sync_failure_stops_the_live_controller() {
+        let backend = Arc::new(FakeBackend::default());
+        let mut controller = BufferedWritebackController::spawn(
+            backend,
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+
+        controller.health.mark_permanent_failure();
+        assert_eq!(
+            controller.plan_write(0, 512).unwrap_err().kind(),
+            io::ErrorKind::Other
+        );
+        assert!(!controller.reset_after_flush());
+    }
+
+    #[test]
+    fn reset_before_quiesce_fails_permanently_without_clearing_reservation() {
+        let backend = Arc::new(FakeBackend::default());
+        let mut controller = BufferedWritebackController::spawn(
+            backend,
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+        let reservation = controller.plan_write(0, 512).unwrap();
+
+        assert!(!controller.reset_after_flush());
+        assert!(controller.pending.is_some());
+        assert!(controller.latched_error.is_some());
+        assert!(controller
+            .finish_write(reservation, WritebackOutcome::Written(0))
+            .is_err());
+    }
+
+    fn submit_small_generation(controller: &mut BufferedWritebackController, offset: u64) {
+        let reservation = controller.plan_write(offset, 512).unwrap();
+        controller
+            .finish_write(reservation, WritebackOutcome::Written(512))
+            .unwrap();
+        controller.submit_current_generation().unwrap();
+    }
+
+    fn bitmap_ranges(pages: &[bool]) -> Vec<DirtyRange> {
+        let mut ranges = Vec::new();
+        let mut page = 0;
+        while page < pages.len() {
+            if !pages[page] {
+                page += 1;
+                continue;
+            }
+
+            let start = page;
+            while page < pages.len() && pages[page] {
+                page += 1;
+            }
+            ranges.push(DirtyRange {
+                start: start as u64 * TEST_PAGE_SIZE,
+                end: page as u64 * TEST_PAGE_SIZE,
+            });
+        }
+        ranges
     }
 }

--- a/src/devices/src/virtio/block/writeback.rs
+++ b/src/devices/src/virtio/block/writeback.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use log::warn;
 
 pub(crate) const MINIMUM_RANGE_BYTES: u64 = 64 * 1024 * 1024;
+const HARD_LIMIT_MULTIPLIER: u64 = 2;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct DirtyRange {
@@ -40,56 +41,83 @@ impl DirtyRange {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WritebackAction {
+    Advisory(DirtyRange),
+    Drain(DirtyRange),
+}
+
 #[derive(Debug)]
 struct WritebackWindow {
     trigger_bytes: u64,
-    logical_bytes: u64,
-    dirty_range: Option<DirtyRange>,
-    submitted: bool,
+    hard_limit_bytes: u64,
+    batch_logical_bytes: u64,
+    batch_range: Option<DirtyRange>,
+    outstanding_logical_bytes: u64,
+    outstanding_range: Option<DirtyRange>,
 }
 
 impl WritebackWindow {
     fn new(trigger_bytes: u64) -> Self {
         Self {
             trigger_bytes,
-            logical_bytes: 0,
-            dirty_range: None,
-            submitted: false,
+            hard_limit_bytes: trigger_bytes.saturating_mul(HARD_LIMIT_MULTIPLIER),
+            batch_logical_bytes: 0,
+            batch_range: None,
+            outstanding_logical_bytes: 0,
+            outstanding_range: None,
         }
     }
 
-    fn record_write(&mut self, offset: u64, length: u64) -> Option<DirtyRange> {
-        // One advisory submission is enough to start background writeout for this durability
-        // epoch. Later writes are still covered by the mandatory full sync at guest flush time.
-        if self.submitted {
-            return None;
-        }
+    fn prepare_write(&self, length: u64) -> Option<DirtyRange> {
+        let projected_bytes = self.outstanding_logical_bytes.saturating_add(length);
+        (projected_bytes > self.hard_limit_bytes)
+            .then_some(self.outstanding_range)
+            .flatten()
+    }
 
+    fn record_write(&mut self, offset: u64, length: u64) -> Option<WritebackAction> {
         let range = DirtyRange::new(offset, length)?;
-        self.logical_bytes = self.logical_bytes.saturating_add(length);
-        self.dirty_range = Some(
-            self.dirty_range
+
+        self.batch_logical_bytes = self.batch_logical_bytes.saturating_add(length);
+        self.batch_range = Some(
+            self.batch_range
                 .map_or(range, |existing| existing.merge(range)),
         );
 
-        let dirty_range = self.dirty_range?;
-        if self.logical_bytes < self.trigger_bytes || dirty_range.len() < MINIMUM_RANGE_BYTES {
-            return None;
+        self.outstanding_logical_bytes = self.outstanding_logical_bytes.saturating_add(length);
+        self.outstanding_range = Some(
+            self.outstanding_range
+                .map_or(range, |existing| existing.merge(range)),
+        );
+
+        if self.outstanding_logical_bytes >= self.hard_limit_bytes {
+            return self.outstanding_range.map(WritebackAction::Drain);
         }
 
-        self.submitted = true;
-        Some(dirty_range)
+        let batch_range = self.batch_range?;
+        if self.batch_logical_bytes >= self.trigger_bytes
+            && batch_range.len() >= MINIMUM_RANGE_BYTES
+        {
+            return Some(WritebackAction::Advisory(batch_range));
+        }
+
+        None
     }
 
-    #[cfg(test)]
-    fn pending_range(&self) -> Option<DirtyRange> {
-        self.dirty_range
+    fn complete_advisory(&mut self) {
+        self.batch_logical_bytes = 0;
+        self.batch_range = None;
+    }
+
+    fn complete_drain(&mut self) {
+        self.complete_advisory();
+        self.outstanding_logical_bytes = 0;
+        self.outstanding_range = None;
     }
 
     fn complete_flush(&mut self) {
-        self.logical_bytes = 0;
-        self.dirty_range = None;
-        self.submitted = false;
+        self.complete_drain();
     }
 }
 
@@ -112,32 +140,65 @@ impl BufferedWritebackConfig {
         BufferedWritebackController {
             file: Arc::clone(&self.file),
             window: WritebackWindow::new(self.trigger_bytes),
-            disabled: false,
         }
     }
 }
 
-/// Schedules one advisory data-writeback range per guest durability epoch.
+/// Applies rolling advisory writeback and hard backpressure to one buffered raw-file block device.
 ///
-/// `sync_file_range(..., SYNC_FILE_RANGE_WRITE)` does not claim durability. Guest flush
-/// completion still depends on the existing full file sync after every earlier write has been
-/// processed by the block worker. This controller is a latency hint rather than a dirty-memory
-/// containment boundary: after the first submission, later writes wait for the mandatory guest
-/// flush. Hosts running untrusted guests must enforce memory and dirty-page limits independently.
+/// The configured threshold starts asynchronous range writeback. Twice that threshold is the hard
+/// logical-byte watermark: the device worker synchronously drains the accumulated range before it
+/// accepts more dirtying writes. The hard drain constrains host page-cache exposure even when the
+/// guest never issues `FLUSH`.
+///
+/// Neither operation acknowledges guest durability. Guest `FLUSH` completion still depends on the
+/// existing full Imago sync after every earlier write has been processed by the block worker.
 pub(crate) struct BufferedWritebackController {
     file: Arc<File>,
     window: WritebackWindow,
-    disabled: bool,
 }
 
 impl BufferedWritebackController {
-    pub(crate) fn record_write(&mut self, offset: u64, length: u64) {
-        if self.disabled {
-            return;
+    pub(crate) fn hard_limit_bytes(&self) -> u64 {
+        self.window.hard_limit_bytes
+    }
+
+    pub(crate) fn prepare_write(&mut self, length: u64) -> io::Result<()> {
+        if length > self.window.hard_limit_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "buffered block write exceeds the hard writeback watermark",
+            ));
         }
 
-        if let Some(range) = self.window.record_write(offset, length) {
-            self.submit(range);
+        if let Some(range) = self.window.prepare_write(length) {
+            self.drain(range)?;
+            self.window.complete_drain();
+        }
+        Ok(())
+    }
+
+    pub(crate) fn record_write(&mut self, offset: u64, length: u64) -> io::Result<()> {
+        match self.window.record_write(offset, length) {
+            Some(WritebackAction::Advisory(range)) => {
+                match self.sync_range(range, libc::SYNC_FILE_RANGE_WRITE) {
+                    Ok(()) => self.window.complete_advisory(),
+                    Err(error) => {
+                        // Keep the range and counters intact. A later write retries the advisory
+                        // operation, while the hard watermark still prevents unbounded dirtying.
+                        warn!(
+                            "Buffered block advisory writeback failed; retaining hard backpressure: {error}"
+                        );
+                    }
+                }
+                Ok(())
+            }
+            Some(WritebackAction::Drain(range)) => {
+                self.drain(range)?;
+                self.window.complete_drain();
+                Ok(())
+            }
+            None => Ok(()),
         }
     }
 
@@ -145,36 +206,38 @@ impl BufferedWritebackController {
         self.window.complete_flush();
     }
 
-    fn submit(&mut self, range: DirtyRange) {
-        let Ok(offset) = libc::off64_t::try_from(range.start) else {
-            self.disable("offset exceeds sync_file_range limits");
-            return;
-        };
-        let Ok(length) = libc::off64_t::try_from(range.len()) else {
-            self.disable("length exceeds sync_file_range limits");
-            return;
-        };
-
-        // Safe: the controller owns a live descriptor for the exact backing inode reopened by
-        // Imago, and the remaining arguments are validated integers plus a Linux-defined flag.
-        let result = unsafe {
-            libc::sync_file_range(
-                self.file.as_raw_fd(),
-                offset,
-                length,
-                libc::SYNC_FILE_RANGE_WRITE,
-            )
-        };
-        if result != 0 {
-            let error = io::Error::last_os_error();
-            warn!("Disabling buffered block preflush after sync_file_range failed: {error}");
-            self.disabled = true;
-        }
+    fn drain(&self, range: DirtyRange) -> io::Result<()> {
+        let flags = libc::SYNC_FILE_RANGE_WAIT_BEFORE
+            | libc::SYNC_FILE_RANGE_WRITE
+            | libc::SYNC_FILE_RANGE_WAIT_AFTER;
+        self.sync_range(range, flags).map_err(|error| {
+            warn!("Buffered block hard writeback drain failed; blocking further writes: {error}");
+            error
+        })
     }
 
-    fn disable(&mut self, reason: &str) {
-        warn!("Disabling buffered block preflush: {reason}");
-        self.disabled = true;
+    fn sync_range(&self, range: DirtyRange, flags: libc::c_uint) -> io::Result<()> {
+        let offset = libc::off64_t::try_from(range.start).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "writeback range offset exceeds sync_file_range limits",
+            )
+        })?;
+        let length = libc::off64_t::try_from(range.len()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "writeback range length exceeds sync_file_range limits",
+            )
+        })?;
+
+        // Safe: the controller owns a live descriptor for the exact backing inode reopened by
+        // Imago, and the remaining arguments are validated integers plus Linux-defined flags.
+        let result = unsafe { libc::sync_file_range(self.file.as_raw_fd(), offset, length, flags) };
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
     }
 }
 
@@ -203,53 +266,104 @@ mod tests {
     }
 
     #[test]
-    fn threshold_submits_only_once_until_durability_completes() {
-        let mut window = WritebackWindow::new(96 * 1024 * 1024);
-        assert_eq!(window.record_write(0, 64 * 1024 * 1024), None);
-        assert_eq!(
-            window.record_write(64 * 1024 * 1024, 32 * 1024 * 1024),
-            Some(DirtyRange {
-                start: 0,
-                end: 96 * 1024 * 1024
-            })
-        );
-        assert_eq!(
-            window.pending_range(),
-            Some(DirtyRange {
-                start: 0,
-                end: 96 * 1024 * 1024
-            })
-        );
+    fn rolling_window_rearms_without_a_guest_flush() {
+        let trigger = MINIMUM_RANGE_BYTES;
+        let mut window = WritebackWindow::new(trigger);
 
-        assert_eq!(window.record_write(256 * 1024 * 1024, 512), None);
         assert_eq!(
-            window.pending_range(),
+            window.record_write(0, trigger),
+            Some(WritebackAction::Advisory(DirtyRange {
+                start: 0,
+                end: trigger,
+            }))
+        );
+        window.complete_advisory();
+
+        assert_eq!(
+            window.record_write(trigger, trigger),
+            Some(WritebackAction::Drain(DirtyRange {
+                start: 0,
+                end: trigger * 2,
+            }))
+        );
+        window.complete_drain();
+
+        assert_eq!(
+            window.record_write(trigger * 2, trigger),
+            Some(WritebackAction::Advisory(DirtyRange {
+                start: trigger * 2,
+                end: trigger * 3,
+            }))
+        );
+    }
+
+    #[test]
+    fn projected_hard_limit_drains_before_another_write() {
+        let trigger = MINIMUM_RANGE_BYTES;
+        let mut window = WritebackWindow::new(trigger);
+        assert!(matches!(
+            window.record_write(0, trigger),
+            Some(WritebackAction::Advisory(_))
+        ));
+        window.complete_advisory();
+
+        assert_eq!(
+            window.prepare_write(trigger + 1),
             Some(DirtyRange {
                 start: 0,
-                end: 96 * 1024 * 1024
+                end: trigger,
             })
         );
+    }
+
+    #[test]
+    fn successful_guest_flush_resets_both_watermarks() {
+        let trigger = MINIMUM_RANGE_BYTES;
+        let mut window = WritebackWindow::new(trigger);
+        assert!(window.record_write(0, trigger).is_some());
 
         window.complete_flush();
-        assert_eq!(window.pending_range(), None);
-        assert_eq!(
-            window.record_write(512 * 1024 * 1024, 96 * 1024 * 1024),
-            Some(DirtyRange {
-                start: 512 * 1024 * 1024,
-                end: 608 * 1024 * 1024
-            })
-        );
+
+        assert_eq!(window.batch_logical_bytes, 0);
+        assert_eq!(window.batch_range, None);
+        assert_eq!(window.outstanding_logical_bytes, 0);
+        assert_eq!(window.outstanding_range, None);
+        assert_eq!(window.prepare_write(trigger * 2), None);
     }
 
     #[test]
     fn empty_write_does_not_change_the_window() {
-        let mut window = WritebackWindow::new(1);
+        let mut window = WritebackWindow::new(MINIMUM_RANGE_BYTES);
         assert_eq!(window.record_write(1024, 0), None);
-        assert_eq!(window.pending_range(), None);
+        assert_eq!(window.batch_range, None);
+        assert_eq!(window.outstanding_range, None);
     }
 
     #[test]
-    fn regular_file_accepts_advisory_writeback() {
+    fn oversized_request_cannot_bypass_the_hard_watermark() {
+        let path = temporary_file_path("oversized");
+        let file = OpenOptions::new()
+            .create_new(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        let mut controller = BufferedWritebackController {
+            file: Arc::new(file),
+            window: WritebackWindow::new(MINIMUM_RANGE_BYTES),
+        };
+
+        let error = controller
+            .prepare_write(MINIMUM_RANGE_BYTES * HARD_LIMIT_MULTIPLIER + 1)
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+
+        drop(controller);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn regular_file_supports_advisory_and_hard_writeback() {
         let path = temporary_file_path("regular");
         let file = OpenOptions::new()
             .create_new(true)
@@ -257,38 +371,36 @@ mod tests {
             .write(true)
             .open(&path)
             .unwrap();
-        file.set_len(MINIMUM_RANGE_BYTES).unwrap();
+        file.set_len(MINIMUM_RANGE_BYTES * 2).unwrap();
 
         let mut controller = BufferedWritebackController {
             file: Arc::new(file),
-            window: WritebackWindow::new(1),
-            disabled: false,
+            window: WritebackWindow::new(MINIMUM_RANGE_BYTES),
         };
-        controller.record_write(0, MINIMUM_RANGE_BYTES);
-        assert!(!controller.disabled);
-        assert_eq!(
-            controller.window.pending_range(),
-            Some(DirtyRange {
-                start: 0,
-                end: MINIMUM_RANGE_BYTES
-            })
-        );
+        controller.record_write(0, MINIMUM_RANGE_BYTES).unwrap();
+        controller
+            .record_write(MINIMUM_RANGE_BYTES, MINIMUM_RANGE_BYTES)
+            .unwrap();
+        assert_eq!(controller.window.outstanding_range, None);
 
         drop(controller);
         std::fs::remove_file(path).unwrap();
     }
 
     #[test]
-    fn unsupported_file_disables_only_the_advisory_controller() {
+    fn unsupported_file_cannot_bypass_the_hard_watermark() {
         let unsupported = OpenOptions::new().write(true).open("/dev/null").unwrap();
         let mut controller = BufferedWritebackController {
             file: Arc::new(unsupported),
-            window: WritebackWindow::new(1),
-            disabled: false,
+            window: WritebackWindow::new(MINIMUM_RANGE_BYTES),
         };
 
-        controller.record_write(0, MINIMUM_RANGE_BYTES);
-        assert!(controller.disabled);
+        // The advisory failure is tolerated, but the accumulated range remains accounted.
+        controller.record_write(0, MINIMUM_RANGE_BYTES).unwrap();
+        assert!(controller
+            .record_write(MINIMUM_RANGE_BYTES, MINIMUM_RANGE_BYTES)
+            .is_err());
+        assert!(controller.prepare_write(1).is_err());
     }
 
     fn temporary_file_path(label: &str) -> std::path::PathBuf {

--- a/src/devices/src/virtio/block/writeback.rs
+++ b/src/devices/src/virtio/block/writeback.rs
@@ -53,6 +53,7 @@ struct WritebackWindow {
     trigger_bytes: u64,
     logical_bytes: u64,
     dirty_range: Option<DirtyRange>,
+    submitted: bool,
 }
 
 impl WritebackWindow {
@@ -61,10 +62,17 @@ impl WritebackWindow {
             trigger_bytes,
             logical_bytes: 0,
             dirty_range: None,
+            submitted: false,
         }
     }
 
     fn record_write(&mut self, offset: u64, length: u64) -> Option<DirtyRange> {
+        // One advisory submission is enough to start background writeout for this durability
+        // epoch. Later writes are still covered by the mandatory full sync at guest flush time.
+        if self.submitted {
+            return None;
+        }
+
         let range = DirtyRange::new(offset, length)?;
         self.logical_bytes = self.logical_bytes.saturating_add(length);
         self.dirty_range = Some(
@@ -77,8 +85,7 @@ impl WritebackWindow {
             return None;
         }
 
-        self.logical_bytes = 0;
-        self.dirty_range = None;
+        self.submitted = true;
         Some(dirty_range)
     }
 
@@ -89,6 +96,39 @@ impl WritebackWindow {
     fn complete_flush(&mut self) {
         self.logical_bytes = 0;
         self.dirty_range = None;
+        self.submitted = false;
+    }
+}
+
+/// Immutable inputs used to create a fresh controller when a block device is reactivated.
+#[derive(Clone)]
+pub(crate) struct BufferedWritebackConfig {
+    file: Arc<File>,
+    trigger_bytes: u64,
+}
+
+impl BufferedWritebackConfig {
+    pub(crate) fn from_environment(file: Arc<File>) -> Option<Self> {
+        let trigger_bytes = env::var(TRIGGER_ENV)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_TRIGGER_BYTES);
+        if trigger_bytes == 0 {
+            return None;
+        }
+
+        Some(Self {
+            file,
+            trigger_bytes,
+        })
+    }
+
+    pub(crate) fn controller(&self) -> BufferedWritebackController {
+        BufferedWritebackController {
+            file: Arc::clone(&self.file),
+            window: WritebackWindow::new(self.trigger_bytes),
+            disabled: false,
+        }
     }
 }
 
@@ -104,38 +144,12 @@ pub(crate) struct BufferedWritebackController {
 }
 
 impl BufferedWritebackController {
-    pub(crate) fn from_environment(file: Arc<File>) -> Option<Self> {
-        let trigger_bytes = env::var(TRIGGER_ENV)
-            .ok()
-            .and_then(|value| value.parse().ok())
-            .unwrap_or(DEFAULT_TRIGGER_BYTES);
-        if trigger_bytes == 0 {
-            return None;
-        }
-
-        Some(Self {
-            file,
-            window: WritebackWindow::new(trigger_bytes),
-            disabled: false,
-        })
-    }
-
     pub(crate) fn record_write(&mut self, offset: u64, length: u64) {
         if self.disabled {
             return;
         }
 
         if let Some(range) = self.window.record_write(offset, length) {
-            self.submit(range);
-        }
-    }
-
-    pub(crate) fn prepare_flush(&mut self) {
-        if self.disabled {
-            return;
-        }
-
-        if let Some(range) = self.window.pending_range() {
             self.submit(range);
         }
     }
@@ -154,8 +168,8 @@ impl BufferedWritebackController {
             return;
         };
 
-        // Safe: the controller owns a live duplicate of the exact file object used by Imago, and
-        // the remaining arguments are validated integer values and a Linux-defined flag.
+        // Safe: the controller owns a live descriptor for the exact backing inode reopened by
+        // Imago, and the remaining arguments are validated integers plus a Linux-defined flag.
         let result = unsafe {
             libc::sync_file_range(
                 self.file.as_raw_fd(),
@@ -202,7 +216,7 @@ mod tests {
     }
 
     #[test]
-    fn threshold_submits_one_coalesced_range_and_starts_a_new_window() {
+    fn threshold_submits_only_once_until_durability_completes() {
         let mut window = WritebackWindow::new(96 * 1024 * 1024);
         assert_eq!(window.record_write(0, 64 * 1024 * 1024), None);
         assert_eq!(
@@ -212,31 +226,32 @@ mod tests {
                 end: 96 * 1024 * 1024
             })
         );
-        assert_eq!(window.pending_range(), None);
+        assert_eq!(
+            window.pending_range(),
+            Some(DirtyRange {
+                start: 0,
+                end: 96 * 1024 * 1024
+            })
+        );
 
         assert_eq!(window.record_write(256 * 1024 * 1024, 512), None);
         assert_eq!(
             window.pending_range(),
             Some(DirtyRange {
-                start: 256 * 1024 * 1024,
-                end: 256 * 1024 * 1024 + 512
+                start: 0,
+                end: 96 * 1024 * 1024
             })
         );
-    }
-
-    #[test]
-    fn flush_keeps_pending_range_until_durability_completes() {
-        let mut window = WritebackWindow::new(u64::MAX);
-        window.record_write(4096, 128 * 1024 * 1024);
-        let expected = DirtyRange {
-            start: 4096,
-            end: 4096 + 128 * 1024 * 1024,
-        };
-        assert_eq!(window.pending_range(), Some(expected));
-        assert_eq!(window.pending_range(), Some(expected));
 
         window.complete_flush();
         assert_eq!(window.pending_range(), None);
+        assert_eq!(
+            window.record_write(512 * 1024 * 1024, 96 * 1024 * 1024),
+            Some(DirtyRange {
+                start: 512 * 1024 * 1024,
+                end: 608 * 1024 * 1024
+            })
+        );
     }
 
     #[test]
@@ -264,7 +279,13 @@ mod tests {
         };
         controller.record_write(0, MINIMUM_RANGE_BYTES);
         assert!(!controller.disabled);
-        assert_eq!(controller.window.pending_range(), None);
+        assert_eq!(
+            controller.window.pending_range(),
+            Some(DirtyRange {
+                start: 0,
+                end: MINIMUM_RANGE_BYTES
+            })
+        );
 
         drop(controller);
         std::fs::remove_file(path).unwrap();

--- a/src/devices/src/virtio/block/writeback.rs
+++ b/src/devices/src/virtio/block/writeback.rs
@@ -9,12 +9,10 @@ use std::sync::Arc;
 
 use log::warn;
 
-// Heavy sequential writers in the measured guest issued about 16 GiB between durability
-// barriers. Starting one advisory writeback near the end of that interval leaves the final fsync
-// responsible for durability while giving Linux time to drain dirty pages on an otherwise-idle
-// device. The environment override is intentionally internal and exists for controlled host
-// tuning; zero disables advisory writeback without changing the guest-visible cache contract.
-const DEFAULT_TRIGGER_BYTES: u64 = 12 * 1024 * 1024 * 1024;
+// Starting one advisory writeback before a guest durability barrier can bound host dirty memory,
+// but the measured 12 GiB policy reduced sequential-write throughput. Keep this mechanism opt-in
+// through an internal environment override until the host runtime selects a workload-aware policy;
+// zero, an invalid value and an unset variable all preserve the existing writeback behavior.
 const MINIMUM_RANGE_BYTES: u64 = 64 * 1024 * 1024;
 const TRIGGER_ENV: &str = "KRUN_BLOCK_WRITEBACK_PREFLUSH_BYTES";
 
@@ -89,6 +87,7 @@ impl WritebackWindow {
         Some(dirty_range)
     }
 
+    #[cfg(test)]
     fn pending_range(&self) -> Option<DirtyRange> {
         self.dirty_range
     }
@@ -109,13 +108,8 @@ pub(crate) struct BufferedWritebackConfig {
 
 impl BufferedWritebackConfig {
     pub(crate) fn from_environment(file: Arc<File>) -> Option<Self> {
-        let trigger_bytes = env::var(TRIGGER_ENV)
-            .ok()
-            .and_then(|value| value.parse().ok())
-            .unwrap_or(DEFAULT_TRIGGER_BYTES);
-        if trigger_bytes == 0 {
-            return None;
-        }
+        let value = env::var(TRIGGER_ENV).ok();
+        let trigger_bytes = parse_trigger_bytes(value.as_deref())?;
 
         Some(Self {
             file,
@@ -192,6 +186,14 @@ impl BufferedWritebackController {
 }
 
 //--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn parse_trigger_bytes(value: Option<&str>) -> Option<u64> {
+    value?.parse().ok().filter(|bytes| *bytes > 0)
+}
+
+//--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
 
@@ -259,6 +261,15 @@ mod tests {
         let mut window = WritebackWindow::new(1);
         assert_eq!(window.record_write(1024, 0), None);
         assert_eq!(window.pending_range(), None);
+    }
+
+    #[test]
+    fn preflush_requires_an_explicit_positive_threshold() {
+        assert_eq!(parse_trigger_bytes(None), None);
+        assert_eq!(parse_trigger_bytes(Some("")), None);
+        assert_eq!(parse_trigger_bytes(Some("invalid")), None);
+        assert_eq!(parse_trigger_bytes(Some("0")), None);
+        assert_eq!(parse_trigger_bytes(Some("128")), Some(128));
     }
 
     #[test]

--- a/src/devices/src/virtio/block/writeback.rs
+++ b/src/devices/src/virtio/block/writeback.rs
@@ -1,7 +1,6 @@
 // Copyright 2026 The Microsandbox Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
 use std::fs::File;
 use std::io;
 use std::os::fd::AsRawFd;
@@ -9,12 +8,7 @@ use std::sync::Arc;
 
 use log::warn;
 
-// Starting one advisory writeback before a guest durability barrier can bound host dirty memory,
-// but the measured 12 GiB policy reduced sequential-write throughput. Keep this mechanism opt-in
-// through an internal environment override until the host runtime selects a workload-aware policy;
-// zero, an invalid value and an unset variable all preserve the existing writeback behavior.
-const MINIMUM_RANGE_BYTES: u64 = 64 * 1024 * 1024;
-const TRIGGER_ENV: &str = "KRUN_BLOCK_WRITEBACK_PREFLUSH_BYTES";
+pub(crate) const MINIMUM_RANGE_BYTES: u64 = 64 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct DirtyRange {
@@ -107,14 +101,11 @@ pub(crate) struct BufferedWritebackConfig {
 }
 
 impl BufferedWritebackConfig {
-    pub(crate) fn from_environment(file: Arc<File>) -> Option<Self> {
-        let value = env::var(TRIGGER_ENV).ok();
-        let trigger_bytes = parse_trigger_bytes(value.as_deref())?;
-
-        Some(Self {
+    pub(crate) fn new(file: Arc<File>, trigger_bytes: u64) -> Self {
+        Self {
             file,
             trigger_bytes,
-        })
+        }
     }
 
     pub(crate) fn controller(&self) -> BufferedWritebackController {
@@ -186,14 +177,6 @@ impl BufferedWritebackController {
 }
 
 //--------------------------------------------------------------------------------------------------
-// Functions
-//--------------------------------------------------------------------------------------------------
-
-fn parse_trigger_bytes(value: Option<&str>) -> Option<u64> {
-    value?.parse().ok().filter(|bytes| *bytes > 0)
-}
-
-//--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
 
@@ -261,15 +244,6 @@ mod tests {
         let mut window = WritebackWindow::new(1);
         assert_eq!(window.record_write(1024, 0), None);
         assert_eq!(window.pending_range(), None);
-    }
-
-    #[test]
-    fn preflush_requires_an_explicit_positive_threshold() {
-        assert_eq!(parse_trigger_bytes(None), None);
-        assert_eq!(parse_trigger_bytes(Some("")), None);
-        assert_eq!(parse_trigger_bytes(Some("invalid")), None);
-        assert_eq!(parse_trigger_bytes(Some("0")), None);
-        assert_eq!(parse_trigger_bytes(Some("128")), Some(128));
     }
 
     #[test]

--- a/src/devices/src/virtio/block/writeback.rs
+++ b/src/devices/src/virtio/block/writeback.rs
@@ -21,16 +21,15 @@ use log::warn;
 /// Smallest supported per-device hard writeback budget.
 pub(crate) const MINIMUM_WRITEBACK_BUDGET_BYTES: u64 = 128 * 1024 * 1024;
 
-const MINIMUM_BATCH_BYTES: u64 = 32 * 1024 * 1024;
-const MAXIMUM_BATCH_BYTES: u64 = 256 * 1024 * 1024;
-const BATCH_BUDGET_DIVISOR: u64 = 4;
+const MINIMUM_RETIREMENT_BYTES: u64 = 32 * 1024 * 1024;
 /// Maximum exact disjoint ranges retained in one generation before it is submitted early.
 ///
 /// This bounds both controller metadata and the number of `sync_file_range` calls in one job
 /// independently of the caller-supplied hard byte budget. At 4 KiB per page, 8192 extents cover
-/// the full 32 MiB minimum batch while limiting one job's range vector to roughly 128 KiB.
+/// a 32 MiB minimally fragmented retirement while limiting one job's range vector to roughly
+/// 128 KiB.
 const MAX_EXTENTS_PER_GENERATION: usize = 8192;
-const MAX_QUEUED_BATCHES: usize = 64;
+const MAX_QUEUED_GENERATIONS: usize = 64;
 const WORKER_THREAD_NAME: &str = "virtio-blk-writeback";
 
 //--------------------------------------------------------------------------------------------------
@@ -141,15 +140,14 @@ pub(crate) struct BufferedWritebackConfig {
 
 /// Bounds buffered dirty data and moves range writeback off the virtio block worker.
 ///
-/// The configured value is the single hard budget. A smaller batch target is derived internally
-/// to provide completion jitter headroom. Credits represent unique page-aligned extents and are
-/// released only after the background worker completes exact range writeback. This bounds dirty
-/// file data without turning each internal batch into a durability boundary. Guest `FLUSH`
-/// remains governed by the existing full backing-image sync, including the data-retrieval metadata
-/// required by the host filesystem.
+/// The configured value is the single hard budget. Credits represent unique page-aligned extents
+/// and are released only after the background worker completes exact range writeback. Hot rewrites
+/// remain inside their already-reserved finite window; retirement starts only when a new unique page
+/// cannot fit or metadata fragmentation reaches its explicit bound. Guest `FLUSH` remains governed
+/// by the existing full backing-image sync, including the data-retrieval metadata required by the
+/// host filesystem.
 pub(crate) struct BufferedWritebackController {
     hard_budget_bytes: u64,
-    batch_bytes: u64,
     page_size: u64,
     tracked: ExtentSet,
     current_generation: u64,
@@ -449,8 +447,7 @@ impl BufferedWritebackController {
         health: Arc<SharedHealth>,
     ) -> io::Result<Self> {
         validate_policy(hard_budget_bytes, page_size)?;
-        let batch_bytes = derive_batch_bytes(hard_budget_bytes, page_size);
-        let queue_capacity = queue_capacity(hard_budget_bytes, batch_bytes);
+        let queue_capacity = queue_capacity(hard_budget_bytes);
         let (job_sender, job_receiver) = bounded(queue_capacity);
         let (completion_sender, completion_receiver) = bounded(queue_capacity + 1);
         let (shutdown_sender, shutdown_receiver) = bounded(1);
@@ -462,7 +459,6 @@ impl BufferedWritebackController {
 
         Ok(Self {
             hard_budget_bytes,
-            batch_bytes,
             page_size,
             tracked: ExtentSet::default(),
             current_generation: 0,
@@ -589,11 +585,6 @@ impl BufferedWritebackController {
             }
         }
 
-        if self.current_extents.bytes >= self.batch_bytes {
-            if let Err(error) = self.submit_current_generation() {
-                self.latch_error(&error);
-            }
-        }
         self.check_error()
     }
 
@@ -653,7 +644,7 @@ impl BufferedWritebackController {
             return Ok(None);
         }
 
-        let capped_length = requested_bytes.min(self.batch_bytes);
+        let capped_length = requested_bytes.min(self.hard_budget_bytes);
         let mut low = 0;
         let mut high = capped_length;
 
@@ -661,17 +652,17 @@ impl BufferedWritebackController {
             let candidate = low + (high - low).div_ceil(2);
             let range = DirtyRange::for_write(offset, candidate, self.page_size)?
                 .expect("positive candidate must have a range");
-            let fits_batch = self
+            let fits_generation = self
                 .current_extents
                 .bytes
                 .checked_add(self.current_extents.additional_bytes(range))
-                .is_some_and(|bytes| bytes <= self.batch_bytes);
+                .is_some_and(|bytes| bytes <= self.hard_budget_bytes);
             let fits_hard = self
                 .tracked
                 .bytes
                 .checked_add(self.tracked.additional_bytes(range))
                 .is_some_and(|bytes| bytes <= self.hard_budget_bytes);
-            if fits_batch && fits_hard {
+            if fits_generation && fits_hard {
                 low = candidate;
             } else {
                 high = candidate - 1;
@@ -688,7 +679,7 @@ impl BufferedWritebackController {
     }
 
     fn commit_range(&mut self, range: DirtyRange) -> io::Result<()> {
-        let projected_batch = self
+        let projected_generation = self
             .current_extents
             .bytes
             .checked_add(self.current_extents.additional_bytes(range));
@@ -696,7 +687,7 @@ impl BufferedWritebackController {
             .tracked
             .bytes
             .checked_add(self.tracked.additional_bytes(range));
-        if projected_batch.is_none_or(|bytes| bytes > self.batch_bytes)
+        if projected_generation.is_none_or(|bytes| bytes > self.hard_budget_bytes)
             || projected_hard.is_none_or(|bytes| bytes > self.hard_budget_bytes)
         {
             return Err(io::Error::new(
@@ -927,10 +918,10 @@ fn validate_policy(hard_budget_bytes: u64, page_size: u64) -> io::Result<()> {
             "writeback page size must be a non-zero power of two",
         ));
     }
-    if page_size > MINIMUM_BATCH_BYTES {
+    if page_size > MINIMUM_WRITEBACK_BUDGET_BYTES {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "writeback page size exceeds the minimum batch size",
+            "writeback page size exceeds the minimum hard budget",
         ));
     }
     if hard_budget_bytes < MINIMUM_WRITEBACK_BUDGET_BYTES {
@@ -941,26 +932,14 @@ fn validate_policy(hard_budget_bytes: u64, page_size: u64) -> io::Result<()> {
             ),
         ));
     }
-    if align_down(hard_budget_bytes / 2, page_size) < page_size {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "writeback hard budget is too small for one batch",
-        ));
-    }
     Ok(())
 }
 
-fn derive_batch_bytes(hard_budget_bytes: u64, page_size: u64) -> u64 {
-    let quarter_budget = align_down(hard_budget_bytes / BATCH_BUDGET_DIVISOR, page_size);
-    let target = quarter_budget.clamp(MINIMUM_BATCH_BYTES, MAXIMUM_BATCH_BYTES);
-    align_down(target, page_size).min(align_down(hard_budget_bytes / 2, page_size))
-}
-
-fn queue_capacity(hard_budget_bytes: u64, batch_bytes: u64) -> usize {
-    let batches = hard_budget_bytes.div_ceil(batch_bytes);
-    usize::try_from(batches)
-        .unwrap_or(MAX_QUEUED_BATCHES)
-        .clamp(1, MAX_QUEUED_BATCHES)
+fn queue_capacity(hard_budget_bytes: u64) -> usize {
+    let generations = hard_budget_bytes.div_ceil(MINIMUM_RETIREMENT_BYTES);
+    usize::try_from(generations)
+        .unwrap_or(MAX_QUEUED_GENERATIONS)
+        .clamp(1, MAX_QUEUED_GENERATIONS)
 }
 
 fn run_worker(
@@ -974,7 +953,7 @@ fn run_worker(
     // producer blocked on the bounded job queue.
     let max_jobs_per_group = job_receiver
         .capacity()
-        .unwrap_or(MAX_QUEUED_BATCHES)
+        .unwrap_or(MAX_QUEUED_GENERATIONS)
         .saturating_add(1);
 
     loop {
@@ -1281,19 +1260,10 @@ mod tests {
     }
 
     #[test]
-    fn batch_policy_keeps_quarter_budget_jitter_headroom() {
-        assert_eq!(
-            derive_batch_bytes(MINIMUM_WRITEBACK_BUDGET_BYTES, TEST_PAGE_SIZE),
-            MINIMUM_BATCH_BYTES
-        );
-        assert_eq!(
-            derive_batch_bytes(512 * 1024 * 1024, TEST_PAGE_SIZE),
-            128 * 1024 * 1024
-        );
-        assert_eq!(
-            derive_batch_bytes(8 * 1024 * 1024 * 1024, TEST_PAGE_SIZE),
-            MAXIMUM_BATCH_BYTES
-        );
+    fn queue_capacity_scales_with_the_finite_hard_window() {
+        assert_eq!(queue_capacity(MINIMUM_WRITEBACK_BUDGET_BYTES), 4);
+        assert_eq!(queue_capacity(512 * 1024 * 1024), 16);
+        assert_eq!(queue_capacity(8 * 1024 * 1024 * 1024), 64);
     }
 
     #[cfg(target_os = "linux")]
@@ -1407,7 +1377,7 @@ mod tests {
     }
 
     #[test]
-    fn planner_caps_a_large_request_at_the_soft_batch() {
+    fn planner_caps_a_large_request_at_the_hard_budget() {
         let backend = Arc::new(FakeBackend::default());
         let mut controller = BufferedWritebackController::spawn(
             backend,
@@ -1418,14 +1388,17 @@ mod tests {
         let reservation = controller
             .plan_write(0, MINIMUM_WRITEBACK_BUDGET_BYTES)
             .unwrap();
-        assert_eq!(reservation.len(), MINIMUM_BATCH_BYTES);
+        assert_eq!(reservation.len(), MINIMUM_WRITEBACK_BUDGET_BYTES);
         controller
-            .finish_write(reservation, WritebackOutcome::Written(MINIMUM_BATCH_BYTES))
+            .finish_write(
+                reservation,
+                WritebackOutcome::Written(MINIMUM_WRITEBACK_BUDGET_BYTES),
+            )
             .unwrap();
     }
 
     #[test]
-    fn planner_accounts_for_page_alignment_at_the_batch_edge() {
+    fn planner_accounts_for_page_alignment_at_the_hard_edge() {
         let backend = Arc::new(FakeBackend::default());
         let mut controller = BufferedWritebackController::spawn(
             backend,
@@ -1436,14 +1409,54 @@ mod tests {
         let reservation = controller
             .plan_write(512, MINIMUM_WRITEBACK_BUDGET_BYTES)
             .unwrap();
-        assert_eq!(reservation.len(), MINIMUM_BATCH_BYTES - 512);
+        assert_eq!(reservation.len(), MINIMUM_WRITEBACK_BUDGET_BYTES - 512);
         controller
             .finish_write(
                 reservation,
-                WritebackOutcome::Written(MINIMUM_BATCH_BYTES - 512),
+                WritebackOutcome::Written(MINIMUM_WRITEBACK_BUDGET_BYTES - 512),
             )
             .unwrap();
-        assert_eq!(controller.tracked.bytes, MINIMUM_BATCH_BYTES);
+        assert_eq!(controller.tracked.bytes, MINIMUM_WRITEBACK_BUDGET_BYTES);
+    }
+
+    #[test]
+    fn hard_pressure_starts_retirement_but_hot_rewrites_do_not() {
+        let backend = Arc::new(FakeBackend::default());
+        let mut controller = BufferedWritebackController::spawn(
+            backend.clone(),
+            MINIMUM_WRITEBACK_BUDGET_BYTES,
+            TEST_PAGE_SIZE,
+        )
+        .unwrap();
+
+        let initial = controller
+            .plan_write(0, MINIMUM_WRITEBACK_BUDGET_BYTES)
+            .unwrap();
+        controller
+            .finish_write(
+                initial,
+                WritebackOutcome::Written(MINIMUM_WRITEBACK_BUDGET_BYTES),
+            )
+            .unwrap();
+        assert!(backend.start_calls.lock().unwrap().is_empty());
+
+        let rewrite = controller.plan_write(0, TEST_PAGE_SIZE).unwrap();
+        controller
+            .finish_write(rewrite, WritebackOutcome::Written(TEST_PAGE_SIZE))
+            .unwrap();
+        assert!(backend.start_calls.lock().unwrap().is_empty());
+        assert_eq!(controller.tracked.bytes, MINIMUM_WRITEBACK_BUDGET_BYTES);
+
+        let next = controller
+            .plan_write(MINIMUM_WRITEBACK_BUDGET_BYTES, TEST_PAGE_SIZE)
+            .unwrap();
+        controller
+            .finish_write(next, WritebackOutcome::Written(TEST_PAGE_SIZE))
+            .unwrap();
+        controller.quiesce().unwrap();
+
+        assert_eq!(backend.start_calls.lock().unwrap().len(), 2);
+        assert_eq!(controller.tracked.bytes, 0);
     }
 
     #[test]
@@ -1484,7 +1497,7 @@ mod tests {
             controller.current_extents.insert(range);
             controller.tracked.insert(range);
         }
-        assert!(controller.current_extents.bytes < controller.batch_bytes);
+        assert!(controller.current_extents.bytes < controller.hard_budget_bytes);
 
         let next_offset = MAX_EXTENTS_PER_GENERATION as u64 * TEST_PAGE_SIZE * 2;
         let reservation = controller.plan_write(next_offset, 512).unwrap();
@@ -1695,18 +1708,22 @@ mod tests {
         )
         .unwrap();
 
-        let first = controller.plan_write(0, MINIMUM_BATCH_BYTES).unwrap();
+        let first = controller.plan_write(0, MINIMUM_RETIREMENT_BYTES).unwrap();
         controller
-            .finish_write(first, WritebackOutcome::Written(MINIMUM_BATCH_BYTES))
+            .finish_write(first, WritebackOutcome::Written(MINIMUM_RETIREMENT_BYTES))
             .unwrap();
+        controller.submit_current_generation().unwrap();
         backend.wait_for_calls(1);
 
         let rewrite = controller.plan_write(0, TEST_PAGE_SIZE).unwrap();
         controller
             .finish_write(rewrite, WritebackOutcome::Written(TEST_PAGE_SIZE))
             .unwrap();
-        assert_eq!(controller.tracked.bytes, MINIMUM_BATCH_BYTES);
-        assert_eq!(controller.submitted[0].extents.bytes, MINIMUM_BATCH_BYTES);
+        assert_eq!(controller.tracked.bytes, MINIMUM_RETIREMENT_BYTES);
+        assert_eq!(
+            controller.submitted[0].extents.bytes,
+            MINIMUM_RETIREMENT_BYTES
+        );
         assert_eq!(controller.current_extents.bytes, TEST_PAGE_SIZE);
 
         backend.allow(2);
@@ -1717,7 +1734,7 @@ mod tests {
             vec![
                 vec![DirtyRange {
                     start: 0,
-                    end: MINIMUM_BATCH_BYTES,
+                    end: MINIMUM_RETIREMENT_BYTES,
                 }],
                 vec![DirtyRange {
                     start: 0,

--- a/src/devices/src/virtio/block/writeback.rs
+++ b/src/devices/src/virtio/block/writeback.rs
@@ -1,0 +1,296 @@
+// Copyright 2026 The Microsandbox Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::env;
+use std::fs::File;
+use std::io;
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+use log::warn;
+
+// Heavy sequential writers in the measured guest issued about 16 GiB between durability
+// barriers. Starting one advisory writeback near the end of that interval leaves the final fsync
+// responsible for durability while giving Linux time to drain dirty pages on an otherwise-idle
+// device. The environment override is intentionally internal and exists for controlled host
+// tuning; zero disables advisory writeback without changing the guest-visible cache contract.
+const DEFAULT_TRIGGER_BYTES: u64 = 12 * 1024 * 1024 * 1024;
+const MINIMUM_RANGE_BYTES: u64 = 64 * 1024 * 1024;
+const TRIGGER_ENV: &str = "KRUN_BLOCK_WRITEBACK_PREFLUSH_BYTES";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct DirtyRange {
+    start: u64,
+    end: u64,
+}
+
+impl DirtyRange {
+    fn new(offset: u64, length: u64) -> Option<Self> {
+        if length == 0 {
+            return None;
+        }
+
+        Some(Self {
+            start: offset,
+            end: offset.saturating_add(length),
+        })
+    }
+
+    fn merge(self, other: Self) -> Self {
+        Self {
+            start: self.start.min(other.start),
+            end: self.end.max(other.end),
+        }
+    }
+
+    fn len(self) -> u64 {
+        self.end.saturating_sub(self.start)
+    }
+}
+
+#[derive(Debug)]
+struct WritebackWindow {
+    trigger_bytes: u64,
+    logical_bytes: u64,
+    dirty_range: Option<DirtyRange>,
+}
+
+impl WritebackWindow {
+    fn new(trigger_bytes: u64) -> Self {
+        Self {
+            trigger_bytes,
+            logical_bytes: 0,
+            dirty_range: None,
+        }
+    }
+
+    fn record_write(&mut self, offset: u64, length: u64) -> Option<DirtyRange> {
+        let range = DirtyRange::new(offset, length)?;
+        self.logical_bytes = self.logical_bytes.saturating_add(length);
+        self.dirty_range = Some(
+            self.dirty_range
+                .map_or(range, |existing| existing.merge(range)),
+        );
+
+        let dirty_range = self.dirty_range?;
+        if self.logical_bytes < self.trigger_bytes || dirty_range.len() < MINIMUM_RANGE_BYTES {
+            return None;
+        }
+
+        self.logical_bytes = 0;
+        self.dirty_range = None;
+        Some(dirty_range)
+    }
+
+    fn pending_range(&self) -> Option<DirtyRange> {
+        self.dirty_range
+    }
+
+    fn complete_flush(&mut self) {
+        self.logical_bytes = 0;
+        self.dirty_range = None;
+    }
+}
+
+/// Schedules bounded advisory data writeback for one buffered raw-file block device.
+///
+/// `sync_file_range(..., SYNC_FILE_RANGE_WRITE)` does not claim durability. Guest flush
+/// completion still depends on the existing full file sync after every earlier write has been
+/// processed by the block worker.
+pub(crate) struct BufferedWritebackController {
+    file: Arc<File>,
+    window: WritebackWindow,
+    disabled: bool,
+}
+
+impl BufferedWritebackController {
+    pub(crate) fn from_environment(file: Arc<File>) -> Option<Self> {
+        let trigger_bytes = env::var(TRIGGER_ENV)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_TRIGGER_BYTES);
+        if trigger_bytes == 0 {
+            return None;
+        }
+
+        Some(Self {
+            file,
+            window: WritebackWindow::new(trigger_bytes),
+            disabled: false,
+        })
+    }
+
+    pub(crate) fn record_write(&mut self, offset: u64, length: u64) {
+        if self.disabled {
+            return;
+        }
+
+        if let Some(range) = self.window.record_write(offset, length) {
+            self.submit(range);
+        }
+    }
+
+    pub(crate) fn prepare_flush(&mut self) {
+        if self.disabled {
+            return;
+        }
+
+        if let Some(range) = self.window.pending_range() {
+            self.submit(range);
+        }
+    }
+
+    pub(crate) fn complete_flush(&mut self) {
+        self.window.complete_flush();
+    }
+
+    fn submit(&mut self, range: DirtyRange) {
+        let Ok(offset) = libc::off64_t::try_from(range.start) else {
+            self.disable("offset exceeds sync_file_range limits");
+            return;
+        };
+        let Ok(length) = libc::off64_t::try_from(range.len()) else {
+            self.disable("length exceeds sync_file_range limits");
+            return;
+        };
+
+        // Safe: the controller owns a live duplicate of the exact file object used by Imago, and
+        // the remaining arguments are validated integer values and a Linux-defined flag.
+        let result = unsafe {
+            libc::sync_file_range(
+                self.file.as_raw_fd(),
+                offset,
+                length,
+                libc::SYNC_FILE_RANGE_WRITE,
+            )
+        };
+        if result != 0 {
+            let error = io::Error::last_os_error();
+            warn!("Disabling buffered block preflush after sync_file_range failed: {error}");
+            self.disabled = true;
+        }
+    }
+
+    fn disable(&mut self, reason: &str) {
+        warn!("Disabling buffered block preflush: {reason}");
+        self.disabled = true;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::fs::OpenOptions;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    #[test]
+    fn dirty_range_merges_out_of_order_writes() {
+        let first = DirtyRange::new(128, 64).unwrap();
+        let second = DirtyRange::new(32, 48).unwrap();
+        assert_eq!(
+            first.merge(second),
+            DirtyRange {
+                start: 32,
+                end: 192
+            }
+        );
+    }
+
+    #[test]
+    fn threshold_submits_one_coalesced_range_and_starts_a_new_window() {
+        let mut window = WritebackWindow::new(96 * 1024 * 1024);
+        assert_eq!(window.record_write(0, 64 * 1024 * 1024), None);
+        assert_eq!(
+            window.record_write(64 * 1024 * 1024, 32 * 1024 * 1024),
+            Some(DirtyRange {
+                start: 0,
+                end: 96 * 1024 * 1024
+            })
+        );
+        assert_eq!(window.pending_range(), None);
+
+        assert_eq!(window.record_write(256 * 1024 * 1024, 512), None);
+        assert_eq!(
+            window.pending_range(),
+            Some(DirtyRange {
+                start: 256 * 1024 * 1024,
+                end: 256 * 1024 * 1024 + 512
+            })
+        );
+    }
+
+    #[test]
+    fn flush_keeps_pending_range_until_durability_completes() {
+        let mut window = WritebackWindow::new(u64::MAX);
+        window.record_write(4096, 128 * 1024 * 1024);
+        let expected = DirtyRange {
+            start: 4096,
+            end: 4096 + 128 * 1024 * 1024,
+        };
+        assert_eq!(window.pending_range(), Some(expected));
+        assert_eq!(window.pending_range(), Some(expected));
+
+        window.complete_flush();
+        assert_eq!(window.pending_range(), None);
+    }
+
+    #[test]
+    fn empty_write_does_not_change_the_window() {
+        let mut window = WritebackWindow::new(1);
+        assert_eq!(window.record_write(1024, 0), None);
+        assert_eq!(window.pending_range(), None);
+    }
+
+    #[test]
+    fn regular_file_accepts_advisory_writeback() {
+        let path = temporary_file_path("regular");
+        let file = OpenOptions::new()
+            .create_new(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        file.set_len(MINIMUM_RANGE_BYTES).unwrap();
+
+        let mut controller = BufferedWritebackController {
+            file: Arc::new(file),
+            window: WritebackWindow::new(1),
+            disabled: false,
+        };
+        controller.record_write(0, MINIMUM_RANGE_BYTES);
+        assert!(!controller.disabled);
+        assert_eq!(controller.window.pending_range(), None);
+
+        drop(controller);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn unsupported_file_disables_only_the_advisory_controller() {
+        let unsupported = OpenOptions::new().write(true).open("/dev/null").unwrap();
+        let mut controller = BufferedWritebackController {
+            file: Arc::new(unsupported),
+            window: WritebackWindow::new(1),
+            disabled: false,
+        };
+
+        controller.record_write(0, MINIMUM_RANGE_BYTES);
+        assert!(controller.disabled);
+    }
+
+    fn temporary_file_path(label: &str) -> std::path::PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "libkrun-writeback-{label}-{}-{nonce}",
+            std::process::id()
+        ))
+    }
+}

--- a/src/devices/src/virtio/block/writeback.rs
+++ b/src/devices/src/virtio/block/writeback.rs
@@ -120,8 +120,8 @@ pub(crate) enum WritebackOutcome {
 }
 
 trait WritebackBackend: Send + Sync + 'static {
-    fn writeback(&self, ranges: &[DirtyRange]) -> io::Result<()>;
-    fn sync_data(&self) -> io::Result<()>;
+    fn start_writeback(&self, ranges: &[DirtyRange]) -> io::Result<()>;
+    fn wait_writeback(&self, ranges: &[DirtyRange]) -> io::Result<()>;
 }
 
 #[cfg(target_os = "linux")]
@@ -143,9 +143,10 @@ pub(crate) struct BufferedWritebackConfig {
 ///
 /// The configured value is the single hard budget. A smaller batch target is derived internally
 /// to provide completion jitter headroom. Credits represent unique page-aligned extents and are
-/// released only after the background worker completes exact range writeback followed by a
-/// same-inode data-and-allocation-metadata barrier. Guest `FLUSH` remains governed by the existing
-/// full backing-image sync.
+/// released only after the background worker completes exact range writeback. This bounds dirty
+/// file data without turning each internal batch into a durability boundary. Guest `FLUSH`
+/// remains governed by the existing full backing-image sync, including the data-retrieval metadata
+/// required by the host filesystem.
 pub(crate) struct BufferedWritebackController {
     hard_budget_bytes: u64,
     batch_bytes: u64,
@@ -337,10 +338,8 @@ impl WritebackReservation {
 }
 
 #[cfg(target_os = "linux")]
-impl WritebackBackend for SyncFileRangeBackend {
-    fn writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
-        let flags = libc::SYNC_FILE_RANGE_WRITE;
-
+impl SyncFileRangeBackend {
+    fn sync_ranges(&self, ranges: &[DirtyRange], flags: u32) -> io::Result<()> {
         for range in ranges {
             let offset = libc::off64_t::try_from(range.start).map_err(|_| {
                 io::Error::new(
@@ -356,9 +355,7 @@ impl WritebackBackend for SyncFileRangeBackend {
             })?;
 
             // Safe: the backend owns a live descriptor for the exact backing inode. Ranges are
-            // validated, page-aligned integers and the flag is a Linux-defined constant. Do not
-            // use either WAIT flag here: file_fdatawait_range advances the file description's
-            // writeback-error cursor and could hide EIO/ENOSPC from the authoritative fdatasync.
+            // validated, page-aligned integers and the flags are Linux-defined constants.
             let result =
                 unsafe { libc::sync_file_range(self.file.as_raw_fd(), offset, length, flags) };
             if result != 0 {
@@ -368,11 +365,21 @@ impl WritebackBackend for SyncFileRangeBackend {
 
         Ok(())
     }
+}
 
-    fn sync_data(&self) -> io::Result<()> {
-        // Unlike sync_file_range, fdatasync also orders the allocation and copy-on-write metadata
-        // needed to retrieve the written bytes. Credits are not reusable until this succeeds.
-        self.file.sync_data()
+#[cfg(target_os = "linux")]
+impl WritebackBackend for SyncFileRangeBackend {
+    fn start_writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
+        self.sync_ranges(ranges, libc::SYNC_FILE_RANGE_WRITE)
+    }
+
+    fn wait_writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
+        // The earlier WRITE kick submitted the generation's dirty pages. WAIT_AFTER proves that
+        // their page-cache writeback completed before their credit is reused, but deliberately
+        // does not make this internal containment batch a durability boundary. The Imago backing
+        // file was opened separately through /proc/self/fd, so advancing this descriptor's errseq
+        // cursor cannot consume an error that the guest-visible full sync still needs to report.
+        self.sync_ranges(ranges, libc::SYNC_FILE_RANGE_WAIT_AFTER)
     }
 }
 
@@ -965,7 +972,7 @@ fn run_worker(
     // The completion channel is one slot larger than the job channel. Limit one coalesced group to
     // that same size so the worker can always publish every result without deadlocking against a
     // producer blocked on the bounded job queue.
-    let max_jobs_per_barrier = job_receiver
+    let max_jobs_per_group = job_receiver
         .capacity()
         .unwrap_or(MAX_QUEUED_BATCHES)
         .saturating_add(1);
@@ -981,18 +988,18 @@ fn run_worker(
             }
         };
 
-        let mut generations = Vec::with_capacity(max_jobs_per_barrier);
+        let mut jobs = Vec::with_capacity(max_jobs_per_group);
         let mut next_job = first_job;
-        let mut first_range_error = None;
+        let mut first_error = None;
         let mut jobs_disconnected = false;
 
         loop {
-            if let Err(error) = backend.writeback(&next_job.ranges) {
-                first_range_error.get_or_insert((next_job.generation, error));
+            if let Err(error) = backend.start_writeback(&next_job.ranges) {
+                first_error.get_or_insert((next_job.generation, "start", error));
             }
-            generations.push(next_job.generation);
+            jobs.push(next_job);
 
-            if generations.len() == max_jobs_per_barrier {
+            if jobs.len() == max_jobs_per_group {
                 break;
             }
             match job_receiver.try_recv() {
@@ -1005,37 +1012,25 @@ fn run_worker(
             }
         }
 
-        // sync_file_range does not guarantee allocation or COW metadata durability. One fdatasync
-        // covers every generation drained above and always runs, even after a failed range kick.
-        // The barrier cannot prove a nonzero kick result harmless, so that failure remains
-        // permanent and prevents every coalesced generation from releasing credit.
-        let barrier_error = backend.sync_data().err();
-        let group_failure = match (first_range_error, barrier_error) {
-            (Some((generation, range_error)), barrier_error) => {
-                if let Some(barrier_error) = barrier_error {
-                    warn!(
-                        "Range writeback kick for generation {generation} failed: {range_error}; \
-                         the containment data barrier also failed: {barrier_error}"
-                    );
-                } else {
-                    warn!(
-                        "Range writeback kick for generation {generation} failed closed after the \
-                         containment data barrier: {range_error}"
-                    );
-                }
-                Some(WritebackFailure {
-                    error: Arc::new(range_error),
-                })
+        // Kick every queued generation before waiting so the host block layer can keep multiple
+        // ranges in flight. Completion waits return containment credit only after the associated
+        // page-cache writeback has finished; durability metadata remains the responsibility of the
+        // existing guest-visible full sync.
+        for job in &jobs {
+            if let Err(error) = backend.wait_writeback(&job.ranges) {
+                first_error.get_or_insert((job.generation, "completion", error));
             }
-            (None, Some(barrier_error)) => Some(WritebackFailure {
-                error: Arc::new(barrier_error),
-            }),
-            (None, None) => None,
-        };
+        }
+        let group_failure = first_error.map(|(generation, operation, error)| {
+            warn!("Range writeback {operation} for generation {generation} failed closed: {error}");
+            WritebackFailure {
+                error: Arc::new(error),
+            }
+        });
 
-        for generation in generations {
+        for job in jobs {
             let completion = WritebackCompletion {
-                generation,
+                generation: job.generation,
                 result: match &group_failure {
                     None => Ok(()),
                     Some(failure) => Err(failure.clone()),
@@ -1077,33 +1072,33 @@ mod tests {
 
     #[derive(Default)]
     struct FakeBackend {
-        calls: Mutex<Vec<Vec<DirtyRange>>>,
-        barrier_calls: Mutex<usize>,
-        barrier_failures: Mutex<VecDeque<io::ErrorKind>>,
+        start_calls: Mutex<Vec<Vec<DirtyRange>>>,
+        wait_calls: Mutex<Vec<Vec<DirtyRange>>>,
+        wait_failures: Mutex<VecDeque<io::ErrorKind>>,
     }
 
     impl WritebackBackend for FakeBackend {
-        fn writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
-            self.calls.lock().unwrap().push(ranges.to_vec());
+        fn start_writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
+            self.start_calls.lock().unwrap().push(ranges.to_vec());
             Ok(())
         }
 
-        fn sync_data(&self) -> io::Result<()> {
-            *self.barrier_calls.lock().unwrap() += 1;
-            match self.barrier_failures.lock().unwrap().pop_front() {
-                Some(kind) => Err(io::Error::new(kind, "injected data-barrier failure")),
+        fn wait_writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
+            self.wait_calls.lock().unwrap().push(ranges.to_vec());
+            match self.wait_failures.lock().unwrap().pop_front() {
+                Some(kind) => Err(io::Error::new(kind, "injected completion-wait failure")),
                 None => Ok(()),
             }
         }
     }
 
     impl FakeBackend {
-        fn fail_next_barrier(&self, kind: io::ErrorKind) {
-            self.barrier_failures.lock().unwrap().push_back(kind);
+        fn fail_next_wait(&self, kind: io::ErrorKind) {
+            self.wait_failures.lock().unwrap().push_back(kind);
         }
 
-        fn barrier_calls(&self) -> usize {
-            *self.barrier_calls.lock().unwrap()
+        fn wait_calls(&self) -> usize {
+            self.wait_calls.lock().unwrap().len()
         }
     }
 
@@ -1120,7 +1115,7 @@ mod tests {
     }
 
     impl WritebackBackend for GatedBackend {
-        fn writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
+        fn start_writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
             let mut state = self.state.lock().unwrap();
             state.calls.push(ranges.to_vec());
             self.changed.notify_all();
@@ -1131,7 +1126,7 @@ mod tests {
             Ok(())
         }
 
-        fn sync_data(&self) -> io::Result<()> {
+        fn wait_writeback(&self, _ranges: &[DirtyRange]) -> io::Result<()> {
             Ok(())
         }
     }
@@ -1164,23 +1159,23 @@ mod tests {
     }
 
     #[derive(Default)]
-    struct BarrierGatedBackend {
+    struct CompletionGatedBackend {
         changed: Condvar,
-        state: Mutex<BarrierGatedState>,
+        state: Mutex<CompletionGatedState>,
     }
 
     #[derive(Default)]
-    struct BarrierGatedState {
+    struct CompletionGatedState {
         calls: Vec<Vec<DirtyRange>>,
         writeback_permits: usize,
         writeback_failures: VecDeque<io::ErrorKind>,
-        barrier_calls: usize,
-        barrier_permits: usize,
-        barrier_failures: VecDeque<io::ErrorKind>,
+        wait_calls: usize,
+        wait_permits: usize,
+        wait_failures: VecDeque<io::ErrorKind>,
     }
 
-    impl WritebackBackend for BarrierGatedBackend {
-        fn writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
+    impl WritebackBackend for CompletionGatedBackend {
+        fn start_writeback(&self, ranges: &[DirtyRange]) -> io::Result<()> {
             let mut state = self.state.lock().unwrap();
             state.calls.push(ranges.to_vec());
             self.changed.notify_all();
@@ -1194,36 +1189,36 @@ mod tests {
             }
         }
 
-        fn sync_data(&self) -> io::Result<()> {
+        fn wait_writeback(&self, _ranges: &[DirtyRange]) -> io::Result<()> {
             let mut state = self.state.lock().unwrap();
-            state.barrier_calls += 1;
+            state.wait_calls += 1;
             self.changed.notify_all();
-            while state.barrier_permits == 0 {
+            while state.wait_permits == 0 {
                 state = self.changed.wait(state).unwrap();
             }
-            state.barrier_permits -= 1;
-            match state.barrier_failures.pop_front() {
-                Some(kind) => Err(io::Error::new(kind, "injected data-barrier failure")),
+            state.wait_permits -= 1;
+            match state.wait_failures.pop_front() {
+                Some(kind) => Err(io::Error::new(kind, "injected completion-wait failure")),
                 None => Ok(()),
             }
         }
     }
 
-    impl BarrierGatedBackend {
+    impl CompletionGatedBackend {
         fn allow_writebacks(&self, jobs: usize) {
             let mut state = self.state.lock().unwrap();
             state.writeback_permits += jobs;
             self.changed.notify_all();
         }
 
-        fn allow_barriers(&self, barriers: usize) {
+        fn allow_waits(&self, waits: usize) {
             let mut state = self.state.lock().unwrap();
-            state.barrier_permits += barriers;
+            state.wait_permits += waits;
             self.changed.notify_all();
         }
 
-        fn fail_next_barrier(&self, kind: io::ErrorKind) {
-            self.state.lock().unwrap().barrier_failures.push_back(kind);
+        fn fail_next_wait(&self, kind: io::ErrorKind) {
+            self.state.lock().unwrap().wait_failures.push_back(kind);
         }
 
         fn fail_next_writeback(&self, kind: io::ErrorKind) {
@@ -1249,16 +1244,16 @@ mod tests {
             }
         }
 
-        fn wait_for_barriers(&self, calls: usize) {
+        fn wait_for_waits(&self, calls: usize) {
             let mut state = self.state.lock().unwrap();
-            while state.barrier_calls < calls {
+            while state.wait_calls < calls {
                 let (new_state, timeout) = self
                     .changed
                     .wait_timeout(state, Duration::from_secs(5))
                     .unwrap();
                 assert!(
                     !timeout.timed_out(),
-                    "writeback worker did not reach the expected data barrier"
+                    "writeback worker did not reach the expected completion wait"
                 );
                 state = new_state;
             }
@@ -1268,19 +1263,19 @@ mod tests {
             self.state.lock().unwrap().calls.clone()
         }
 
-        fn barrier_calls(&self) -> usize {
-            self.state.lock().unwrap().barrier_calls
+        fn wait_calls(&self) -> usize {
+            self.state.lock().unwrap().wait_calls
         }
     }
 
     struct PanicBackend;
 
     impl WritebackBackend for PanicBackend {
-        fn writeback(&self, _ranges: &[DirtyRange]) -> io::Result<()> {
+        fn start_writeback(&self, _ranges: &[DirtyRange]) -> io::Result<()> {
             panic!("injected writeback worker panic");
         }
 
-        fn sync_data(&self) -> io::Result<()> {
+        fn wait_writeback(&self, _ranges: &[DirtyRange]) -> io::Result<()> {
             Ok(())
         }
     }
@@ -1303,7 +1298,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn linux_backend_writes_back_and_syncs_a_regular_file() {
+    fn linux_backend_starts_and_waits_for_regular_file_writeback() {
         let backing = TempFile::new().unwrap();
         backing.as_file().set_len(TEST_PAGE_SIZE * 2).unwrap();
         backing
@@ -1315,12 +1310,17 @@ mod tests {
             file: Arc::new(backing.as_file().try_clone().unwrap()),
         };
         backend
-            .writeback(&[DirtyRange {
+            .start_writeback(&[DirtyRange {
                 start: 0,
                 end: TEST_PAGE_SIZE,
             }])
             .unwrap();
-        backend.sync_data().unwrap();
+        backend
+            .wait_writeback(&[DirtyRange {
+                start: 0,
+                end: TEST_PAGE_SIZE,
+            }])
+            .unwrap();
     }
 
     #[test]
@@ -1551,7 +1551,7 @@ mod tests {
         controller.quiesce().unwrap();
 
         assert_eq!(
-            backend.calls.lock().unwrap().as_slice(),
+            backend.start_calls.lock().unwrap().as_slice(),
             &[vec![
                 DirtyRange {
                     start: 0,
@@ -1564,12 +1564,12 @@ mod tests {
             ]]
         );
         assert_eq!(controller.tracked.bytes, 0);
-        assert_eq!(backend.barrier_calls(), 1);
+        assert_eq!(backend.wait_calls(), 1);
     }
 
     #[test]
-    fn queued_generations_share_one_barrier_before_releasing_credit() {
-        let backend = Arc::new(BarrierGatedBackend::default());
+    fn queued_generations_wait_for_each_range_before_releasing_credit() {
+        let backend = Arc::new(CompletionGatedBackend::default());
         let mut controller = BufferedWritebackController::spawn(
             backend.clone(),
             MINIMUM_WRITEBACK_BUDGET_BYTES,
@@ -1583,9 +1583,9 @@ mod tests {
 
         backend.allow_writebacks(2);
         backend.wait_for_writebacks(2);
-        backend.wait_for_barriers(1);
+        backend.wait_for_waits(1);
 
-        assert_eq!(backend.barrier_calls(), 1);
+        assert_eq!(backend.wait_calls(), 1);
         assert_eq!(backend.calls().len(), 2);
         assert_eq!(controller.tracked.bytes, TEST_PAGE_SIZE * 2);
         assert!(controller
@@ -1597,17 +1597,18 @@ mod tests {
             TryRecvError::Empty
         );
 
-        backend.allow_barriers(1);
+        backend.allow_waits(2);
         controller.quiesce().unwrap();
+        assert_eq!(backend.wait_calls(), 2);
         assert_eq!(controller.tracked.bytes, 0);
         assert!(controller.submitted.is_empty());
         assert!(controller.health.is_healthy());
     }
 
     #[test]
-    fn barrier_failure_fails_every_coalesced_generation() {
-        let backend = Arc::new(BarrierGatedBackend::default());
-        backend.fail_next_barrier(io::ErrorKind::Other);
+    fn completion_failure_fails_every_coalesced_generation() {
+        let backend = Arc::new(CompletionGatedBackend::default());
+        backend.fail_next_wait(io::ErrorKind::Other);
         let mut controller = BufferedWritebackController::spawn(
             backend.clone(),
             MINIMUM_WRITEBACK_BUDGET_BYTES,
@@ -1621,8 +1622,8 @@ mod tests {
 
         backend.allow_writebacks(2);
         backend.wait_for_writebacks(2);
-        backend.wait_for_barriers(1);
-        backend.allow_barriers(1);
+        backend.wait_for_waits(1);
+        backend.allow_waits(2);
 
         assert_eq!(
             controller.quiesce().unwrap_err().kind(),
@@ -1639,8 +1640,8 @@ mod tests {
     }
 
     #[test]
-    fn successful_data_barrier_does_not_hide_a_range_kick_failure() {
-        let backend = Arc::new(BarrierGatedBackend::default());
+    fn successful_completion_wait_does_not_hide_a_range_kick_failure() {
+        let backend = Arc::new(CompletionGatedBackend::default());
         backend.fail_next_writeback(io::ErrorKind::Other);
         let mut controller = BufferedWritebackController::spawn(
             backend.clone(),
@@ -1655,20 +1656,20 @@ mod tests {
 
         backend.allow_writebacks(2);
         backend.wait_for_writebacks(2);
-        backend.wait_for_barriers(1);
+        backend.wait_for_waits(1);
         assert_eq!(controller.tracked.bytes, TEST_PAGE_SIZE * 2);
         assert_eq!(
             controller.completion_receiver.try_recv().unwrap_err(),
             TryRecvError::Empty
         );
-        backend.allow_barriers(1);
+        backend.allow_waits(2);
 
         assert_eq!(
             controller.quiesce().unwrap_err().kind(),
             io::ErrorKind::Other
         );
 
-        assert_eq!(backend.barrier_calls(), 1);
+        assert_eq!(backend.wait_calls(), 2);
         assert_eq!(controller.tracked.bytes, TEST_PAGE_SIZE * 2);
         assert_eq!(controller.submitted.len(), 2);
         assert!(controller
@@ -1729,7 +1730,7 @@ mod tests {
     #[test]
     fn worker_error_latches_without_releasing_credits() {
         let backend = Arc::new(FakeBackend::default());
-        backend.fail_next_barrier(io::ErrorKind::Other);
+        backend.fail_next_wait(io::ErrorKind::Other);
         let mut controller = BufferedWritebackController::spawn(
             backend,
             MINIMUM_WRITEBACK_BUDGET_BYTES,
@@ -1755,7 +1756,7 @@ mod tests {
             io::ErrorKind::Other
         );
 
-        // A later sync cannot prove that bytes behind an already-reported barrier error survived.
+        // A later sync cannot prove that bytes behind an already-reported completion error survived.
         assert!(!controller.reset_after_flush());
         assert_eq!(controller.tracked.bytes, 0);
         assert!(controller.latched_error.is_some());
@@ -1765,7 +1766,7 @@ mod tests {
     #[test]
     fn unsupported_backend_error_survives_full_sync_reset() {
         let backend = Arc::new(FakeBackend::default());
-        backend.fail_next_barrier(io::ErrorKind::Unsupported);
+        backend.fail_next_wait(io::ErrorKind::Unsupported);
         let mut controller = BufferedWritebackController::spawn(
             backend,
             MINIMUM_WRITEBACK_BUDGET_BYTES,

--- a/src/devices/src/virtio/file_traits.rs
+++ b/src/devices/src/virtio/file_traits.rs
@@ -510,14 +510,18 @@ impl FileReadWriteAtVolatile for DiskProperties {
             .try_into()
             .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
 
+        // Keep the invariant local to the backing-write boundary as well as the virtio request
+        // parser: a bounded mutation is accepted in full or rejected before its first writev.
+        self.validate_mutation_range(offset, full_length_u64)?;
+
         let mut chunk_offset = offset;
         while !iovec.is_empty() {
-            let chunk_length = self.buffered_write_chunk_bytes(iovec.len());
+            let plan = self.plan_buffered_mutation(chunk_offset, iovec.len())?;
+            let chunk_length = plan.len();
             let (chunk, remainder) = iovec.split_at(chunk_length);
 
-            self.prepare_buffered_write(chunk_offset, chunk_length)?;
-            self.file.lock().unwrap().writev(chunk, chunk_offset)?;
-            self.record_buffered_write(chunk_offset, chunk_length)?;
+            let operation_result = self.file.lock().unwrap().writev(chunk, chunk_offset);
+            self.finish_buffered_mutation(plan, operation_result)?;
 
             iovec = remainder;
             if !iovec.is_empty() {

--- a/src/devices/src/virtio/file_traits.rs
+++ b/src/devices/src/virtio/file_traits.rs
@@ -504,13 +504,28 @@ impl FileReadWriteAtVolatile for DiskProperties {
                 IoSlice::new(slice)
             })
             .collect::<Vec<_>>();
-        let iovec = IoVector::from(buffers);
+        let mut iovec = IoVector::from(buffers);
         let full_length_u64 = iovec.len();
         let full_length = full_length_u64
             .try_into()
             .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
-        self.file.lock().unwrap().writev(iovec, offset)?;
-        self.record_buffered_write(offset, full_length_u64);
+
+        let mut chunk_offset = offset;
+        while !iovec.is_empty() {
+            let chunk_length = self.buffered_write_chunk_bytes(iovec.len());
+            let (chunk, remainder) = iovec.split_at(chunk_length);
+
+            self.prepare_buffered_write(chunk_offset, chunk_length)?;
+            self.file.lock().unwrap().writev(chunk, chunk_offset)?;
+            self.record_buffered_write(chunk_offset, chunk_length)?;
+
+            iovec = remainder;
+            if !iovec.is_empty() {
+                chunk_offset = chunk_offset.checked_add(chunk_length).ok_or_else(|| {
+                    Error::new(ErrorKind::InvalidInput, "block write range overflow")
+                })?;
+            }
+        }
         Ok(full_length)
     }
 }

--- a/src/devices/src/virtio/file_traits.rs
+++ b/src/devices/src/virtio/file_traits.rs
@@ -505,11 +505,12 @@ impl FileReadWriteAtVolatile for DiskProperties {
             })
             .collect::<Vec<_>>();
         let iovec = IoVector::from(buffers);
-        let full_length = iovec
-            .len()
+        let full_length_u64 = iovec.len();
+        let full_length = full_length_u64
             .try_into()
             .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
         self.file.lock().unwrap().writev(iovec, offset)?;
+        self.record_buffered_write(offset, full_length_u64);
         Ok(full_length)
     }
 }

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -532,7 +532,8 @@ impl VmBuilder {
 
         // Apply block device configuration
         #[cfg(feature = "blk")]
-        for (i, config) in self.disk.configs.into_iter().enumerate() {
+        for (i, configured_disk) in self.disk.configs.into_iter().enumerate() {
+            let config = configured_disk.config;
             let block_id = config
                 .id
                 .clone()
@@ -549,11 +550,13 @@ impl VmBuilder {
                 is_disk_read_only: config.read_only,
                 direct_io: config.direct_io,
                 sync_mode,
-                writeback_preflush_bytes: config.writeback_preflush_bytes,
             };
 
-            vmr.add_block_device(blk_config)
-                .map_err(|e| Error::Config(ConfigError::Block(e.to_string())))?;
+            vmr.add_block_device_with_writeback_preflush(
+                blk_config,
+                configured_disk.writeback_preflush_bytes,
+            )
+            .map_err(|e| Error::Config(ConfigError::Block(e.to_string())))?;
         }
 
         // Format execution configuration
@@ -880,11 +883,14 @@ mod tests {
             .disk
             .configs
             .iter()
-            .map(|c| c.path.to_string_lossy().into_owned())
+            .map(|c| c.config.path.to_string_lossy().into_owned())
             .collect();
         assert_eq!(paths, vec!["/a.raw", "/b.qcow2", "/c.vmdk"]);
-        assert_eq!(builder.disk.configs[1].format, DiskImageFormat::Qcow2);
-        assert!(builder.disk.configs[2].read_only);
+        assert_eq!(
+            builder.disk.configs[1].config.format,
+            DiskImageFormat::Qcow2
+        );
+        assert!(builder.disk.configs[2].config.read_only);
     }
 
     #[cfg(feature = "blk")]
@@ -895,9 +901,9 @@ mod tests {
             .disk(|d| d.path("/b.raw").id("data"))
             .disk(|d| d.path("/c.raw"));
 
-        assert!(builder.disk.configs[0].id.is_none());
-        assert_eq!(builder.disk.configs[1].id.as_deref(), Some("data"));
-        assert!(builder.disk.configs[2].id.is_none());
+        assert!(builder.disk.configs[0].config.id.is_none());
+        assert_eq!(builder.disk.configs[1].config.id.as_deref(), Some("data"));
+        assert!(builder.disk.configs[2].config.id.is_none());
     }
 
     #[cfg(feature = "blk")]
@@ -916,19 +922,19 @@ mod tests {
             })
             .disk(|d| d.path("/b.raw"));
 
-        assert!(builder.disk.configs[0].read_only);
-        assert_eq!(builder.disk.configs[0].cache, CacheMode::Unsafe);
-        assert!(builder.disk.configs[0].direct_io);
-        assert_eq!(builder.disk.configs[0].sync, SyncMode::None);
+        assert!(builder.disk.configs[0].config.read_only);
+        assert_eq!(builder.disk.configs[0].config.cache, CacheMode::Unsafe);
+        assert!(builder.disk.configs[0].config.direct_io);
+        assert_eq!(builder.disk.configs[0].config.sync, SyncMode::None);
         assert_eq!(
             builder.disk.configs[0].writeback_preflush_bytes,
             Some(128 * 1024 * 1024)
         );
 
-        assert!(!builder.disk.configs[1].read_only);
-        assert_eq!(builder.disk.configs[1].cache, CacheMode::Writeback);
-        assert!(!builder.disk.configs[1].direct_io);
-        assert_eq!(builder.disk.configs[1].sync, SyncMode::Full);
+        assert!(!builder.disk.configs[1].config.read_only);
+        assert_eq!(builder.disk.configs[1].config.cache, CacheMode::Writeback);
+        assert!(!builder.disk.configs[1].config.direct_io);
+        assert_eq!(builder.disk.configs[1].config.sync, SyncMode::Full);
         assert_eq!(builder.disk.configs[1].writeback_preflush_bytes, None);
     }
 }

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -549,6 +549,7 @@ impl VmBuilder {
                 is_disk_read_only: config.read_only,
                 direct_io: config.direct_io,
                 sync_mode,
+                writeback_preflush_bytes: config.writeback_preflush_bytes,
             };
 
             vmr.add_block_device(blk_config)
@@ -911,6 +912,7 @@ mod tests {
                     .cache(CacheMode::Unsafe)
                     .direct_io(true)
                     .sync(SyncMode::None)
+                    .writeback_preflush_bytes(128 * 1024 * 1024)
             })
             .disk(|d| d.path("/b.raw"));
 
@@ -918,10 +920,15 @@ mod tests {
         assert_eq!(builder.disk.configs[0].cache, CacheMode::Unsafe);
         assert!(builder.disk.configs[0].direct_io);
         assert_eq!(builder.disk.configs[0].sync, SyncMode::None);
+        assert_eq!(
+            builder.disk.configs[0].writeback_preflush_bytes,
+            Some(128 * 1024 * 1024)
+        );
 
         assert!(!builder.disk.configs[1].read_only);
         assert_eq!(builder.disk.configs[1].cache, CacheMode::Writeback);
         assert!(!builder.disk.configs[1].direct_io);
         assert_eq!(builder.disk.configs[1].sync, SyncMode::Full);
+        assert_eq!(builder.disk.configs[1].writeback_preflush_bytes, None);
     }
 }

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -552,9 +552,9 @@ impl VmBuilder {
                 sync_mode,
             };
 
-            vmr.add_block_device_with_writeback_preflush(
+            vmr.add_block_device_with_writeback_limit(
                 blk_config,
-                configured_disk.writeback_preflush_bytes,
+                configured_disk.writeback_limit_bytes,
             )
             .map_err(|e| Error::Config(ConfigError::Block(e.to_string())))?;
         }
@@ -918,7 +918,7 @@ mod tests {
                     .cache(CacheMode::Unsafe)
                     .direct_io(true)
                     .sync(SyncMode::None)
-                    .writeback_preflush_bytes(128 * 1024 * 1024)
+                    .writeback_limit_bytes(128 * 1024 * 1024)
             })
             .disk(|d| d.path("/b.raw"));
 
@@ -927,7 +927,7 @@ mod tests {
         assert!(builder.disk.configs[0].config.direct_io);
         assert_eq!(builder.disk.configs[0].config.sync, SyncMode::None);
         assert_eq!(
-            builder.disk.configs[0].writeback_preflush_bytes,
+            builder.disk.configs[0].writeback_limit_bytes,
             Some(128 * 1024 * 1024)
         );
 
@@ -935,6 +935,6 @@ mod tests {
         assert_eq!(builder.disk.configs[1].config.cache, CacheMode::Writeback);
         assert!(!builder.disk.configs[1].config.direct_io);
         assert_eq!(builder.disk.configs[1].config.sync, SyncMode::Full);
-        assert_eq!(builder.disk.configs[1].writeback_preflush_bytes, None);
+        assert_eq!(builder.disk.configs[1].writeback_limit_bytes, None);
     }
 }

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -331,6 +331,7 @@ pub struct DiskBuilder {
     current_cache: CacheMode,
     current_direct_io: bool,
     current_sync: SyncMode,
+    current_writeback_preflush_bytes: Option<u64>,
 }
 
 /// Configuration for a single block device.
@@ -346,6 +347,8 @@ pub struct DiskConfig {
     pub cache: CacheMode,
     pub direct_io: bool,
     pub sync: SyncMode,
+    /// Host dirty-data threshold that starts advisory writeback before a guest flush.
+    pub writeback_preflush_bytes: Option<u64>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -937,6 +940,7 @@ impl DiskBuilder {
             current_cache: CacheMode::Writeback,
             current_direct_io: false,
             current_sync: SyncMode::Full,
+            current_writeback_preflush_bytes: None,
         }
     }
 
@@ -970,12 +974,14 @@ impl DiskBuilder {
                 cache: self.current_cache,
                 direct_io: self.current_direct_io,
                 sync: self.current_sync,
+                writeback_preflush_bytes: self.current_writeback_preflush_bytes,
             });
             self.current_read_only = false;
             self.current_format = DiskImageFormat::Raw;
             self.current_cache = CacheMode::Writeback;
             self.current_direct_io = false;
             self.current_sync = SyncMode::Full;
+            self.current_writeback_preflush_bytes = None;
         }
 
         self.current_path = Some(path.as_ref().to_path_buf());
@@ -1006,6 +1012,16 @@ impl DiskBuilder {
         self
     }
 
+    /// Start advisory host writeback after this many buffered bytes have been written.
+    ///
+    /// This Linux-only optimization is valid for writable raw disks using writeback caching,
+    /// buffered I/O and an active sync mode. The minimum active threshold is 64 MiB; a value of
+    /// zero disables the optimization. Invalid combinations fail explicitly when the VM is built.
+    pub fn writeback_preflush_bytes(mut self, bytes: u64) -> Self {
+        self.current_writeback_preflush_bytes = (bytes > 0).then_some(bytes);
+        self
+    }
+
     /// Finalize the builder (called internally).
     pub(crate) fn finalize(mut self) -> Self {
         if let Some(path) = self.current_path.take() {
@@ -1017,6 +1033,7 @@ impl DiskBuilder {
                 cache: self.current_cache,
                 direct_io: self.current_direct_io,
                 sync: self.current_sync,
+                writeback_preflush_bytes: self.current_writeback_preflush_bytes,
             });
         }
         self

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -331,7 +331,7 @@ pub struct DiskBuilder {
     current_cache: CacheMode,
     current_direct_io: bool,
     current_sync: SyncMode,
-    current_writeback_preflush_bytes: Option<u64>,
+    current_writeback_limit_bytes: Option<u64>,
 }
 
 /// Configuration for a single block device.
@@ -354,7 +354,7 @@ pub struct DiskConfig {
 #[derive(Debug, Clone)]
 pub(crate) struct ConfiguredDisk {
     pub(crate) config: DiskConfig,
-    pub(crate) writeback_preflush_bytes: Option<u64>,
+    pub(crate) writeback_limit_bytes: Option<u64>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -946,7 +946,7 @@ impl DiskBuilder {
             current_cache: CacheMode::Writeback,
             current_direct_io: false,
             current_sync: SyncMode::Full,
-            current_writeback_preflush_bytes: None,
+            current_writeback_limit_bytes: None,
         }
     }
 
@@ -982,14 +982,14 @@ impl DiskBuilder {
                     direct_io: self.current_direct_io,
                     sync: self.current_sync,
                 },
-                writeback_preflush_bytes: self.current_writeback_preflush_bytes,
+                writeback_limit_bytes: self.current_writeback_limit_bytes,
             });
             self.current_read_only = false;
             self.current_format = DiskImageFormat::Raw;
             self.current_cache = CacheMode::Writeback;
             self.current_direct_io = false;
             self.current_sync = SyncMode::Full;
-            self.current_writeback_preflush_bytes = None;
+            self.current_writeback_limit_bytes = None;
         }
 
         self.current_path = Some(path.as_ref().to_path_buf());
@@ -1020,17 +1020,21 @@ impl DiskBuilder {
         self
     }
 
-    /// Start rolling host writeback after this many buffered bytes have been written.
+    /// Limit outstanding buffered host dirty data to this many bytes.
     ///
-    /// This Linux-only optimization is valid for writable raw disks using writeback caching,
-    /// buffered I/O and an active sync mode. The minimum active threshold is 64 MiB; a value of
-    /// zero disables the optimization. Invalid combinations fail explicitly when the VM is built.
-    /// The configured value is the soft threshold for asynchronous range writeback. Twice that
-    /// value is a VMM-enforced per-device hard watermark: the block worker synchronously drains its
-    /// accumulated range before accepting more dirtying writes. Guest flushes still perform the
-    /// existing full durability sync.
-    pub fn writeback_preflush_bytes(mut self, bytes: u64) -> Self {
-        self.current_writeback_preflush_bytes = (bytes > 0).then_some(bytes);
+    /// This Linux-only policy is valid for writable raw disks using writeback caching, buffered
+    /// I/O and an active sync mode. The minimum active budget is 128 MiB; zero disables the policy.
+    /// Libkrun derives smaller internal batches, retires their data and allocation metadata on a
+    /// background helper, and applies backpressure before this per-device, page-aligned dirty-data
+    /// budget can be exceeded. Guest flushes still perform the existing full durability sync.
+    ///
+    /// While this policy is active, host hole punching is not exposed to the guest: discard and
+    /// write-zeroes-with-unmap are unavailable, while ordinary write-zeroes requests use accounted
+    /// data writes. On supporting Linux kernels and filesystems, writes also request best-effort
+    /// cache pruning; that hint is an optimization, not a bound on clean page-cache residency.
+    /// Invalid combinations fail explicitly when the VM is built.
+    pub fn writeback_limit_bytes(mut self, bytes: u64) -> Self {
+        self.current_writeback_limit_bytes = (bytes > 0).then_some(bytes);
         self
     }
 
@@ -1047,7 +1051,7 @@ impl DiskBuilder {
                     direct_io: self.current_direct_io,
                     sync: self.current_sync,
                 },
-                writeback_preflush_bytes: self.current_writeback_preflush_bytes,
+                writeback_limit_bytes: self.current_writeback_limit_bytes,
             });
         }
         self

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -323,7 +323,7 @@ pub enum SyncMode {
 #[cfg(feature = "blk")]
 #[derive(Debug, Clone)]
 pub struct DiskBuilder {
-    pub(crate) configs: Vec<DiskConfig>,
+    pub(crate) configs: Vec<ConfiguredDisk>,
     current_path: Option<PathBuf>,
     current_id: Option<String>,
     current_read_only: bool,
@@ -347,8 +347,14 @@ pub struct DiskConfig {
     pub cache: CacheMode,
     pub direct_io: bool,
     pub sync: SyncMode,
-    /// Host dirty-data threshold that starts advisory writeback before a guest flush.
-    pub writeback_preflush_bytes: Option<u64>,
+}
+
+/// Internal disk configuration paired with host-only tuning state.
+#[cfg(feature = "blk")]
+#[derive(Debug, Clone)]
+pub(crate) struct ConfiguredDisk {
+    pub(crate) config: DiskConfig,
+    pub(crate) writeback_preflush_bytes: Option<u64>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -966,14 +972,16 @@ impl DiskBuilder {
     pub fn path(mut self, path: impl AsRef<Path>) -> Self {
         // Finalize any pending config
         if let Some(pending_path) = self.current_path.take() {
-            self.configs.push(DiskConfig {
-                path: pending_path,
-                id: self.current_id.take(),
-                read_only: self.current_read_only,
-                format: self.current_format,
-                cache: self.current_cache,
-                direct_io: self.current_direct_io,
-                sync: self.current_sync,
+            self.configs.push(ConfiguredDisk {
+                config: DiskConfig {
+                    path: pending_path,
+                    id: self.current_id.take(),
+                    read_only: self.current_read_only,
+                    format: self.current_format,
+                    cache: self.current_cache,
+                    direct_io: self.current_direct_io,
+                    sync: self.current_sync,
+                },
                 writeback_preflush_bytes: self.current_writeback_preflush_bytes,
             });
             self.current_read_only = false;
@@ -1012,11 +1020,14 @@ impl DiskBuilder {
         self
     }
 
-    /// Start advisory host writeback after this many buffered bytes have been written.
+    /// Start one advisory host writeback range after this many buffered bytes have been written.
     ///
     /// This Linux-only optimization is valid for writable raw disks using writeback caching,
     /// buffered I/O and an active sync mode. The minimum active threshold is 64 MiB; a value of
     /// zero disables the optimization. Invalid combinations fail explicitly when the VM is built.
+    /// The advisory writeback is issued at most once between successful guest flushes; it is not a
+    /// dirty-memory limit. Hosts running untrusted workloads must enforce memory and dirty-page
+    /// containment independently, for example with cgroups and Linux writeback policy.
     pub fn writeback_preflush_bytes(mut self, bytes: u64) -> Self {
         self.current_writeback_preflush_bytes = (bytes > 0).then_some(bytes);
         self
@@ -1025,14 +1036,16 @@ impl DiskBuilder {
     /// Finalize the builder (called internally).
     pub(crate) fn finalize(mut self) -> Self {
         if let Some(path) = self.current_path.take() {
-            self.configs.push(DiskConfig {
-                path,
-                id: self.current_id.take(),
-                read_only: self.current_read_only,
-                format: self.current_format,
-                cache: self.current_cache,
-                direct_io: self.current_direct_io,
-                sync: self.current_sync,
+            self.configs.push(ConfiguredDisk {
+                config: DiskConfig {
+                    path,
+                    id: self.current_id.take(),
+                    read_only: self.current_read_only,
+                    format: self.current_format,
+                    cache: self.current_cache,
+                    direct_io: self.current_direct_io,
+                    sync: self.current_sync,
+                },
                 writeback_preflush_bytes: self.current_writeback_preflush_bytes,
             });
         }

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -1020,14 +1020,15 @@ impl DiskBuilder {
         self
     }
 
-    /// Start one advisory host writeback range after this many buffered bytes have been written.
+    /// Start rolling host writeback after this many buffered bytes have been written.
     ///
     /// This Linux-only optimization is valid for writable raw disks using writeback caching,
     /// buffered I/O and an active sync mode. The minimum active threshold is 64 MiB; a value of
     /// zero disables the optimization. Invalid combinations fail explicitly when the VM is built.
-    /// The advisory writeback is issued at most once between successful guest flushes; it is not a
-    /// dirty-memory limit. Hosts running untrusted workloads must enforce memory and dirty-page
-    /// containment independently, for example with cgroups and Linux writeback policy.
+    /// The configured value is the soft threshold for asynchronous range writeback. Twice that
+    /// value is a VMM-enforced per-device hard watermark: the block worker synchronously drains its
+    /// accumulated range before accepting more dirtying writes. Guest flushes still perform the
+    /// existing full durability sync.
     pub fn writeback_preflush_bytes(mut self, bytes: u64) -> Self {
         self.current_writeback_preflush_bytes = (bytes > 0).then_some(bytes);
         self

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -785,6 +785,7 @@ pub unsafe extern "C" fn krun_add_disk(
                 sync_mode: SyncMode::Full,
                 #[cfg(target_os = "macos")]
                 sync_mode: SyncMode::Relaxed,
+                writeback_preflush_bytes: None,
             };
             cfg.add_block_cfg(block_device_config);
         }
@@ -836,6 +837,7 @@ pub unsafe extern "C" fn krun_add_disk2(
                 sync_mode: SyncMode::Full,
                 #[cfg(target_os = "macos")]
                 sync_mode: SyncMode::Relaxed,
+                writeback_preflush_bytes: None,
             };
             cfg.add_block_cfg(block_device_config);
         }
@@ -891,6 +893,7 @@ pub unsafe extern "C" fn krun_add_disk3(
                 is_disk_read_only: read_only,
                 direct_io,
                 sync_mode,
+                writeback_preflush_bytes: None,
             };
             cfg.add_block_cfg(block_device_config);
         }
@@ -923,6 +926,7 @@ pub unsafe extern "C" fn krun_set_root_disk(ctx_id: u32, c_disk_path: *const c_c
                 sync_mode: SyncMode::Full,
                 #[cfg(target_os = "macos")]
                 sync_mode: SyncMode::Relaxed,
+                writeback_preflush_bytes: None,
             };
             cfg.set_root_block_cfg(block_device_config);
         }
@@ -955,6 +959,7 @@ pub unsafe extern "C" fn krun_set_data_disk(ctx_id: u32, c_disk_path: *const c_c
                 sync_mode: SyncMode::Full,
                 #[cfg(target_os = "macos")]
                 sync_mode: SyncMode::Relaxed,
+                writeback_preflush_bytes: None,
             };
             cfg.set_data_block_cfg(block_device_config);
         }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -785,7 +785,6 @@ pub unsafe extern "C" fn krun_add_disk(
                 sync_mode: SyncMode::Full,
                 #[cfg(target_os = "macos")]
                 sync_mode: SyncMode::Relaxed,
-                writeback_preflush_bytes: None,
             };
             cfg.add_block_cfg(block_device_config);
         }
@@ -837,7 +836,6 @@ pub unsafe extern "C" fn krun_add_disk2(
                 sync_mode: SyncMode::Full,
                 #[cfg(target_os = "macos")]
                 sync_mode: SyncMode::Relaxed,
-                writeback_preflush_bytes: None,
             };
             cfg.add_block_cfg(block_device_config);
         }
@@ -893,7 +891,6 @@ pub unsafe extern "C" fn krun_add_disk3(
                 is_disk_read_only: read_only,
                 direct_io,
                 sync_mode,
-                writeback_preflush_bytes: None,
             };
             cfg.add_block_cfg(block_device_config);
         }
@@ -926,7 +923,6 @@ pub unsafe extern "C" fn krun_set_root_disk(ctx_id: u32, c_disk_path: *const c_c
                 sync_mode: SyncMode::Full,
                 #[cfg(target_os = "macos")]
                 sync_mode: SyncMode::Relaxed,
-                writeback_preflush_bytes: None,
             };
             cfg.set_root_block_cfg(block_device_config);
         }
@@ -959,7 +955,6 @@ pub unsafe extern "C" fn krun_set_data_disk(ctx_id: u32, c_disk_path: *const c_c
                 sync_mode: SyncMode::Full,
                 #[cfg(target_os = "macos")]
                 sync_mode: SyncMode::Relaxed,
-                writeback_preflush_bytes: None,
             };
             cfg.set_data_block_cfg(block_device_config);
         }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -479,18 +479,15 @@ impl VmResources {
         self.block.insert(config, self.metrics.clone())
     }
 
-    /// Adds a block device with optional rolling writeback and per-device hard backpressure.
+    /// Adds a block device with an optional per-device hard dirty-data budget.
     #[cfg(feature = "blk")]
-    pub fn add_block_device_with_writeback_preflush(
+    pub fn add_block_device_with_writeback_limit(
         &mut self,
         config: BlockDeviceConfig,
-        writeback_preflush_bytes: Option<u64>,
+        writeback_limit_bytes: Option<u64>,
     ) -> Result<BlockConfigError> {
-        self.block.insert_with_writeback_preflush(
-            config,
-            writeback_preflush_bytes,
-            self.metrics.clone(),
-        )
+        self.block
+            .insert_with_writeback_limit(config, writeback_limit_bytes, self.metrics.clone())
     }
 
     /// Sets a vsock device to be attached when the VM starts.

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -479,7 +479,7 @@ impl VmResources {
         self.block.insert(config, self.metrics.clone())
     }
 
-    /// Adds a block device with an optional one-shot writeback threshold between guest flushes.
+    /// Adds a block device with optional rolling writeback and per-device hard backpressure.
     #[cfg(feature = "blk")]
     pub fn add_block_device_with_writeback_preflush(
         &mut self,

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -479,6 +479,20 @@ impl VmResources {
         self.block.insert(config, self.metrics.clone())
     }
 
+    /// Adds a block device with an optional one-shot writeback threshold between guest flushes.
+    #[cfg(feature = "blk")]
+    pub fn add_block_device_with_writeback_preflush(
+        &mut self,
+        config: BlockDeviceConfig,
+        writeback_preflush_bytes: Option<u64>,
+    ) -> Result<BlockConfigError> {
+        self.block.insert_with_writeback_preflush(
+            config,
+            writeback_preflush_bytes,
+            self.metrics.clone(),
+        )
+    }
+
     /// Sets a vsock device to be attached when the VM starts.
     pub fn set_vsock_device(&mut self, config: VsockDeviceConfig) -> Result<VsockConfigError> {
         self.vsock.insert(config)

--- a/src/vmm/src/vmm_config/block.rs
+++ b/src/vmm/src/vmm_config/block.rs
@@ -34,8 +34,6 @@ pub struct BlockDeviceConfig {
     pub is_disk_read_only: bool,
     pub direct_io: bool,
     pub sync_mode: SyncMode,
-    /// Optional host dirty-data threshold for advisory writeback before a guest flush.
-    pub writeback_preflush_bytes: Option<u64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -64,6 +62,31 @@ impl BlockBuilder {
     }
 
     pub fn create_block(config: BlockDeviceConfig, metrics: MetricsWriter) -> Result<Block> {
+        Self::create_block_with_writeback_preflush(config, None, metrics)
+    }
+
+    /// Inserts a block device with an optional advisory writeback threshold.
+    pub fn insert_with_writeback_preflush(
+        &mut self,
+        config: BlockDeviceConfig,
+        writeback_preflush_bytes: Option<u64>,
+        metrics: MetricsWriter,
+    ) -> Result<()> {
+        let block_dev = Arc::new(Mutex::new(Self::create_block_with_writeback_preflush(
+            config,
+            writeback_preflush_bytes,
+            metrics,
+        )?));
+        self.list.push_back(block_dev);
+        Ok(())
+    }
+
+    /// Creates a block device with an optional advisory writeback threshold.
+    pub fn create_block_with_writeback_preflush(
+        config: BlockDeviceConfig,
+        writeback_preflush_bytes: Option<u64>,
+        metrics: MetricsWriter,
+    ) -> Result<Block> {
         let device_metrics = metrics.register_block_device(config.block_id.clone());
         devices::virtio::Block::new_with_writeback_preflush(
             config.block_id,
@@ -74,7 +97,7 @@ impl BlockBuilder {
             config.is_disk_read_only,
             config.direct_io,
             config.sync_mode,
-            config.writeback_preflush_bytes,
+            writeback_preflush_bytes,
             device_metrics,
         )
         .map_err(BlockConfigError::CreateBlockDevice)

--- a/src/vmm/src/vmm_config/block.rs
+++ b/src/vmm/src/vmm_config/block.rs
@@ -62,33 +62,33 @@ impl BlockBuilder {
     }
 
     pub fn create_block(config: BlockDeviceConfig, metrics: MetricsWriter) -> Result<Block> {
-        Self::create_block_with_writeback_preflush(config, None, metrics)
+        Self::create_block_with_writeback_limit(config, None, metrics)
     }
 
-    /// Inserts a block device with an optional advisory writeback threshold.
-    pub fn insert_with_writeback_preflush(
+    /// Inserts a block device with an optional hard buffered dirty-data budget.
+    pub fn insert_with_writeback_limit(
         &mut self,
         config: BlockDeviceConfig,
-        writeback_preflush_bytes: Option<u64>,
+        writeback_limit_bytes: Option<u64>,
         metrics: MetricsWriter,
     ) -> Result<()> {
-        let block_dev = Arc::new(Mutex::new(Self::create_block_with_writeback_preflush(
+        let block_dev = Arc::new(Mutex::new(Self::create_block_with_writeback_limit(
             config,
-            writeback_preflush_bytes,
+            writeback_limit_bytes,
             metrics,
         )?));
         self.list.push_back(block_dev);
         Ok(())
     }
 
-    /// Creates a block device with an optional advisory writeback threshold.
-    pub fn create_block_with_writeback_preflush(
+    /// Creates a block device with an optional hard buffered dirty-data budget.
+    pub fn create_block_with_writeback_limit(
         config: BlockDeviceConfig,
-        writeback_preflush_bytes: Option<u64>,
+        writeback_limit_bytes: Option<u64>,
         metrics: MetricsWriter,
     ) -> Result<Block> {
         let device_metrics = metrics.register_block_device(config.block_id.clone());
-        devices::virtio::Block::new_with_writeback_preflush(
+        devices::virtio::Block::new_with_writeback_limit(
             config.block_id,
             None,
             config.cache_type,
@@ -97,7 +97,7 @@ impl BlockBuilder {
             config.is_disk_read_only,
             config.direct_io,
             config.sync_mode,
-            writeback_preflush_bytes,
+            writeback_limit_bytes,
             device_metrics,
         )
         .map_err(BlockConfigError::CreateBlockDevice)

--- a/src/vmm/src/vmm_config/block.rs
+++ b/src/vmm/src/vmm_config/block.rs
@@ -34,6 +34,8 @@ pub struct BlockDeviceConfig {
     pub is_disk_read_only: bool,
     pub direct_io: bool,
     pub sync_mode: SyncMode,
+    /// Optional host dirty-data threshold for advisory writeback before a guest flush.
+    pub writeback_preflush_bytes: Option<u64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -63,7 +65,7 @@ impl BlockBuilder {
 
     pub fn create_block(config: BlockDeviceConfig, metrics: MetricsWriter) -> Result<Block> {
         let device_metrics = metrics.register_block_device(config.block_id.clone());
-        devices::virtio::Block::new(
+        devices::virtio::Block::new_with_writeback_preflush(
             config.block_id,
             None,
             config.cache_type,
@@ -72,6 +74,7 @@ impl BlockBuilder {
             config.is_disk_read_only,
             config.direct_io,
             config.sync_mode,
+            config.writeback_preflush_bytes,
             device_metrics,
         )
         .map_err(BlockConfigError::CreateBlockDevice)


### PR DESCRIPTION
## TL;DR

Add an explicit Linux-only per-disk hard budget for buffered writable raw disks. Libkrun accounts exact dirty extents, starts and waits for range writeback in a bounded background worker, and applies backpressure before the configured bound can be exceeded.

The policy is disabled by default. Range completion is only the dirty-memory containment boundary; guest `FLUSH` retains the existing full Imago sync as its durability boundary. Containment does not depend on cgroups, guest cooperation or ambient host dirty-page policy.

## Description

- Add `DiskBuilder::writeback_limit_bytes` and carry its optional hard budget through the VMM block-device configuration without changing existing C API behavior.
- Keep every disk disabled by default; zero also disables the policy, while active budgets must be at least 128 MiB.
- Reject unsupported hosts and incompatible read-only, non-raw, direct-I/O, unsafe-cache or sync-disabled disks explicitly.
- Reserve page-aligned unique dirty extents before each mutation and admit only a prefix that fits both the internal batch and the per-device hard budget.
- Kick all currently queued ranges with `SYNC_FILE_RANGE_WRITE`, then wait for their page-cache writeback with `SYNC_FILE_RANGE_WAIT_AFTER` before releasing exact generation credit.
- Keep rewritten pages charged until the newest generation completes, and retain all credits after range, worker or full-sync failures.
- Fail future writes and reactivations closed after a permanent writeback error instead of silently disabling containment.
- Disable discard and zero-with-unmap while bounded mode is active, routing ordinary zeroing through explicit accounted data writes.
- Use Imago 0.1.4 to request best-effort `RWF_DONTCACHE` pruning after completed writes; correctness and the hard bound do not depend on this hint.
- Keep the existing Imago full flush and sync as the guest-visible durability operation. The range worker does not claim data or metadata durability.

```rust
use msb_krun::VmBuilder;

let builder = VmBuilder::new().disk(|disk| {
    disk.path("/var/lib/microsandbox/root.raw")
        .writeback_limit_bytes(512 * 1024 * 1024)
});
```

## Focused performance result

The exact `be17b419` candidate ran the unchanged customer disk suite on OVH with one campaign replicate and two fixed trials per profile. This is an engineering A/B, not a p99 or replacement publication campaign.

- Sequential write: repaired 512 MiB limit 1,668 MB/s; earlier hard-barrier controller 1,668 MB/s; contemporaneous disabled control 9,752 MB/s.
- Random write: repaired limit 432.5 MB/s; disabled control 323.5 MB/s.
- Sequential read: repaired limit 19,600 IOPS; disabled control 19,650 IOPS.
- Random read: repaired limit 364 MB/s; disabled control 365.5 MB/s.
- Hardlink: repaired limit 10.355 bogo ops/s; disabled control 10.42 bogo ops/s.
- Host-global telemetry: repaired limit peaked at 19.4 MiB Dirty and 97.0 MiB Writeback; disabled control peaked at 1,033 MiB Dirty and 865 MiB Writeback.

The range-completion correction preserves containment but does not recover sequential throughput at a 512 MiB budget. The dominant ceiling is the hard budget below the workload's approximately 1 GiB active dirty set, not the removed `fdatasync` barrier. This PR deliberately does not select a product default; the builder remains disabled unless its host caller supplies a budget.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p msb_krun_devices --features blk --lib` on exact Linux x86_64 commit: 97 passed
- [x] `cargo clippy -p msb_krun_devices --features blk --lib -- -D warnings`
- [x] GitHub Linux x86_64/aarch64 and macOS aarch64 code-quality checks
- [x] GitHub Linux and Windows unit tests
- [x] GitHub Linux integration tests and formatting checks
- [x] Exact Microsandbox integration build and unchanged OVH disk A/B
