### PR TITLE
fix(irqchip): restore explicit selection and safe x86 geometry

### DIFF
--- a/src/arch/src/x86_64/layout.rs
+++ b/src/arch/src/x86_64/layout.rs
@@ -29,11 +29,12 @@ pub const IRQ_BASE: u32 = 5;
 /// Last usable IRQ ID for virtio device interrupts on x86_64 when using
 /// KVM's in-kernel IOAPIC (hardcoded to 24 pins by KVM_IOAPIC_NUM_PINS).
 pub const IRQ_MAX: u32 = 15;
-/// Number of redirection entries exposed by the userspace IOAPIC.
-pub const IOAPIC_NUM_PINS: usize = 256;
-/// Last usable IRQ ID when using the userspace split irqchip. The upper
-/// IOAPIC pins are left out of the virtio allocation range for platform use.
-pub const IRQ_MAX_SPLIT: u32 = 223;
+/// Number of redirection entries exposed by KVM's in-kernel IOAPIC.
+pub const KVM_IOAPIC_NUM_PINS: usize = 24;
+/// Number of redirection entries addressable through one 8-bit IOREGSEL.
+pub const IOAPIC_NUM_PINS: usize = 120;
+/// Last usable IRQ ID when using the userspace split irqchip.
+pub const IRQ_MAX_SPLIT: u32 = IOAPIC_NUM_PINS as u32 - 1;
 
 /// Address for the TSS setup.
 pub const KVM_TSS_ADDRESS: u64 = 0xfffb_d000;

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -249,6 +249,7 @@ pub fn arch_memory_regions(
 /// * `cmdline_size` - Size of the kernel command line in bytes including the null terminator.
 /// * `initrd` - Information about where the ramdisk image was loaded in the `guest_mem`.
 /// * `num_cpus` - Number of virtual CPUs the guest will have.
+/// * `ioapic_num_pins` - Number of redirection entries exposed by the active IOAPIC.
 #[allow(unused_variables)]
 pub fn configure_system(
     guest_mem: &GuestMemoryMmap,
@@ -257,6 +258,7 @@ pub fn configure_system(
     cmdline_size: usize,
     initrd: &Option<InitrdConfig>,
     num_cpus: u8,
+    ioapic_num_pins: usize,
 ) -> super::Result<()> {
     const KERNEL_BOOT_FLAG_MAGIC: u16 = 0xaa55;
     const KERNEL_HDR_MAGIC: u32 = 0x5372_6448;
@@ -269,7 +271,7 @@ pub fn configure_system(
 
     // Note that this puts the mptable at the last 1k of Linux's 640k base RAM
     #[cfg(not(feature = "tee"))]
-    mptable::setup_mptable(guest_mem, num_cpus).map_err(Error::MpTableSetup)?;
+    mptable::setup_mptable(guest_mem, num_cpus, ioapic_num_pins).map_err(Error::MpTableSetup)?;
 
     let mut params: BootParamsWrapper = BootParamsWrapper(boot_params::default());
 
@@ -362,6 +364,7 @@ fn add_e820_entry(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::x86_64::layout::KVM_IOAPIC_NUM_PINS;
     use arch_gen::x86::bootparam::e820entry;
 
     const KERNEL_LOAD_ADDR: u64 = 0x0100_0000;
@@ -405,7 +408,15 @@ mod tests {
         let no_vcpus = 4;
         let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let info = ArchMemoryInfo::default();
-        let config_err = configure_system(&gm, &info, GuestAddress(0), 0, &None, 1);
+        let config_err = configure_system(
+            &gm,
+            &info,
+            GuestAddress(0),
+            0,
+            &None,
+            1,
+            KVM_IOAPIC_NUM_PINS,
+        );
         assert!(config_err.is_err());
         #[cfg(not(feature = "tee"))]
         assert_eq!(
@@ -418,21 +429,48 @@ mod tests {
         let (arch_mem_info, arch_mem_regions) =
             arch_memory_regions(mem_size, Some(KERNEL_LOAD_ADDR), KERNEL_SIZE, 0, None);
         let gm = GuestMemoryMmap::from_ranges(&arch_mem_regions).unwrap();
-        configure_system(&gm, &arch_mem_info, GuestAddress(0), 0, &None, no_vcpus).unwrap();
+        configure_system(
+            &gm,
+            &arch_mem_info,
+            GuestAddress(0),
+            0,
+            &None,
+            no_vcpus,
+            KVM_IOAPIC_NUM_PINS,
+        )
+        .unwrap();
 
         // Now assigning some memory that is equal to the start of the 32bit memory hole.
         let mem_size = 3328 << 20;
         let (arch_mem_info, arch_mem_regions) =
             arch_memory_regions(mem_size, Some(KERNEL_LOAD_ADDR), KERNEL_SIZE, 0, None);
         let gm = GuestMemoryMmap::from_ranges(&arch_mem_regions).unwrap();
-        configure_system(&gm, &arch_mem_info, GuestAddress(0), 0, &None, no_vcpus).unwrap();
+        configure_system(
+            &gm,
+            &arch_mem_info,
+            GuestAddress(0),
+            0,
+            &None,
+            no_vcpus,
+            KVM_IOAPIC_NUM_PINS,
+        )
+        .unwrap();
 
         // Now assigning some memory that falls after the 32bit memory hole.
         let mem_size = 3330 << 20;
         let (arch_mem_info, arch_mem_regions) =
             arch_memory_regions(mem_size, Some(KERNEL_LOAD_ADDR), KERNEL_SIZE, 0, None);
         let gm = GuestMemoryMmap::from_ranges(&arch_mem_regions).unwrap();
-        configure_system(&gm, &arch_mem_info, GuestAddress(0), 0, &None, no_vcpus).unwrap();
+        configure_system(
+            &gm,
+            &arch_mem_info,
+            GuestAddress(0),
+            0,
+            &None,
+            no_vcpus,
+            KVM_IOAPIC_NUM_PINS,
+        )
+        .unwrap();
     }
 
     #[test]

--- a/src/arch/src/x86_64/mptable.rs
+++ b/src/arch/src/x86_64/mptable.rs
@@ -13,7 +13,6 @@ use libc::c_char;
 
 use arch_gen::x86::mpspec;
 
-use crate::x86_64::layout::IOAPIC_NUM_PINS;
 use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryBackend, GuestMemoryMmap};
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
@@ -60,6 +59,8 @@ pub enum Error {
     Clear,
     /// Number of CPUs exceeds the maximum supported CPUs
     TooManyCpus,
+    /// The IOAPIC pin count cannot be represented by the MP table.
+    InvalidIoapicPinCount,
     /// Failure to write the MP floating pointer.
     WriteMpfIntel,
     /// Failure to write MP CPU entry.
@@ -117,26 +118,29 @@ fn mpf_intel_compute_checksum(v: &mpspec::mpf_intel) -> u8 {
     (!checksum).wrapping_add(1)
 }
 
-fn compute_mp_size(num_cpus: u8) -> usize {
+fn compute_mp_size(num_cpus: u8, ioapic_num_pins: usize) -> usize {
     mem::size_of::<MpcTableWrapper>()
         + mem::size_of::<MpcCpuWrapper>() * (num_cpus as usize)
         + mem::size_of::<MpcIoapicWrapper>()
         + mem::size_of::<MpcBusWrapper>()
-        + mem::size_of::<MpcIntsrcWrapper>() * IOAPIC_NUM_PINS
+        + mem::size_of::<MpcIntsrcWrapper>() * ioapic_num_pins
         + mem::size_of::<MpcLintsrcWrapper>() * 2
 }
 
 /// Performs setup of the MP table for the given `num_cpus`.
-pub fn setup_mptable(mem: &GuestMemoryMmap, num_cpus: u8) -> Result<()> {
+pub fn setup_mptable(mem: &GuestMemoryMmap, num_cpus: u8, ioapic_num_pins: usize) -> Result<()> {
     if u32::from(num_cpus) > MAX_SUPPORTED_CPUS {
         return Err(Error::TooManyCpus);
+    }
+    if ioapic_num_pins == 0 || ioapic_num_pins > usize::from(u8::MAX) + 1 {
+        return Err(Error::InvalidIoapicPinCount);
     }
 
     // Used to keep track of the next base pointer into the MP table.
     let mpf_base = GuestAddress(MP_FLOATING_POINTER_START);
     let mut base_mp = GuestAddress(MPTABLE_START);
 
-    let mp_size = compute_mp_size(num_cpus);
+    let mp_size = compute_mp_size(num_cpus, ioapic_num_pins);
 
     let mut checksum: u8 = 0;
     let ioapicid: u8 = num_cpus + 1;
@@ -223,7 +227,7 @@ pub fn setup_mptable(mem: &GuestMemoryMmap, num_cpus: u8) -> Result<()> {
         base_mp = base_mp.unchecked_add(size);
         checksum = checksum.wrapping_add(compute_checksum(&mpc_ioapic.0));
     }
-    for i in 0..IOAPIC_NUM_PINS {
+    for i in 0..ioapic_num_pins {
         let size = mem::size_of::<MpcIntsrcWrapper>() as u64;
         let mut mpc_intsrc = MpcIntsrcWrapper(mpspec::mpc_intsrc::default());
         mpc_intsrc.0.type_ = mpspec::MP_INTSRC as u8;
@@ -294,6 +298,7 @@ pub fn setup_mptable(mem: &GuestMemoryMmap, num_cpus: u8) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::x86_64::layout::IOAPIC_NUM_PINS;
     use std::io;
     use std::io::Write;
     use vm_memory::Bytes;
@@ -330,25 +335,25 @@ mod tests {
     #[test]
     fn bounds_check() {
         let num_cpus = 4;
-        let mem = mp_table_memory(compute_mp_size(num_cpus));
+        let mem = mp_table_memory(compute_mp_size(num_cpus, IOAPIC_NUM_PINS));
 
-        setup_mptable(&mem, num_cpus).unwrap();
+        setup_mptable(&mem, num_cpus, IOAPIC_NUM_PINS).unwrap();
     }
 
     #[test]
     fn bounds_check_fails() {
         let num_cpus = 4;
-        let mem = mp_table_memory(compute_mp_size(num_cpus) - 1);
+        let mem = mp_table_memory(compute_mp_size(num_cpus, IOAPIC_NUM_PINS) - 1);
 
-        assert!(setup_mptable(&mem, num_cpus).is_err());
+        assert!(setup_mptable(&mem, num_cpus, IOAPIC_NUM_PINS).is_err());
     }
 
     #[test]
     fn mpf_intel_checksum() {
         let num_cpus = 1;
-        let mem = mp_table_memory(compute_mp_size(num_cpus));
+        let mem = mp_table_memory(compute_mp_size(num_cpus, IOAPIC_NUM_PINS));
 
-        setup_mptable(&mem, num_cpus).unwrap();
+        setup_mptable(&mem, num_cpus, IOAPIC_NUM_PINS).unwrap();
 
         let mpf_intel: MpfIntelWrapper = mem
             .read_obj(GuestAddress(MP_FLOATING_POINTER_START))
@@ -363,9 +368,9 @@ mod tests {
     #[test]
     fn mpc_table_checksum() {
         let num_cpus = 4;
-        let mem = mp_table_memory(compute_mp_size(num_cpus));
+        let mem = mp_table_memory(compute_mp_size(num_cpus, IOAPIC_NUM_PINS));
 
-        setup_mptable(&mem, num_cpus).unwrap();
+        setup_mptable(&mem, num_cpus, IOAPIC_NUM_PINS).unwrap();
 
         let mpc_offset = mpc_table_offset(&mem);
         let mpc_table: MpcTableWrapper = mem.read_obj(mpc_offset).unwrap();
@@ -392,45 +397,48 @@ mod tests {
     }
 
     #[test]
-    fn intsrc_entries_cover_ioapic_pin_32() {
+    fn intsrc_entries_match_ioapic_geometry() {
         let num_cpus = 1;
-        let mem = mp_table_memory(compute_mp_size(num_cpus));
+        for ioapic_num_pins in [24, 64, IOAPIC_NUM_PINS] {
+            let mem = mp_table_memory(compute_mp_size(num_cpus, ioapic_num_pins));
 
-        setup_mptable(&mem, num_cpus).unwrap();
+            setup_mptable(&mem, num_cpus, ioapic_num_pins).unwrap();
 
-        let mpc_offset = mpc_table_offset(&mem);
-        let mpc_table: MpcTableWrapper = mem.read_obj(mpc_offset).unwrap();
-        let mpc_end = mpc_offset
-            .checked_add(u64::from(mpc_table.0.length))
-            .unwrap();
-        let mut entry_offset = mpc_offset
-            .checked_add(mem::size_of::<MpcTableWrapper>() as u64)
-            .unwrap();
-        let mut intsrc_count = 0;
-        let mut found_pin_32 = false;
-
-        while entry_offset < mpc_end {
-            let entry_type: u8 = mem.read_obj(entry_offset).unwrap();
-            if u32::from(entry_type) == mpspec::MP_INTSRC {
-                let intsrc: MpcIntsrcWrapper = mem.read_obj(entry_offset).unwrap();
-                intsrc_count += 1;
-                found_pin_32 |= intsrc.0.srcbusirq == 32 && intsrc.0.dstirq == 32;
-            }
-            entry_offset = entry_offset
-                .checked_add(table_entry_size(entry_type) as u64)
+            let mpc_offset = mpc_table_offset(&mem);
+            let mpc_table: MpcTableWrapper = mem.read_obj(mpc_offset).unwrap();
+            let mpc_end = mpc_offset
+                .checked_add(u64::from(mpc_table.0.length))
                 .unwrap();
-        }
+            let mut entry_offset = mpc_offset
+                .checked_add(mem::size_of::<MpcTableWrapper>() as u64)
+                .unwrap();
+            let mut intsrc_count = 0;
+            let mut found_last_pin = false;
 
-        assert_eq!(intsrc_count, IOAPIC_NUM_PINS);
-        assert!(found_pin_32);
+            while entry_offset < mpc_end {
+                let entry_type: u8 = mem.read_obj(entry_offset).unwrap();
+                if u32::from(entry_type) == mpspec::MP_INTSRC {
+                    let intsrc: MpcIntsrcWrapper = mem.read_obj(entry_offset).unwrap();
+                    intsrc_count += 1;
+                    let last_pin = (ioapic_num_pins - 1) as u8;
+                    found_last_pin |= intsrc.0.srcbusirq == last_pin && intsrc.0.dstirq == last_pin;
+                }
+                entry_offset = entry_offset
+                    .checked_add(table_entry_size(entry_type) as u64)
+                    .unwrap();
+            }
+
+            assert_eq!(intsrc_count, ioapic_num_pins);
+            assert!(found_last_pin);
+        }
     }
 
     #[test]
     fn cpu_entry_count() {
-        let mem = mp_table_memory(compute_mp_size(MAX_SUPPORTED_CPUS as u8));
+        let mem = mp_table_memory(compute_mp_size(MAX_SUPPORTED_CPUS as u8, IOAPIC_NUM_PINS));
 
         for i in 0..MAX_SUPPORTED_CPUS as u8 {
-            setup_mptable(&mem, i).unwrap();
+            setup_mptable(&mem, i, IOAPIC_NUM_PINS).unwrap();
 
             let mpf_intel: MpfIntelWrapper = mem
                 .read_obj(GuestAddress(MP_FLOATING_POINTER_START))
@@ -462,9 +470,23 @@ mod tests {
     #[test]
     fn cpu_entry_count_max() {
         let cpus = MAX_SUPPORTED_CPUS + 1;
-        let mem = mp_table_memory(compute_mp_size(cpus as u8));
+        let mem = mp_table_memory(compute_mp_size(cpus as u8, IOAPIC_NUM_PINS));
 
-        let result = setup_mptable(&mem, cpus as u8).unwrap_err();
+        let result = setup_mptable(&mem, cpus as u8, IOAPIC_NUM_PINS).unwrap_err();
         assert_eq!(result, Error::TooManyCpus);
+    }
+
+    #[test]
+    fn rejects_unrepresentable_ioapic_geometry() {
+        let mem = mp_table_memory(compute_mp_size(1, IOAPIC_NUM_PINS));
+
+        assert_eq!(
+            setup_mptable(&mem, 1, 0).unwrap_err(),
+            Error::InvalidIoapicPinCount
+        );
+        assert_eq!(
+            setup_mptable(&mem, 1, usize::from(u8::MAX) + 2).unwrap_err(),
+            Error::InvalidIoapicPinCount
+        );
     }
 }

--- a/src/devices/src/legacy/ioapic.rs
+++ b/src/devices/src/legacy/ioapic.rs
@@ -80,7 +80,7 @@ pub struct IoApicEntryInfo {
     trig_mode: u8,
     _dest_idx: u16,
     _dest_mode: u8,
-    _delivery_mode: u8,
+    delivery_mode: u8,
     _vector: u8,
 
     addr: u32,
@@ -100,7 +100,6 @@ pub struct IoApic {
     irr: [u64; IRR_WORDS],
     ioredtbl: [u64; IOAPIC_NUM_PINS],
     version: u8,
-    irq_eoi: [i32; IOAPIC_NUM_PINS],
     irq_routes: Vec<kvm_irq_routing_entry>,
     irq_sender: crossbeam_channel::Sender<WorkerMessage>,
 }
@@ -128,7 +127,6 @@ impl IoApic {
             irr: [0; IRR_WORDS],
             ioredtbl: [1 << IOAPIC_LVT_MASKED_SHIFT; IOAPIC_NUM_PINS],
             version: 0x20,
-            irq_eoi: [0; IOAPIC_NUM_PINS],
             irq_routes: Vec::with_capacity(IOAPIC_NUM_PINS),
             irq_sender: _irq_sender,
         };
@@ -181,16 +179,12 @@ impl IoApic {
         let trig_mode = ((entry >> IOAPIC_LVT_TRIGGER_MODE_SHIFT) & 1) as u8;
         let dest_mode = ((entry >> IOAPIC_LVT_DEST_MODE_SHIFT) & 1) as u8;
 
-        if delivery_mode as u64 == IOAPIC_DM_EXTINT {
-            panic!("ioapic: libkrun does not have PIC support");
-        }
-
         IoApicEntryInfo {
             masked: ((entry >> IOAPIC_LVT_MASKED_SHIFT) & 1) as u8,
             trig_mode,
             _dest_idx: dest_idx,
             _dest_mode: dest_mode,
-            _delivery_mode: delivery_mode,
+            delivery_mode,
             _vector: vector,
 
             addr: ((APIC_DEFAULT_ADDRESS as u64)
@@ -230,7 +224,7 @@ impl IoApic {
         for i in 0..IOAPIC_NUM_PINS {
             let info = self.parse_entry(&self.ioredtbl[i]);
 
-            if info.masked == 0 {
+            if info.masked == 0 && info.delivery_mode as u64 != IOAPIC_DM_EXTINT {
                 let msg = MsiMessage {
                     address: info.addr as u64,
                     data: info.data as u64,
@@ -241,14 +235,21 @@ impl IoApic {
         }
 
         let (response_sender, response_receiver) = unbounded();
-        self.irq_sender
+        if self
+            .irq_sender
             .send(WorkerMessage::GsiRoute(
-                response_sender.clone(),
+                response_sender,
                 self.irq_routes.clone(),
             ))
-            .unwrap();
-        if !response_receiver.recv().unwrap() {
-            error!("unable to set GSI Routes for IO APIC");
+            .is_err()
+        {
+            error!("unable to send GSI routes to the IRQ worker");
+            return;
+        }
+        match response_receiver.recv() {
+            Ok(true) => {}
+            Ok(false) => error!("unable to set GSI routes for IO APIC"),
+            Err(_) => error!("IRQ worker stopped while setting GSI routes"),
         }
     }
 
@@ -264,6 +265,47 @@ impl IoApic {
         self.irr[word] &= !(1u64 << bit);
     }
 
+    fn selected_redirection_entry(&self) -> Option<(usize, bool)> {
+        let register = usize::from(self.ioregsel).checked_sub(IOAPIC_REG_REDTBL_BASE as usize)?;
+        let index = register >> 1;
+        (index < IOAPIC_NUM_PINS).then_some((index, register & 1 != 0))
+    }
+
+    fn end_of_interrupt(&mut self, vector: u8) {
+        let mut cleared_remote_irr = false;
+        for entry in &mut self.ioredtbl {
+            if (*entry & IOAPIC_VECTOR_MASK) as u8 == vector && *entry & IOAPIC_LVT_REMOTE_IRR != 0
+            {
+                *entry &= !IOAPIC_LVT_REMOTE_IRR;
+                cleared_remote_irr = true;
+            }
+        }
+
+        // A level-triggered line may still be asserted after EOI. Service it again only when an
+        // entry actually transitioned, which avoids unnecessary worker traffic for stray EOIs.
+        if cleared_remote_irr {
+            self.service();
+        }
+    }
+
+    fn send_irq_line(&self, virq: usize, active: bool) {
+        let (response_sender, response_receiver) = unbounded();
+        if self
+            .irq_sender
+            .send(WorkerMessage::IrqLine(response_sender, virq as u32, active))
+            .is_err()
+        {
+            error!("IRQ worker stopped before IRQ {virq} could be set to {active}");
+            return;
+        }
+
+        match response_receiver.recv() {
+            Ok(true) => {}
+            Ok(false) => error!("unable to set IRQ {virq} to {active}"),
+            Err(_) => error!("IRQ worker stopped while setting IRQ {virq} to {active}"),
+        }
+    }
+
     fn service(&mut self) {
         for i in 0..IOAPIC_NUM_PINS {
             if self.irr_is_set(i) {
@@ -271,7 +313,7 @@ impl IoApic {
 
                 let entry = self.ioredtbl[i];
                 let info = self.parse_entry(&entry);
-                if info.masked == 0 {
+                if info.masked == 0 && info.delivery_mode as u64 != IOAPIC_DM_EXTINT {
                     if info.trig_mode as u64 == IOAPIC_TRIGGER_EDGE {
                         self.irr_clear(i);
                     } else {
@@ -283,49 +325,11 @@ impl IoApic {
                         continue;
                     }
 
-                    let (response_sender, response_receiver) = unbounded();
                     if info.trig_mode as u64 == IOAPIC_TRIGGER_EDGE {
-                        self.irq_sender
-                            .send(WorkerMessage::IrqLine(
-                                response_sender.clone(),
-                                i as u32,
-                                true,
-                            ))
-                            .unwrap();
-                        if !response_receiver.recv().unwrap() {
-                            error!(
-                                "unable to set IRQ LINE for IRQ {} with active set to {}",
-                                i, true
-                            );
-                        }
-
-                        self.irq_sender
-                            .send(WorkerMessage::IrqLine(
-                                response_sender.clone(),
-                                i as u32,
-                                false,
-                            ))
-                            .unwrap();
-                        if !response_receiver.recv().unwrap() {
-                            error!(
-                                "unable to set IRQ LINE for IRQ {} with active set to {}",
-                                i, false
-                            );
-                        }
+                        self.send_irq_line(i, true);
+                        self.send_irq_line(i, false);
                     } else {
-                        self.irq_sender
-                            .send(WorkerMessage::IrqLine(
-                                response_sender.clone(),
-                                i as u32,
-                                true,
-                            ))
-                            .unwrap();
-                        if !response_receiver.recv().unwrap() {
-                            error!(
-                                "unable to set IRQ LINE for IRQ {} with active set to {}",
-                                i, true
-                            );
-                        }
+                        self.send_irq_line(i, true);
                     }
                 }
             }
@@ -340,6 +344,10 @@ impl IrqChipT for IoApic {
 
     fn get_mmio_size(&self) -> u64 {
         0x1000
+    }
+
+    fn num_pins(&self) -> usize {
+        IOAPIC_NUM_PINS
     }
 
     fn set_irq(
@@ -388,34 +396,26 @@ impl BusDevice for IoApic {
                             | ((IOAPIC_NUM_PINS as u32 - 1) << IOAPIC_VER_ENTRIES_SHIFT)
                     }
                     _ => {
-                        let Some(reg_index) =
-                            (self.ioregsel as u64).checked_sub(IOAPIC_REG_REDTBL_BASE)
-                        else {
+                        let Some((index, high)) = self.selected_redirection_entry() else {
                             debug!("ioapic: read: invalid ioregsel {}", self.ioregsel);
                             data.fill(0);
                             return;
                         };
-                        let index = reg_index >> 1;
                         debug!("ioapic: read: ioredtbl register {index}");
-                        let mut val = 0u32;
 
-                        // we can only read from this register in 32-bit chunks.
-                        // Therefore, we need to check if we are reading the
-                        // upper 32 bits or the lower
-                        if index < IOAPIC_NUM_PINS as u64 {
-                            if self.ioregsel & 1 > 0 {
-                                // read upper 32 bits
-                                val = (self.ioredtbl[index as usize] >> 32) as u32;
-                            } else {
-                                // read lower 32 bits
-                                val = (self.ioredtbl[index as usize] & 0xffff_ffffu64) as u32;
-                            }
+                        if high {
+                            (self.ioredtbl[index] >> 32) as u32
+                        } else {
+                            (self.ioredtbl[index] & 0xffff_ffffu64) as u32
                         }
-                        val
                     }
                 }
             }
-            _ => unreachable!(),
+            _ => {
+                debug!("ioapic: read: unsupported offset {offset:#x}");
+                data.fill(0);
+                return;
+            }
         };
 
         // turn the value into native endian byte order and put that value into `data`
@@ -451,45 +451,44 @@ impl BusDevice for IoApic {
                     // NOTE: these are read-only registers, so they should never be written to
                     IO_APIC_VER | IO_APIC_ARB => debug!("ioapic: write: IOAPIC VERSION"),
                     _ => {
-                        let Some(reg_index) =
-                            (self.ioregsel as u64).checked_sub(IOAPIC_REG_REDTBL_BASE)
-                        else {
+                        let Some((index, high)) = self.selected_redirection_entry() else {
                             debug!("ioapic: write: invalid ioregsel {}", self.ioregsel);
                             return;
                         };
-
-                        let index = reg_index >> 1;
                         debug!("ioapic: write: ioredtbl register {index}");
-                        if index >= IOAPIC_NUM_PINS as u64 {
-                            warn!("ioapic: write: virq out of pin range {index}");
-                            return;
-                        }
-
-                        let ro_bits = self.ioredtbl[index as usize] & IOAPIC_RO_BITS;
+                        let ro_bits = self.ioredtbl[index] & IOAPIC_RO_BITS;
                         // check if we are writing to the upper 32-bits of the
                         // register or the lower 32-bits
-                        if self.ioregsel & 1 > 0 {
-                            self.ioredtbl[index as usize] &= 0xffff_ffff;
-                            self.ioredtbl[index as usize] |= (val as u64) << 32;
+                        if high {
+                            self.ioredtbl[index] &= 0xffff_ffff;
+                            self.ioredtbl[index] |= (val as u64) << 32;
                         } else {
-                            self.ioredtbl[index as usize] &= !0xffff_ffff;
-                            self.ioredtbl[index as usize] |= val as u64;
+                            self.ioredtbl[index] &= !0xffff_ffff;
+                            self.ioredtbl[index] |= val as u64;
                         }
 
                         // restore RO bits
-                        self.ioredtbl[index as usize] &= IOAPIC_RW_BITS;
-                        self.ioredtbl[index as usize] |= ro_bits;
-                        self.irq_eoi[index as usize] = 0;
+                        self.ioredtbl[index] &= IOAPIC_RW_BITS;
+                        self.ioredtbl[index] |= ro_bits;
+
+                        // ExtINT requires a legacy PIC, which libkrun does not emulate. Keep the
+                        // entry masked instead of allowing guest-controlled state to panic the VMM.
+                        let delivery_mode =
+                            (self.ioredtbl[index] >> IOAPIC_LVT_DELIV_MODE_SHIFT) & IOAPIC_DM_MASK;
+                        if delivery_mode == IOAPIC_DM_EXTINT {
+                            warn!("ioapic: masking unsupported ExtINT route for pin {index}");
+                            self.ioredtbl[index] |= 1 << IOAPIC_LVT_MASKED_SHIFT;
+                        }
 
                         // if the trigger mode is EDGE, clear IRR bit
-                        self.fix_edge_remote_irr(index as usize);
+                        self.fix_edge_remote_irr(index);
                         self.update_routes();
                         self.service();
                     }
                 }
             }
-            IO_EOI => todo!(),
-            _ => unreachable!(),
+            IO_EOI => self.end_of_interrupt((val as u64 & IOAPIC_VECTOR_MASK) as u8),
+            _ => debug!("ioapic: write: ignoring unsupported offset {offset:#x}"),
         }
     }
 }
@@ -506,7 +505,6 @@ mod tests {
             irr: [0; IRR_WORDS],
             ioredtbl: [1 << IOAPIC_LVT_MASKED_SHIFT; IOAPIC_NUM_PINS],
             version: 0x20,
-            irq_eoi: [0; IOAPIC_NUM_PINS],
             irq_routes: Vec::new(),
             irq_sender,
         }
@@ -525,5 +523,53 @@ mod tests {
             ioapic.irr_clear(pin);
             assert!(!ioapic.irr_is_set(pin));
         }
+    }
+
+    #[test]
+    fn last_pin_is_addressable_through_ioregsel() {
+        let mut ioapic = test_ioapic();
+
+        ioapic.ioregsel = 0xfe;
+        assert_eq!(ioapic.selected_redirection_entry(), Some((119, false)));
+        ioapic.ioregsel = 0xff;
+        assert_eq!(ioapic.selected_redirection_entry(), Some((119, true)));
+        assert_eq!(IOAPIC_NUM_PINS, 120);
+    }
+
+    #[test]
+    fn unsupported_mmio_accesses_and_eoi_do_not_panic() {
+        let mut ioapic = test_ioapic();
+        let mut data = [0xff; 4];
+
+        ioapic.read(0, 0x20, &mut data);
+        assert_eq!(data, [0; 4]);
+        ioapic.write(0, 0x20, &[0; 4]);
+        ioapic.write(0, IO_EOI, &[0; 4]);
+    }
+
+    #[test]
+    fn eoi_clears_remote_irr_for_the_matching_vector() {
+        let mut ioapic = test_ioapic();
+        ioapic.ioredtbl[0] = 0x31 | IOAPIC_LVT_REMOTE_IRR;
+        ioapic.ioredtbl[1] = 0x32 | IOAPIC_LVT_REMOTE_IRR;
+
+        ioapic.write(0, IO_EOI, &0x31u32.to_ne_bytes());
+
+        assert_eq!(ioapic.ioredtbl[0] & IOAPIC_LVT_REMOTE_IRR, 0);
+        assert_ne!(ioapic.ioredtbl[1] & IOAPIC_LVT_REMOTE_IRR, 0);
+    }
+
+    #[test]
+    fn extint_routes_are_safely_masked() {
+        let mut ioapic = test_ioapic();
+        ioapic.ioregsel = IOAPIC_REG_REDTBL_BASE as u8;
+
+        ioapic.write(
+            0,
+            IO_WIN,
+            &((IOAPIC_DM_EXTINT as u32) << IOAPIC_LVT_DELIV_MODE_SHIFT).to_ne_bytes(),
+        );
+
+        assert_ne!(ioapic.ioredtbl[0] & (1 << IOAPIC_LVT_MASKED_SHIFT), 0);
     }
 }

--- a/src/devices/src/legacy/irqchip.rs
+++ b/src/devices/src/legacy/irqchip.rs
@@ -28,6 +28,11 @@ impl IrqChipDevice {
         self.inner.get_mmio_size()
     }
 
+    #[cfg(target_arch = "x86_64")]
+    pub fn num_pins(&self) -> usize {
+        self.inner.num_pins()
+    }
+
     pub fn set_irq(
         &self,
         irq_line: Option<u32>,
@@ -116,6 +121,7 @@ impl AIADevice for IrqChipDevice {
 pub trait IrqChipT: BusDevice {
     fn get_mmio_addr(&self) -> u64;
     fn get_mmio_size(&self) -> u64;
+    fn num_pins(&self) -> usize;
     fn set_irq(
         &self,
         irq_line: Option<u32>,
@@ -215,6 +221,10 @@ pub mod test_utils {
         }
         fn get_mmio_size(&self) -> u64 {
             0
+        }
+        #[cfg(target_arch = "x86_64")]
+        fn num_pins(&self) -> usize {
+            arch::x86_64::layout::KVM_IOAPIC_NUM_PINS
         }
         fn set_irq(
             &self,

--- a/src/devices/src/legacy/kvmioapic.rs
+++ b/src/devices/src/legacy/kvmioapic.rs
@@ -3,6 +3,8 @@
 
 use std::io;
 
+use arch::x86_64::layout::KVM_IOAPIC_NUM_PINS;
+
 use crate::bus::BusDevice;
 use crate::legacy::irqchip::IrqChipT;
 use crate::Error as DeviceError;
@@ -35,6 +37,10 @@ impl IrqChipT for KvmIoapic {
 
     fn get_mmio_size(&self) -> u64 {
         0
+    }
+
+    fn num_pins(&self) -> usize {
+        KVM_IOAPIC_NUM_PINS
     }
 
     fn set_irq(

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -914,6 +914,22 @@ const X86_IOAPIC_REDTBL_RW_BITS: u64 = !X86_IOAPIC_REDTBL_RO_BITS;
 #[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 const X86_IOAPIC_VECTOR_MASK: u64 = 0xff;
 
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
+fn x86_mmio_irq_max(_split_irqchip: bool) -> u32 {
+    // WHP always uses the userspace IOAPIC, so the KVM-specific split setting must not constrain
+    // the Windows allocator.
+    X86_IOAPIC_NUM_PINS as u32 - 1
+}
+
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
+fn x86_mmio_irq_max(split_irqchip: bool) -> u32 {
+    if split_irqchip {
+        arch::IRQ_MAX_SPLIT
+    } else {
+        arch::IRQ_MAX
+    }
+}
+
 #[cfg(target_os = "windows")]
 impl devices::BusDevice for WhpIrqChip {
     fn read(&mut self, _vcpuid: u64, offset: u64, data: &mut [u8]) {
@@ -981,6 +997,11 @@ impl IrqChipT for WhpIrqChip {
 
         #[cfg(target_arch = "aarch64")]
         0
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn num_pins(&self) -> usize {
+        X86_IOAPIC_NUM_PINS
     }
 
     fn set_irq(
@@ -1439,14 +1460,8 @@ pub fn build_microvm(
     // is emulated in userspace with X86_IOAPIC_NUM_PINS redirection entries; the usable ceiling is
     // pin NUM_PINS-1, not the legacy in-kernel IRQ_MAX. This lifts the virtio MMIO IRQ count from 11
     // (IRQ_BASE..=IRQ_MAX) to NUM_PINS-IRQ_BASE, enough for a guest with several virtiofs mounts.
-    #[cfg(all(target_arch = "x86_64", target_os = "windows"))]
-    let irq_max = X86_IOAPIC_NUM_PINS as u32 - 1;
-    #[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
-    let irq_max = if vm_resources.split_irqchip {
-        arch::IRQ_MAX_SPLIT
-    } else {
-        arch::IRQ_MAX
-    };
+    #[cfg(target_arch = "x86_64")]
+    let irq_max = x86_mmio_irq_max(vm_resources.split_irqchip);
     #[cfg(not(target_arch = "x86_64"))]
     let irq_max = arch::IRQ_MAX;
     #[allow(unused_mut)]
@@ -4092,6 +4107,41 @@ pub mod tests {
     use super::*;
     #[cfg(not(target_os = "windows"))]
     use crate::vmm_config::kernel_bundle::KernelBundle;
+
+    #[test]
+    #[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
+    fn linux_irqchip_selection_remains_explicit() {
+        assert_eq!(x86_mmio_irq_max(false), arch::IRQ_MAX);
+        assert_eq!(x86_mmio_irq_max(true), arch::IRQ_MAX_SPLIT);
+    }
+
+    #[test]
+    #[cfg(all(target_arch = "x86_64", target_os = "windows"))]
+    fn windows_uses_the_whp_ioapic_capacity() {
+        assert_eq!(x86_mmio_irq_max(false), 63);
+        assert_eq!(x86_mmio_irq_max(true), 63);
+        assert_eq!(X86_IOAPIC_NUM_PINS - arch::IRQ_BASE as usize, 59);
+    }
+
+    #[test]
+    #[cfg(all(target_arch = "x86_64", target_os = "windows"))]
+    fn windows_ioapic_programs_its_last_pin() {
+        let mut ioapic = WhpIoApicState::new();
+
+        ioapic.ioregsel = X86_IOAPIC_VER;
+        assert_eq!(
+            ioapic.read_selected_register() >> X86_IOAPIC_VER_ENTRIES_SHIFT,
+            63
+        );
+
+        ioapic.ioregsel = 0x8e;
+        ioapic.write_selected_register(0x45);
+        ioapic.ioregsel = 0x8f;
+        ioapic.write_selected_register(0);
+        let route = ioapic.route_for_irq(63).unwrap();
+        assert_eq!(route.vector, 0x45);
+        assert!(ioapic.route_for_irq(64).is_none());
+    }
 
     #[test]
     #[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1435,26 +1435,6 @@ pub fn build_microvm(
     // 'mmio_base' address has to be an address which is protected by the kernel
     // and is architectural specific.
     //
-    // x86_64 exposes only IRQ_BASE..=IRQ_MAX (the legacy ISA range) of MMIO interrupt lines with
-    // the in-kernel IOAPIC, which a guest with many virtio-mmio devices (each device takes one
-    // IRQ) can exhaust. The userspace IOAPIC exposes IRQ_BASE..=IRQ_MAX_SPLIT instead. On KVM that
-    // is the split irqchip: enable it automatically when the configured device count would overflow
-    // the in-kernel range, leaving light guests on the faster in-kernel chip. On Windows the IOAPIC
-    // is always userspace, so its full pin range is used unconditionally.
-    #[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
-    if !vm_resources.split_irqchip {
-        // Each virtio-fs share and block device takes one IOAPIC pin; the other configured platform
-        // devices (balloon, virtio-mem, cpu, rng, metrics, console, net, vsock) take a fixed handful
-        // more. A conservative base plus the per-share count errs toward enabling the split irqchip
-        // (which costs a worker thread) rather than exhausting IRQs at device-registration time.
-        // Light guests stay under the range and keep the in-kernel irqchip.
-        const PLATFORM_IRQ_DEVICES: usize = 9;
-        let dynamic = vm_resources.fs.len();
-        let pool = (arch::IRQ_MAX - arch::IRQ_BASE + 1) as usize;
-        if PLATFORM_IRQ_DEVICES + dynamic > pool {
-            vm_resources.split_irqchip = true;
-        }
-    }
     // Use the WhpIrqChip IOAPIC's full pin range. WHP has no in-kernel irqchip, so the guest IOAPIC
     // is emulated in userspace with X86_IOAPIC_NUM_PINS redirection entries; the usable ceiling is
     // pin NUM_PINS-1, not the legacy in-kernel IRQ_MAX. This lifts the virtio MMIO IRQ count from 11

--- a/src/vmm/src/device_manager/kvm/mmio.rs
+++ b/src/vmm/src/device_manager/kvm/mmio.rs
@@ -413,7 +413,7 @@ mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let vm = builder::setup_vm(&guest_mem, false).unwrap();
+        let vm = builder::setup_vm(&guest_mem, false, 1).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         #[cfg(target_arch = "x86_64")]
@@ -435,7 +435,7 @@ mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let vm = builder::setup_vm(&guest_mem, false).unwrap();
+        let vm = builder::setup_vm(&guest_mem, false, 1).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         #[cfg(target_arch = "x86_64")]
@@ -538,7 +538,7 @@ mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let vm = builder::setup_vm(&guest_mem, false).unwrap();
+        let vm = builder::setup_vm(&guest_mem, false, 1).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -323,6 +323,7 @@ impl Vmm {
 
         #[cfg(target_arch = "x86_64")]
         {
+            let ioapic_num_pins = _intc.lock().unwrap().num_pins();
             let cmdline_len = if cfg!(feature = "tee") {
                 arch::x86_64::layout::CMDLINE_SEV_SIZE
             } else {
@@ -336,6 +337,7 @@ impl Vmm {
                 cmdline_len,
                 initrd,
                 vcpus.len() as u8,
+                ioapic_num_pins,
             )
             .map_err(Error::ConfigureSystem)?;
         }


### PR DESCRIPTION
## TL;DR

Follow up #96 by keeping Linux split irqchip selection explicitly opt-in while retaining the Windows IRQ-capacity fix. Align each x86 guest's advertised interrupt topology with its active controller and harden the Linux userspace IOAPIC against guest-triggerable panic paths.

## Description

- Remove the device-count heuristic that silently enabled Linux split irqchip mode and broke the existing opt-in contract and TEE feature builds.
- Limit the Linux userspace IOAPIC to the 120 pins addressable by its 8-bit IOREGSEL, making the split allocator ceiling IRQ 119; keep KVM at 24 pins and WHP at 64 pins.
- Report the active controller's actual pin count in the guest MP table instead of always advertising the userspace maximum.
- Handle invalid IOAPIC MMIO, EOI writes, unsupported ExtINT routes, and IRQ-worker shutdown without panicking the VMM.
- Add regression coverage for Linux selection, Windows allocator capacity and pin 63, MP-table topology, selector bounds, EOI handling, and ExtINT masking.
- Repair the Linux MMIO test call sites left stale by #98's new `setup_vm` vCPU-count parameter.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked -p msb_krun --target x86_64-unknown-linux-gnu -- -D warnings`
- [x] `cargo check --locked -p msb_krun --target x86_64-unknown-linux-gnu` with default, `tdx`, and `amd-sev` feature sets
- [x] `cargo check --locked -p msb_krun_arch --tests --target x86_64-unknown-linux-gnu` and `cargo check --locked -p msb_krun_devices --tests --target x86_64-unknown-linux-gnu`
- [x] `cargo check --locked -p msb_krun_vmm --tests --target x86_64-unknown-linux-gnu`
- [x] Surface Laptop 7 ARM64: `cargo check --locked -p msb_krun --target aarch64-pc-windows-msvc` and `--target x86_64-pc-windows-msvc`
- [x] Surface Laptop 7 ARM64 x64 emulation: all `msb_krun_vmm` and `msb_krun_arch` tests pass for `x86_64-pc-windows-msvc`
