### PR TITLE
feat(vsock): add custom stream and datagram backends

### DIFF
--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -50,7 +50,7 @@ mod queue;
 pub mod rng;
 #[cfg(feature = "snd")]
 pub mod snd;
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(feature = "tee"))]
 pub mod vsock;
 
 #[cfg(not(feature = "tee"))]
@@ -75,7 +75,7 @@ pub use self::queue::{Descriptor, DescriptorChain, Queue};
 pub use self::rng::*;
 #[cfg(feature = "snd")]
 pub use self::snd::Snd;
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(feature = "tee"))]
 pub use self::vsock::*;
 
 /// When the driver initializes the device, it lets the device know about the

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -50,7 +50,9 @@ mod queue;
 pub mod rng;
 #[cfg(feature = "snd")]
 pub mod snd;
-#[cfg(not(feature = "tee"))]
+// Preserve vsock for existing Unix TEE builds while enabling it for ordinary
+// Windows guests. Windows TEE combinations continue to omit the device.
+#[cfg(any(not(target_os = "windows"), not(feature = "tee")))]
 pub mod vsock;
 
 #[cfg(not(feature = "tee"))]
@@ -75,7 +77,7 @@ pub use self::queue::{Descriptor, DescriptorChain, Queue};
 pub use self::rng::*;
 #[cfg(feature = "snd")]
 pub use self::snd::Snd;
-#[cfg(not(feature = "tee"))]
+#[cfg(any(not(target_os = "windows"), not(feature = "tee")))]
 pub use self::vsock::*;
 
 /// When the driver initializes the device, it lets the device know about the

--- a/src/devices/src/virtio/vsock/backend.rs
+++ b/src/devices/src/virtio/vsock/backend.rs
@@ -1,4 +1,8 @@
 use std::io;
+#[cfg(unix)]
+use std::os::fd::RawFd;
+#[cfg(windows)]
+use std::os::windows::io::RawHandle;
 use std::sync::Arc;
 
 use utils::eventfd::{EventFd, EFD_NONBLOCK};
@@ -6,6 +10,14 @@ use utils::eventfd::{EventFd, EFD_NONBLOCK};
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
+
+/// Platform-native object that can be registered with libkrun's event loop.
+#[cfg(unix)]
+pub type VsockPollable = RawFd;
+
+/// Platform-native object that can be registered with libkrun's event loop.
+#[cfg(windows)]
+pub type VsockPollable = RawHandle;
 
 /// Metadata for a guest-initiated connection to a registered host port.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -16,6 +28,35 @@ pub struct VsockConnectRequest {
     pub guest_port: u32,
     /// Host port on which the backend was registered.
     pub host_port: u32,
+}
+
+/// State of the host endpoint behind a guest stream connection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum VsockConnectState {
+    /// The nonblocking host connection is still being established.
+    Connecting,
+    /// The host endpoint is ready for stream traffic.
+    Connected,
+}
+
+/// Metadata identifying one guest datagram peer for a registered host port.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct VsockDatagramPeer {
+    /// CID of the guest sending datagrams.
+    pub guest_cid: u64,
+    /// Source port selected or bound by the guest.
+    pub guest_port: u32,
+    /// Host port on which the backend was registered.
+    pub host_port: u32,
+}
+
+/// Result of receiving one complete datagram from a host backend.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct VsockDatagramRead {
+    /// Number of bytes written into the supplied buffer.
+    pub len: usize,
+    /// Whether the original message exceeded the supplied buffer.
+    pub truncated: bool,
 }
 
 /// Direction requested by a guest shutdown packet.
@@ -57,6 +98,15 @@ pub trait VsockPortBackend: Send + Sync {
 /// continues to own virtio-vsock framing, credit flow, shutdown, and reset
 /// handling around this stream.
 pub trait VsockStreamBackend: Send {
+    /// Report whether a nonblocking host connection has completed.
+    ///
+    /// In-process backends are ready immediately. Socket-backed implementations
+    /// can return [`VsockConnectState::Connecting`] until their poll fd becomes
+    /// writable and then surface the result of `SO_ERROR` here.
+    fn connect_state(&self) -> io::Result<VsockConnectState> {
+        Ok(VsockConnectState::Connected)
+    }
+
     /// Read bytes that should be delivered to the guest.
     fn read(&self, buf: &mut [u8]) -> io::Result<usize>;
 
@@ -65,6 +115,45 @@ pub trait VsockStreamBackend: Send {
 
     /// Apply a guest-requested half-close or full shutdown.
     fn shutdown(&self, how: VsockShutdown) -> io::Result<()>;
+
+    /// Return a pollable host object when the backend has one.
+    ///
+    /// Returning `None` keeps the existing notifier-driven behavior. Returning
+    /// a native object lets libkrun poll a real socket or handle directly.
+    fn pollable(&self) -> Option<VsockPollable> {
+        None
+    }
+}
+
+/// Factory for message-oriented services exposed on one host vsock port.
+///
+/// libkrun opens one endpoint for every `(guest CID, guest source port, host
+/// port)` tuple. This preserves connectionless guest semantics while giving a
+/// host Unix datagram backend a stable reply address for each guest peer.
+pub trait VsockDatagramPortBackend: Send + Sync {
+    /// Open the host endpoint associated with one guest datagram peer.
+    fn open_peer(
+        &self,
+        peer: VsockDatagramPeer,
+        notifier: VsockNotifier,
+    ) -> io::Result<Box<dyn VsockDatagramBackend>>;
+}
+
+/// One nonblocking message-oriented endpoint behind a guest datagram peer.
+pub trait VsockDatagramBackend: Send {
+    /// Atomically deliver one guest message to the host endpoint.
+    ///
+    /// Implementations must never report partial delivery. `WouldBlock` means
+    /// the best-effort datagram may be dropped by the device.
+    fn send(&self, payload: &[u8]) -> io::Result<()>;
+
+    /// Receive one complete host message for delivery to the guest peer.
+    fn receive(&self, buf: &mut [u8]) -> io::Result<VsockDatagramRead>;
+
+    /// Return a pollable host object, or `None` to use [`VsockNotifier`].
+    fn pollable(&self) -> Option<VsockPollable> {
+        None
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -72,7 +161,10 @@ pub trait VsockStreamBackend: Send {
 //--------------------------------------------------------------------------------------------------
 
 impl VsockNotifier {
-    pub(crate) fn new() -> io::Result<Self> {
+    /// Create an independent notifier suitable for backend tests or adapters.
+    ///
+    /// libkrun normally constructs the notifier passed to a route backend.
+    pub fn new() -> io::Result<Self> {
         Ok(Self {
             event: Arc::new(EventFd::new(EFD_NONBLOCK)?),
         })
@@ -83,8 +175,25 @@ impl VsockNotifier {
         self.event.write(1)
     }
 
+    #[cfg(any(unix, test))]
     pub(crate) fn event(&self) -> &EventFd {
         &self.event
+    }
+
+    pub(crate) fn pollable(&self) -> VsockPollable {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            self.event.as_raw_fd()
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::AsRawHandle;
+
+            self.event.as_raw_handle()
+        }
     }
 
     pub(crate) fn clear(&self) -> io::Result<()> {

--- a/src/devices/src/virtio/vsock/custom_stream.rs
+++ b/src/devices/src/virtio/vsock/custom_stream.rs
@@ -1,0 +1,562 @@
+use std::collections::VecDeque;
+use std::io;
+use std::num::Wrapping;
+use std::sync::{Arc, Mutex};
+
+#[cfg(unix)]
+use std::collections::HashMap;
+
+use utils::epoll::EventSet;
+use vm_memory::GuestMemoryMmap;
+
+use super::super::Queue as VirtQueue;
+use super::defs::{self, uapi};
+use super::muxer::{push_packet, MuxerRx};
+use super::muxer_rxq::MuxerRxQ;
+use super::packet::VsockPacket;
+#[cfg(unix)]
+use super::packet::{TsiAcceptReq, TsiConnectReq, TsiListenReq, TsiSendtoAddr};
+use super::proxy::{Proxy, ProxyRemoval, ProxyStatus, ProxyUpdate, RecvPkt};
+use super::{VsockConnectState, VsockNotifier, VsockPollable, VsockShutdown, VsockStreamBackend};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Platform-neutral proxy around a custom stream backend.
+pub struct CustomStreamProxy {
+    id: u64,
+    cid: u64,
+    backend: Box<dyn VsockStreamBackend>,
+    notifier: VsockNotifier,
+    status: ProxyStatus,
+    mem: GuestMemoryMmap,
+    queue: Arc<Mutex<VirtQueue>>,
+    rxq: Arc<Mutex<MuxerRxQ>>,
+    peer_port: u32,
+    local_port: u32,
+    peer_fwd_cnt: Wrapping<u32>,
+    peer_buf_alloc: u32,
+    tx_cnt: Wrapping<u32>,
+    last_tx_cnt_sent: Wrapping<u32>,
+    rx_cnt: Wrapping<u32>,
+    pending_write: VecDeque<u8>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl CustomStreamProxy {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: u64,
+        cid: u64,
+        local_port: u32,
+        peer_port: u32,
+        backend: Box<dyn VsockStreamBackend>,
+        notifier: VsockNotifier,
+        mem: GuestMemoryMmap,
+        queue: Arc<Mutex<VirtQueue>>,
+        rxq: Arc<Mutex<MuxerRxQ>>,
+    ) -> io::Result<Self> {
+        let status = match backend.connect_state()? {
+            VsockConnectState::Connecting => ProxyStatus::Connecting,
+            VsockConnectState::Connected => ProxyStatus::Connected,
+        };
+
+        Ok(Self {
+            id,
+            cid,
+            backend,
+            notifier,
+            status,
+            mem,
+            queue,
+            rxq,
+            peer_port,
+            local_port,
+            peer_fwd_cnt: Wrapping(0),
+            peer_buf_alloc: 0,
+            tx_cnt: Wrapping(0),
+            last_tx_cnt_sent: Wrapping(0),
+            rx_cnt: Wrapping(0),
+            pending_write: VecDeque::new(),
+        })
+    }
+
+    pub fn is_connecting(&self) -> bool {
+        self.status == ProxyStatus::Connecting
+    }
+
+    /// Record peer flow-control state while a route connection is pending.
+    pub fn prepare_connect(&mut self, pkt: &VsockPacket) {
+        self.peer_buf_alloc = pkt.buf_alloc();
+        self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
+        self.local_port = pkt.dst_port();
+        self.peer_port = pkt.src_port();
+    }
+
+    fn uses_notifier(&self) -> bool {
+        self.backend.pollable().is_none()
+    }
+
+    fn event_pollable(&self) -> VsockPollable {
+        self.backend
+            .pollable()
+            .unwrap_or_else(|| self.notifier.pollable())
+    }
+
+    fn connected_poll_events(&self) -> EventSet {
+        if self.uses_notifier() || self.pending_write.is_empty() {
+            EventSet::IN
+        } else {
+            EventSet::IN | EventSet::OUT
+        }
+    }
+
+    fn connecting_poll_events(&self) -> EventSet {
+        if self.uses_notifier() {
+            EventSet::IN
+        } else {
+            EventSet::IN | EventSet::OUT
+        }
+    }
+
+    fn clear_notification(&self) {
+        if self.uses_notifier() {
+            if let Err(err) = self.notifier.clear() {
+                warn!("failed to clear custom vsock notification: {err}");
+            }
+        }
+    }
+
+    fn push_connect_response(&self) {
+        push_packet(
+            self.cid,
+            MuxerRx::OpResponse {
+                local_port: self.local_port,
+                peer_port: self.peer_port,
+            },
+            &self.rxq,
+            &self.queue,
+            &self.mem,
+        );
+    }
+
+    fn push_reset(&self) {
+        push_packet(
+            self.cid,
+            MuxerRx::Reset {
+                local_port: self.local_port,
+                peer_port: self.peer_port,
+            },
+            &self.rxq,
+            &self.queue,
+            &self.mem,
+        );
+    }
+
+    fn peer_avail_credit(&self) -> usize {
+        (Wrapping(self.peer_buf_alloc) - (self.rx_cnt - self.peer_fwd_cnt)).0 as usize
+    }
+
+    fn recv_to_pkt(&self, pkt: &mut VsockPacket) -> RecvPkt {
+        let Some(buf) = pkt.buf_mut() else {
+            return RecvPkt::Error;
+        };
+        let max_len = buf.len().min(self.peer_avail_credit());
+        if max_len == 0 {
+            return RecvPkt::WaitForCredit;
+        }
+
+        match self.backend.read(&mut buf[..max_len]) {
+            Ok(0) => RecvPkt::Close,
+            Ok(count) if count <= max_len => RecvPkt::Read(count),
+            Ok(count) => {
+                warn!(
+                    "vsock backend returned invalid read length: count={count}, capacity={max_len}"
+                );
+                RecvPkt::Error
+            }
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => RecvPkt::Error,
+            Err(err) => {
+                debug!("custom vsock backend read failed: {err}");
+                RecvPkt::Error
+            }
+        }
+    }
+
+    fn recv_pkt(&mut self) -> (bool, bool) {
+        let mut have_used = false;
+        let mut wait_credit = false;
+        let mut queue = self.queue.lock().unwrap();
+
+        while let Some(head) = queue.pop(&self.mem) {
+            let len = match VsockPacket::from_rx_virtq_head(&head) {
+                Ok(mut pkt) => match self.recv_to_pkt(&mut pkt) {
+                    RecvPkt::WaitForCredit => {
+                        wait_credit = true;
+                        0
+                    }
+                    RecvPkt::Read(count) => {
+                        self.rx_cnt += Wrapping(count as u32);
+                        self.init_data_pkt(&mut pkt);
+                        pkt.set_len(count as u32);
+                        pkt.hdr().len() + count
+                    }
+                    RecvPkt::Close => {
+                        self.status = ProxyStatus::Closed;
+                        0
+                    }
+                    RecvPkt::Error => 0,
+                },
+                Err(err) => {
+                    debug!("custom vsock RX queue error: {err:?}");
+                    0
+                }
+            };
+
+            if len == 0 {
+                queue.undo_pop();
+                break;
+            }
+            have_used = true;
+            if let Err(err) = queue.add_used(&self.mem, head.index, len as u32) {
+                error!("failed to add used elements to the queue: {err:?}");
+            }
+        }
+
+        (have_used, wait_credit)
+    }
+
+    fn flush_pending_write(&mut self) -> io::Result<()> {
+        while !self.pending_write.is_empty() {
+            let (front, back) = self.pending_write.as_slices();
+            let buf = if front.is_empty() { back } else { front };
+            match self.backend.write(buf) {
+                Ok(0) => return Err(io::Error::from(io::ErrorKind::WriteZero)),
+                Ok(written) if written <= buf.len() => {
+                    self.pending_write.drain(..written);
+                }
+                Ok(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "vsock backend returned a write length larger than its input",
+                    ));
+                }
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(())
+    }
+
+    fn init_data_pkt(&self, pkt: &mut VsockPacket) {
+        pkt.set_op(uapi::VSOCK_OP_RW)
+            .set_src_cid(uapi::VSOCK_HOST_CID)
+            .set_dst_cid(self.cid)
+            .set_src_port(self.local_port)
+            .set_dst_port(self.peer_port)
+            .set_type(uapi::VSOCK_TYPE_STREAM)
+            .set_buf_alloc(defs::CONN_TX_BUF_SIZE as u32)
+            .set_fwd_cnt(self.tx_cnt.0);
+    }
+
+    fn fail(&mut self, update: &mut ProxyUpdate, context: &str, err: &io::Error) {
+        warn!("{context}: {err}");
+        self.push_reset();
+        self.status = ProxyStatus::Closed;
+        update.signal_queue = true;
+        update.remove_proxy = ProxyRemoval::Deferred;
+        update.polling = Some((self.id, self.event_pollable(), EventSet::empty()));
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Proxy for CustomStreamProxy {
+    #[cfg(unix)]
+    fn id(&self) -> u64 {
+        self.id
+    }
+
+    fn pollable(&self) -> VsockPollable {
+        self.event_pollable()
+    }
+
+    fn status(&self) -> ProxyStatus {
+        self.status
+    }
+
+    #[cfg(unix)]
+    fn connect(&mut self, _pkt: &VsockPacket, _req: TsiConnectReq) -> ProxyUpdate {
+        unreachable!("custom streams do not implement TSI connect")
+    }
+
+    fn confirm_connect(&mut self, pkt: &VsockPacket) -> Option<ProxyUpdate> {
+        self.prepare_connect(pkt);
+        self.push_connect_response();
+        None
+    }
+
+    #[cfg(unix)]
+    fn getpeername(&mut self, _pkt: &VsockPacket) {
+        unreachable!("custom streams do not implement TSI getpeername")
+    }
+
+    fn sendmsg(&mut self, pkt: &VsockPacket) -> ProxyUpdate {
+        let mut update = ProxyUpdate::default();
+        let Some(buf) = pkt.buf() else {
+            return update;
+        };
+
+        self.pending_write.extend(buf);
+        self.tx_cnt += Wrapping(buf.len() as u32);
+        if let Err(err) = self.flush_pending_write() {
+            self.fail(&mut update, "custom vsock backend write failed", &err);
+            return update;
+        }
+        update.polling = Some((self.id, self.event_pollable(), self.connected_poll_events()));
+
+        if (self.tx_cnt - self.last_tx_cnt_sent).0 as usize >= defs::CONN_TX_BUF_SIZE / 2 {
+            self.last_tx_cnt_sent = self.tx_cnt;
+            push_packet(
+                self.cid,
+                MuxerRx::CreditUpdate {
+                    local_port: pkt.dst_port(),
+                    peer_port: pkt.src_port(),
+                    fwd_cnt: self.tx_cnt.0,
+                },
+                &self.rxq,
+                &self.queue,
+                &self.mem,
+            );
+            update.signal_queue = true;
+        }
+
+        update
+    }
+
+    #[cfg(unix)]
+    fn sendto_addr(&mut self, _req: TsiSendtoAddr) -> ProxyUpdate {
+        unreachable!("custom streams do not implement TSI sendto")
+    }
+
+    #[cfg(unix)]
+    fn listen(
+        &mut self,
+        _pkt: &VsockPacket,
+        _req: TsiListenReq,
+        _host_port_map: &Option<HashMap<u16, u16>>,
+    ) -> ProxyUpdate {
+        unreachable!("custom streams do not implement TSI listen")
+    }
+
+    #[cfg(unix)]
+    fn accept(&mut self, _req: TsiAcceptReq) -> ProxyUpdate {
+        unreachable!("custom streams do not implement TSI accept")
+    }
+
+    fn update_peer_credit(&mut self, pkt: &VsockPacket) -> ProxyUpdate {
+        self.peer_buf_alloc = pkt.buf_alloc();
+        self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
+        self.status = ProxyStatus::Connected;
+        self.kick();
+
+        ProxyUpdate {
+            polling: Some((self.id, self.event_pollable(), self.connected_poll_events())),
+            ..Default::default()
+        }
+    }
+
+    fn process_op_response(&mut self, pkt: &VsockPacket) -> ProxyUpdate {
+        self.peer_buf_alloc = pkt.buf_alloc();
+        self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
+        self.status = ProxyStatus::Connected;
+        ProxyUpdate {
+            polling: Some((self.id, self.event_pollable(), self.connected_poll_events())),
+            ..Default::default()
+        }
+    }
+
+    fn shutdown(&mut self, pkt: &VsockPacket) {
+        let recv_off = pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_RCV != 0;
+        let send_off = pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_SEND != 0;
+        let how = match (recv_off, send_off) {
+            (true, true) => VsockShutdown::Both,
+            (true, false) => VsockShutdown::Read,
+            (false, _) => VsockShutdown::Write,
+        };
+        if let Err(err) = self.backend.shutdown(how) {
+            warn!("error shutting down custom vsock backend: {err}");
+        }
+    }
+
+    fn release(&mut self) -> ProxyUpdate {
+        ProxyUpdate {
+            remove_proxy: ProxyRemoval::Deferred,
+            ..Default::default()
+        }
+    }
+
+    fn process_event(&mut self, evset: EventSet) -> ProxyUpdate {
+        let mut update = ProxyUpdate::default();
+
+        if evset.contains(EventSet::HANG_UP) {
+            let err = io::Error::new(io::ErrorKind::ConnectionReset, "backend event closed");
+            self.fail(&mut update, "custom vsock backend closed", &err);
+            return update;
+        }
+
+        if self.status == ProxyStatus::Connecting {
+            self.clear_notification();
+            match self.backend.connect_state() {
+                Ok(VsockConnectState::Connecting) => {
+                    update.polling = Some((
+                        self.id,
+                        self.event_pollable(),
+                        self.connecting_poll_events(),
+                    ));
+                    return update;
+                }
+                Ok(VsockConnectState::Connected) => {
+                    self.status = ProxyStatus::Connected;
+                    self.push_connect_response();
+                    update.signal_queue = true;
+                }
+                Err(err) => {
+                    self.fail(&mut update, "custom vsock backend connect failed", &err);
+                    return update;
+                }
+            }
+        } else if evset.contains(EventSet::IN) {
+            self.clear_notification();
+        }
+
+        if self.status == ProxyStatus::Connected && !self.pending_write.is_empty() {
+            if let Err(err) = self.flush_pending_write() {
+                self.fail(&mut update, "custom vsock backend write failed", &err);
+                return update;
+            }
+        }
+
+        if self.status == ProxyStatus::Connected && evset.contains(EventSet::IN) {
+            let (signal_queue, wait_credit) = self.recv_pkt();
+            update.signal_queue |= signal_queue;
+            if wait_credit {
+                self.status = ProxyStatus::WaitingCreditUpdate;
+                update.push_credit_req = Some(MuxerRx::CreditRequest {
+                    local_port: self.local_port,
+                    peer_port: self.peer_port,
+                    fwd_cnt: self.tx_cnt.0,
+                });
+            }
+
+            if self.status == ProxyStatus::Closed {
+                self.push_reset();
+                update.signal_queue = true;
+                update.polling = Some((self.id, self.event_pollable(), EventSet::empty()));
+                return update;
+            }
+        }
+
+        update.polling = Some((
+            self.id,
+            self.event_pollable(),
+            if self.status == ProxyStatus::WaitingCreditUpdate {
+                EventSet::empty()
+            } else {
+                self.connected_poll_events()
+            },
+        ));
+        update
+    }
+
+    fn kick(&self) {
+        if let Err(err) = self.notifier.notify() {
+            warn!("failed to kick custom vsock backend: {err}");
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use vm_memory::GuestAddress;
+
+    use super::*;
+
+    struct TestStreamState {
+        blocked: AtomicBool,
+        written: Mutex<Vec<u8>>,
+    }
+
+    struct TestStream {
+        state: Arc<TestStreamState>,
+    }
+
+    impl VsockStreamBackend for TestStream {
+        fn read(&self, _buf: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::from(io::ErrorKind::WouldBlock))
+        }
+
+        fn write(&self, buf: &[u8]) -> io::Result<usize> {
+            let mut written = self.state.written.lock().unwrap();
+            if self.state.blocked.load(Ordering::Relaxed) && written.len() >= 2 {
+                return Err(io::Error::from(io::ErrorKind::WouldBlock));
+            }
+            let count = if self.state.blocked.load(Ordering::Relaxed) {
+                buf.len().min(2)
+            } else {
+                buf.len()
+            };
+            written.extend_from_slice(&buf[..count]);
+            Ok(count)
+        }
+
+        fn shutdown(&self, _how: VsockShutdown) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn buffers_partial_writes_without_losing_bytes() {
+        let state = Arc::new(TestStreamState {
+            blocked: AtomicBool::new(true),
+            written: Mutex::new(Vec::new()),
+        });
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mut proxy = CustomStreamProxy::new(
+            1,
+            3,
+            5000,
+            4000,
+            Box::new(TestStream {
+                state: Arc::clone(&state),
+            }),
+            VsockNotifier::new().unwrap(),
+            mem,
+            Arc::new(Mutex::new(VirtQueue::new(256))),
+            Arc::new(Mutex::new(MuxerRxQ::new())),
+        )
+        .unwrap();
+
+        proxy.pending_write.extend(b"hello");
+        proxy.flush_pending_write().unwrap();
+        assert_eq!(&*state.written.lock().unwrap(), b"he");
+        assert_eq!(proxy.pending_write.len(), 3);
+
+        state.blocked.store(false, Ordering::Relaxed);
+        proxy.flush_pending_write().unwrap();
+        assert_eq!(&*state.written.lock().unwrap(), b"hello");
+        assert!(proxy.pending_write.is_empty());
+    }
+}

--- a/src/devices/src/virtio/vsock/custom_stream.rs
+++ b/src/devices/src/virtio/vsock/custom_stream.rs
@@ -230,7 +230,8 @@ impl CustomStreamProxy {
         (have_used, wait_credit)
     }
 
-    fn flush_pending_write(&mut self) -> io::Result<()> {
+    fn flush_pending_write(&mut self) -> io::Result<usize> {
+        let mut total_written = 0;
         while !self.pending_write.is_empty() {
             let (front, back) = self.pending_write.as_slices();
             let buf = if front.is_empty() { back } else { front };
@@ -238,6 +239,8 @@ impl CustomStreamProxy {
                 Ok(0) => return Err(io::Error::from(io::ErrorKind::WriteZero)),
                 Ok(written) if written <= buf.len() => {
                     self.pending_write.drain(..written);
+                    self.tx_cnt += Wrapping(written as u32);
+                    total_written += written;
                 }
                 Ok(_) => {
                     return Err(io::Error::new(
@@ -245,11 +248,33 @@ impl CustomStreamProxy {
                         "vsock backend returned a write length larger than its input",
                     ));
                 }
-                Err(err) if err.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => return Ok(total_written),
                 Err(err) => return Err(err),
             }
         }
-        Ok(())
+        Ok(total_written)
+    }
+
+    /// Return stream credit only after the host backend has consumed bytes
+    /// from the bounded proxy queue.
+    fn maybe_push_credit_update(&mut self, update: &mut ProxyUpdate) {
+        if ((self.tx_cnt - self.last_tx_cnt_sent).0 as usize) < defs::CONN_TX_BUF_SIZE / 2 {
+            return;
+        }
+
+        self.last_tx_cnt_sent = self.tx_cnt;
+        push_packet(
+            self.cid,
+            MuxerRx::CreditUpdate {
+                local_port: self.local_port,
+                peer_port: self.peer_port,
+                fwd_cnt: self.tx_cnt.0,
+            },
+            &self.rxq,
+            &self.queue,
+            &self.mem,
+        );
+        update.signal_queue = true;
     }
 
     fn init_data_pkt(&self, pkt: &mut VsockPacket) {
@@ -298,7 +323,12 @@ impl Proxy for CustomStreamProxy {
 
     fn confirm_connect(&mut self, pkt: &VsockPacket) -> Option<ProxyUpdate> {
         self.prepare_connect(pkt);
-        self.push_connect_response();
+        // A duplicate request can arrive while an asynchronous host connect is
+        // still pending. Do not acknowledge it until connect_state reports the
+        // backend is actually ready.
+        if self.status == ProxyStatus::Connected {
+            self.push_connect_response();
+        }
         None
     }
 
@@ -309,33 +339,40 @@ impl Proxy for CustomStreamProxy {
 
     fn sendmsg(&mut self, pkt: &VsockPacket) -> ProxyUpdate {
         let mut update = ProxyUpdate::default();
-        let Some(buf) = pkt.buf() else {
+        let Some(buf) = pkt.payload() else {
+            let err = io::Error::new(
+                io::ErrorKind::InvalidData,
+                "vsock packet payload does not match its declared length",
+            );
+            self.fail(&mut update, "invalid custom vsock packet", &err);
+            update.remove_proxy = ProxyRemoval::Immediate;
             return update;
         };
 
+        // Flush previously accepted bytes before checking the fixed receive
+        // window. This lets a backend that has become writable make room
+        // without ever allocating beyond the advertised credit.
+        if let Err(err) = self.flush_pending_write() {
+            self.fail(&mut update, "custom vsock backend write failed", &err);
+            return update;
+        }
+        if buf.len() > defs::CONN_TX_BUF_SIZE.saturating_sub(self.pending_write.len()) {
+            let err = io::Error::new(
+                io::ErrorKind::InvalidData,
+                "guest exceeded the custom vsock stream receive window",
+            );
+            self.fail(&mut update, "invalid custom vsock stream credit", &err);
+            update.remove_proxy = ProxyRemoval::Immediate;
+            return update;
+        }
+
         self.pending_write.extend(buf);
-        self.tx_cnt += Wrapping(buf.len() as u32);
         if let Err(err) = self.flush_pending_write() {
             self.fail(&mut update, "custom vsock backend write failed", &err);
             return update;
         }
         update.polling = Some((self.id, self.event_pollable(), self.connected_poll_events()));
-
-        if (self.tx_cnt - self.last_tx_cnt_sent).0 as usize >= defs::CONN_TX_BUF_SIZE / 2 {
-            self.last_tx_cnt_sent = self.tx_cnt;
-            push_packet(
-                self.cid,
-                MuxerRx::CreditUpdate {
-                    local_port: pkt.dst_port(),
-                    peer_port: pkt.src_port(),
-                    fwd_cnt: self.tx_cnt.0,
-                },
-                &self.rxq,
-                &self.queue,
-                &self.mem,
-            );
-            update.signal_queue = true;
-        }
+        self.maybe_push_credit_update(&mut update);
 
         update
     }
@@ -396,8 +433,10 @@ impl Proxy for CustomStreamProxy {
     }
 
     fn release(&mut self) -> ProxyUpdate {
+        self.status = ProxyStatus::Closed;
         ProxyUpdate {
-            remove_proxy: ProxyRemoval::Deferred,
+            polling: Some((self.id, self.event_pollable(), EventSet::empty())),
+            remove_proxy: ProxyRemoval::Immediate,
             ..Default::default()
         }
     }
@@ -441,6 +480,7 @@ impl Proxy for CustomStreamProxy {
                 self.fail(&mut update, "custom vsock backend write failed", &err);
                 return update;
             }
+            self.maybe_push_credit_update(&mut update);
         }
 
         if self.status == ProxyStatus::Connected && evset.contains(EventSet::IN) {
@@ -459,6 +499,7 @@ impl Proxy for CustomStreamProxy {
                 self.push_reset();
                 update.signal_queue = true;
                 update.polling = Some((self.id, self.event_pollable(), EventSet::empty()));
+                update.remove_proxy = ProxyRemoval::Immediate;
                 return update;
             }
         }
@@ -490,9 +531,11 @@ impl Proxy for CustomStreamProxy {
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
-    use vm_memory::GuestAddress;
+    use vm_memory::{Bytes, GuestAddress};
 
+    use super::super::packet::VSOCK_PKT_HDR_SIZE;
     use super::*;
+    use crate::virtio::{Descriptor, DescriptorChain};
 
     struct TestStreamState {
         blocked: AtomicBool,
@@ -527,6 +570,56 @@ mod tests {
         }
     }
 
+    fn tx_packet(mem: &GuestMemoryMmap, declared_len: u32, descriptor: &[u8]) -> VsockPacket {
+        const DESC_TABLE: u64 = 0x1000;
+        const HEADER: u64 = 0x2000;
+        const PAYLOAD: u64 = 0x3000;
+
+        mem.write_obj(
+            Descriptor {
+                addr: HEADER,
+                len: VSOCK_PKT_HDR_SIZE as u32,
+                flags: 1,
+                next: 1,
+            },
+            GuestAddress(DESC_TABLE),
+        )
+        .unwrap();
+        mem.write_obj(
+            Descriptor {
+                addr: PAYLOAD,
+                len: descriptor.len() as u32,
+                flags: 0,
+                next: 0,
+            },
+            GuestAddress(DESC_TABLE + 16),
+        )
+        .unwrap();
+
+        let mut header = [0u8; VSOCK_PKT_HDR_SIZE];
+        header[24..28].copy_from_slice(&declared_len.to_le_bytes());
+        mem.write_slice(&header, GuestAddress(HEADER)).unwrap();
+        mem.write_slice(descriptor, GuestAddress(PAYLOAD)).unwrap();
+
+        let head = DescriptorChain::checked_new(mem, GuestAddress(DESC_TABLE), 2, 0).unwrap();
+        VsockPacket::from_tx_virtq_head(&head).unwrap()
+    }
+
+    fn test_proxy(state: Arc<TestStreamState>, mem: GuestMemoryMmap) -> CustomStreamProxy {
+        CustomStreamProxy::new(
+            1,
+            3,
+            5000,
+            4000,
+            Box::new(TestStream { state }),
+            VsockNotifier::new().unwrap(),
+            mem,
+            Arc::new(Mutex::new(VirtQueue::new(256))),
+            Arc::new(Mutex::new(MuxerRxQ::new())),
+        )
+        .unwrap()
+    }
+
     #[test]
     fn buffers_partial_writes_without_losing_bytes() {
         let state = Arc::new(TestStreamState {
@@ -534,29 +627,53 @@ mod tests {
             written: Mutex::new(Vec::new()),
         });
         let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
-        let mut proxy = CustomStreamProxy::new(
-            1,
-            3,
-            5000,
-            4000,
-            Box::new(TestStream {
-                state: Arc::clone(&state),
-            }),
-            VsockNotifier::new().unwrap(),
-            mem,
-            Arc::new(Mutex::new(VirtQueue::new(256))),
-            Arc::new(Mutex::new(MuxerRxQ::new())),
-        )
-        .unwrap();
+        let mut proxy = test_proxy(Arc::clone(&state), mem);
 
         proxy.pending_write.extend(b"hello");
         proxy.flush_pending_write().unwrap();
         assert_eq!(&*state.written.lock().unwrap(), b"he");
         assert_eq!(proxy.pending_write.len(), 3);
+        assert_eq!(proxy.tx_cnt.0, 2);
 
         state.blocked.store(false, Ordering::Relaxed);
         proxy.flush_pending_write().unwrap();
         assert_eq!(&*state.written.lock().unwrap(), b"hello");
         assert!(proxy.pending_write.is_empty());
+        assert_eq!(proxy.tx_cnt.0, 5);
+    }
+
+    #[test]
+    fn forwards_only_the_declared_packet_payload() {
+        let state = Arc::new(TestStreamState {
+            blocked: AtomicBool::new(false),
+            written: Mutex::new(Vec::new()),
+        });
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let pkt = tx_packet(&mem, 1, b"a-secret-tail");
+        let mut proxy = test_proxy(Arc::clone(&state), mem.clone());
+
+        let update = proxy.sendmsg(&pkt);
+
+        assert!(matches!(update.remove_proxy, ProxyRemoval::Keep));
+        assert_eq!(&*state.written.lock().unwrap(), b"a");
+        assert_eq!(proxy.tx_cnt.0, 1);
+    }
+
+    #[test]
+    fn rejects_writes_beyond_the_bounded_receive_window() {
+        let state = Arc::new(TestStreamState {
+            blocked: AtomicBool::new(true),
+            // The test backend returns WouldBlock after accepting two bytes.
+            written: Mutex::new(vec![0, 0]),
+        });
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let pkt = tx_packet(&mem, 1, b"x");
+        let mut proxy = test_proxy(state, mem.clone());
+        proxy.pending_write.resize(defs::CONN_TX_BUF_SIZE, 0);
+
+        let update = proxy.sendmsg(&pkt);
+
+        assert!(matches!(update.remove_proxy, ProxyRemoval::Immediate));
+        assert_eq!(proxy.pending_write.len(), defs::CONN_TX_BUF_SIZE);
     }
 }

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -20,8 +20,8 @@ use super::super::{
 use super::muxer::VsockMuxer;
 use super::packet::VsockPacket;
 use super::TsiFlags;
-use super::VsockPortBackend;
 use super::{defs, defs::uapi};
+use super::{VsockDatagramPortBackend, VsockPortBackend};
 use crate::virtio::InterruptTransport;
 
 pub(crate) const RXQ_INDEX: usize = 0;
@@ -34,7 +34,11 @@ pub(crate) const EVQ_INDEX: usize = 2;
 ///   them available.
 pub(crate) const AVAIL_FEATURES: u64 = (1 << uapi::VIRTIO_F_VERSION_1 as u64)
     | (1 << uapi::VIRTIO_F_IN_ORDER as u64)
-    | (1 << uapi::VIRTIO_VSOCK_F_DGRAM);
+    | if cfg!(unix) {
+        1 << uapi::VIRTIO_VSOCK_F_DGRAM
+    } else {
+        0
+    };
 
 pub struct Vsock {
     cid: u64,
@@ -56,6 +60,7 @@ impl Vsock {
         host_port_map: Option<HashMap<u16, u16>>,
         unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
         custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
+        custom_dgram_port_map: Option<HashMap<u32, Arc<dyn VsockDatagramPortBackend>>>,
         tsi_flags: TsiFlags,
     ) -> super::Result<Vsock> {
         Ok(Vsock {
@@ -65,6 +70,7 @@ impl Vsock {
                 host_port_map,
                 unix_ipc_port_map,
                 custom_port_map,
+                custom_dgram_port_map,
                 tsi_flags,
             ),
             queue_rx: None,

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -104,6 +104,7 @@ impl Vsock {
         };
 
         let mut have_used = false;
+        let mut needs_backend_kick = false;
 
         debug!("process_rx before while");
         let queue_rx = self
@@ -121,6 +122,7 @@ impl Vsock {
                         // We are using a consuming iterator over the virtio buffers, so, if we can't
                         // fill in this buffer, we'll need to undo the last iterator step.
                         queue_rx.undo_pop();
+                        needs_backend_kick = true;
                         break;
                     }
                 }
@@ -135,6 +137,14 @@ impl Vsock {
             if let Err(e) = queue_rx.add_used(mem, head.index, used_len) {
                 error!("failed to add used elements to the queue: {e:?}");
             }
+        }
+
+        // Backends can need a retry when the guest has just supplied receive
+        // capacity. Drop the virtqueue lock before taking proxy locks so the
+        // muxer thread cannot deadlock in the opposite proxy -> queue order.
+        drop(queue_rx);
+        if needs_backend_kick {
+            self.muxer.kick_backends();
         }
 
         have_used

--- a/src/devices/src/virtio/vsock/dgram.rs
+++ b/src/devices/src/virtio/vsock/dgram.rs
@@ -1,0 +1,245 @@
+use std::collections::HashMap;
+use std::io;
+use std::os::fd::{AsRawFd, RawFd};
+use std::sync::{Arc, Mutex};
+
+use vm_memory::GuestMemoryMmap;
+
+use super::super::Queue as VirtQueue;
+use super::backend::{VsockDatagramBackend, VsockNotifier};
+use super::defs;
+use super::muxer::{push_packet, MuxerRx};
+use super::muxer_rxq::MuxerRxQ;
+use super::packet::{TsiAcceptReq, TsiConnectReq, TsiListenReq, TsiSendtoAddr, VsockPacket};
+use super::proxy::{Proxy, ProxyRemoval, ProxyStatus, ProxyUpdate};
+use utils::epoll::EventSet;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Bound the work performed for one readiness event so a busy datagram service
+/// cannot monopolize the shared vsock muxer thread.
+const MAX_RECEIVE_BATCH: usize = 32;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// One host endpoint associated with a guest datagram source port.
+pub struct DatagramProxy {
+    id: u64,
+    cid: u64,
+    local_port: u32,
+    peer_port: u32,
+    backend: Box<dyn VsockDatagramBackend>,
+    notifier: VsockNotifier,
+    mem: GuestMemoryMmap,
+    queue: Arc<Mutex<VirtQueue>>,
+    rxq: Arc<Mutex<MuxerRxQ>>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl DatagramProxy {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: u64,
+        cid: u64,
+        local_port: u32,
+        peer_port: u32,
+        backend: Box<dyn VsockDatagramBackend>,
+        notifier: VsockNotifier,
+        mem: GuestMemoryMmap,
+        queue: Arc<Mutex<VirtQueue>>,
+        rxq: Arc<Mutex<MuxerRxQ>>,
+    ) -> Self {
+        Self {
+            id,
+            cid,
+            local_port,
+            peer_port,
+            backend,
+            notifier,
+            mem,
+            queue,
+            rxq,
+        }
+    }
+
+    fn uses_notifier(&self) -> bool {
+        self.backend.pollable().is_none()
+    }
+
+    fn receive_batch(&self) -> io::Result<bool> {
+        if self.uses_notifier() {
+            self.notifier.clear()?;
+        }
+
+        let mut delivered = false;
+        for _ in 0..MAX_RECEIVE_BATCH {
+            let mut data = vec![0; defs::MAX_PKT_BUF_SIZE];
+            let read = match self.backend.receive(&mut data) {
+                Ok(read) => read,
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
+                Err(err) => return Err(err),
+            };
+
+            if read.len > data.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "vsock datagram backend returned a length larger than its buffer",
+                ));
+            }
+            if read.truncated {
+                warn!(
+                    "dropping oversized host datagram for vsock port {}",
+                    self.local_port
+                );
+                continue;
+            }
+
+            data.truncate(read.len);
+            push_packet(
+                self.cid,
+                MuxerRx::Datagram {
+                    local_port: self.local_port,
+                    peer_port: self.peer_port,
+                    data,
+                },
+                &self.rxq,
+                &self.queue,
+                &self.mem,
+            );
+            delivered = true;
+        }
+
+        Ok(delivered)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl AsRawFd for DatagramProxy {
+    fn as_raw_fd(&self) -> RawFd {
+        self.backend
+            .pollable()
+            .unwrap_or_else(|| self.notifier.event().as_raw_fd())
+    }
+}
+
+impl Proxy for DatagramProxy {
+    fn id(&self) -> u64 {
+        self.id
+    }
+
+    fn pollable(&self) -> RawFd {
+        self.as_raw_fd()
+    }
+
+    fn status(&self) -> ProxyStatus {
+        ProxyStatus::Connected
+    }
+
+    fn connect(&mut self, _pkt: &VsockPacket, _req: TsiConnectReq) -> ProxyUpdate {
+        ProxyUpdate::default()
+    }
+
+    fn getpeername(&mut self, _pkt: &VsockPacket) {}
+
+    fn sendmsg(&mut self, pkt: &VsockPacket) -> ProxyUpdate {
+        let payload = pkt.buf().unwrap_or_default();
+        match self.backend.send(payload) {
+            Ok(()) => ProxyUpdate::default(),
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                debug!(
+                    "dropping guest datagram for busy host port {}",
+                    self.local_port
+                );
+                ProxyUpdate::default()
+            }
+            Err(err) => {
+                warn!(
+                    "vsock datagram backend failed for host port {}: {err}",
+                    self.local_port
+                );
+                ProxyUpdate {
+                    polling: Some((self.id, self.as_raw_fd(), EventSet::empty())),
+                    remove_proxy: ProxyRemoval::Immediate,
+                    ..Default::default()
+                }
+            }
+        }
+    }
+
+    fn sendto_addr(&mut self, _req: TsiSendtoAddr) -> ProxyUpdate {
+        ProxyUpdate::default()
+    }
+
+    fn listen(
+        &mut self,
+        _pkt: &VsockPacket,
+        _req: TsiListenReq,
+        _host_port_map: &Option<HashMap<u16, u16>>,
+    ) -> ProxyUpdate {
+        ProxyUpdate::default()
+    }
+
+    fn accept(&mut self, _req: TsiAcceptReq) -> ProxyUpdate {
+        ProxyUpdate::default()
+    }
+
+    fn update_peer_credit(&mut self, _pkt: &VsockPacket) -> ProxyUpdate {
+        // Datagram packets deliberately do not participate in stream credit accounting.
+        ProxyUpdate::default()
+    }
+
+    fn process_op_response(&mut self, _pkt: &VsockPacket) -> ProxyUpdate {
+        ProxyUpdate::default()
+    }
+
+    fn release(&mut self) -> ProxyUpdate {
+        ProxyUpdate {
+            polling: Some((self.id, self.as_raw_fd(), EventSet::empty())),
+            remove_proxy: ProxyRemoval::Immediate,
+            ..Default::default()
+        }
+    }
+
+    fn process_event(&mut self, evset: EventSet) -> ProxyUpdate {
+        if evset.contains(EventSet::HANG_UP) {
+            return self.release();
+        }
+
+        if !evset.contains(EventSet::IN) {
+            return ProxyUpdate::default();
+        }
+
+        match self.receive_batch() {
+            Ok(delivered) => ProxyUpdate {
+                signal_queue: delivered,
+                polling: Some((self.id, self.as_raw_fd(), EventSet::IN)),
+                ..Default::default()
+            },
+            Err(err) => {
+                warn!(
+                    "failed to receive host datagram for vsock port {}: {err}",
+                    self.local_port
+                );
+                self.release()
+            }
+        }
+    }
+
+    fn kick(&self) {
+        if self.uses_notifier() {
+            if let Err(err) = self.notifier.notify() {
+                warn!("failed to kick custom vsock datagram backend: {err}");
+            }
+        }
+    }
+}

--- a/src/devices/src/virtio/vsock/dgram.rs
+++ b/src/devices/src/virtio/vsock/dgram.rs
@@ -79,11 +79,15 @@ impl DatagramProxy {
         }
 
         let mut delivered = false;
+        let mut exhausted_batch = true;
         for _ in 0..MAX_RECEIVE_BATCH {
             let mut data = vec![0; defs::MAX_PKT_BUF_SIZE];
             let read = match self.backend.receive(&mut data) {
                 Ok(read) => read,
-                Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                    exhausted_batch = false;
+                    break;
+                }
                 Err(err) => return Err(err),
             };
 
@@ -114,6 +118,13 @@ impl DatagramProxy {
                 &self.mem,
             );
             delivered = true;
+        }
+
+        // Notifier-backed endpoints commonly signal only on an empty-to-ready
+        // transition. Preserve fairness without stranding a 33rd message after
+        // clearing that notification above.
+        if exhausted_batch && self.uses_notifier() {
+            self.notifier.notify()?;
         }
 
         Ok(delivered)
@@ -152,7 +163,10 @@ impl Proxy for DatagramProxy {
     fn getpeername(&mut self, _pkt: &VsockPacket) {}
 
     fn sendmsg(&mut self, pkt: &VsockPacket) -> ProxyUpdate {
-        let payload = pkt.buf().unwrap_or_default();
+        let Some(payload) = pkt.payload() else {
+            warn!("dropping custom vsock datagram with an invalid payload length");
+            return ProxyUpdate::default();
+        };
         match self.backend.send(payload) {
             Ok(()) => ProxyUpdate::default(),
             Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
@@ -241,5 +255,73 @@ impl Proxy for DatagramProxy {
                 warn!("failed to kick custom vsock datagram backend: {err}");
             }
         }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use vm_memory::GuestAddress;
+
+    use super::super::backend::VsockDatagramRead;
+    use super::*;
+
+    struct QueueDatagrams {
+        messages: Mutex<VecDeque<Vec<u8>>>,
+    }
+
+    impl VsockDatagramBackend for QueueDatagrams {
+        fn send(&self, _payload: &[u8]) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn receive(&self, buf: &mut [u8]) -> io::Result<VsockDatagramRead> {
+            let Some(message) = self.messages.lock().unwrap().pop_front() else {
+                return Err(io::Error::from(io::ErrorKind::WouldBlock));
+            };
+            let len = message.len().min(buf.len());
+            buf[..len].copy_from_slice(&message[..len]);
+            Ok(VsockDatagramRead {
+                len,
+                truncated: message.len() > buf.len(),
+            })
+        }
+    }
+
+    #[test]
+    fn notifier_rearms_after_a_full_receive_batch() {
+        let messages = (0..=MAX_RECEIVE_BATCH)
+            .map(|index| vec![index as u8])
+            .collect();
+        let notifier = VsockNotifier::new().unwrap();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let rxq = Arc::new(Mutex::new(MuxerRxQ::new()));
+        let proxy = DatagramProxy::new(
+            1,
+            3,
+            5000,
+            4000,
+            Box::new(QueueDatagrams {
+                messages: Mutex::new(messages),
+            }),
+            notifier.clone(),
+            mem,
+            Arc::new(Mutex::new(VirtQueue::new(256))),
+            Arc::clone(&rxq),
+        );
+
+        assert!(proxy.receive_batch().unwrap());
+        assert_eq!(rxq.lock().unwrap().len(), MAX_RECEIVE_BATCH);
+        // The full batch explicitly re-signals so the remaining datagram is
+        // observable even when the backend only signals empty-to-ready.
+        notifier.event().read().unwrap();
+
+        assert!(proxy.receive_batch().unwrap());
+        assert_eq!(rxq.lock().unwrap().len(), MAX_RECEIVE_BATCH + 1);
     }
 }

--- a/src/devices/src/virtio/vsock/event_handler.rs
+++ b/src/devices/src/virtio/vsock/event_handler.rs
@@ -5,13 +5,26 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use std::os::unix::io::AsRawFd;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
 
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
 
 use super::device::{Vsock, EVQ_INDEX, RXQ_INDEX, TXQ_INDEX};
 use crate::virtio::VirtioDevice;
+
+#[cfg(unix)]
+fn event_pollable(event: &utils::eventfd::EventFd) -> std::os::fd::RawFd {
+    event.as_raw_fd()
+}
+
+#[cfg(windows)]
+fn event_pollable(event: &utils::eventfd::EventFd) -> std::os::windows::io::RawHandle {
+    event.as_raw_handle()
+}
 
 impl Vsock {
     pub(crate) fn handle_rxq_event(&mut self, event: &EpollEvent) -> bool {
@@ -80,15 +93,15 @@ impl Vsock {
         // The subscriber must exist as we previously registered activate_evt via
         // `interest_list()`.
         let self_subscriber = event_manager
-            .subscriber(self.activate_evt.as_raw_fd())
+            .subscriber(event_pollable(&self.activate_evt))
             .unwrap();
 
         event_manager
             .register(
-                self.queue_events[RXQ_INDEX].as_raw_fd(),
+                event_pollable(&self.queue_events[RXQ_INDEX]),
                 EpollEvent::new(
                     EventSet::IN,
-                    self.queue_events[RXQ_INDEX].as_raw_fd() as u64,
+                    event_pollable(&self.queue_events[RXQ_INDEX]) as usize as u64,
                 ),
                 self_subscriber.clone(),
             )
@@ -98,10 +111,10 @@ impl Vsock {
 
         event_manager
             .register(
-                self.queue_events[TXQ_INDEX].as_raw_fd(),
+                event_pollable(&self.queue_events[TXQ_INDEX]),
                 EpollEvent::new(
                     EventSet::IN,
-                    self.queue_events[TXQ_INDEX].as_raw_fd() as u64,
+                    event_pollable(&self.queue_events[TXQ_INDEX]) as usize as u64,
                 ),
                 self_subscriber.clone(),
             )
@@ -110,7 +123,7 @@ impl Vsock {
             });
 
         event_manager
-            .unregister(self.activate_evt.as_raw_fd())
+            .unregister(event_pollable(&self.activate_evt))
             .unwrap_or_else(|e| {
                 error!("Failed to unregister vsock activate evt: {e:?}");
             })
@@ -120,11 +133,11 @@ impl Vsock {
 impl Subscriber for Vsock {
     fn process(&mut self, event: &EpollEvent, event_manager: &mut EventManager) {
         let source = event.fd();
-        let rxq = self.queue_events[RXQ_INDEX].as_raw_fd();
-        let txq = self.queue_events[TXQ_INDEX].as_raw_fd();
-        let evq = self.queue_events[EVQ_INDEX].as_raw_fd();
+        let rxq = event_pollable(&self.queue_events[RXQ_INDEX]);
+        let txq = event_pollable(&self.queue_events[TXQ_INDEX]);
+        let evq = event_pollable(&self.queue_events[EVQ_INDEX]);
         //let backend = self.backend.as_raw_fd();
-        let activate_evt = self.activate_evt.as_raw_fd();
+        let activate_evt = event_pollable(&self.activate_evt);
 
         if self.is_activated() {
             let mut raise_irq = false;
@@ -154,7 +167,7 @@ impl Subscriber for Vsock {
     fn interest_list(&self) -> Vec<EpollEvent> {
         vec![EpollEvent::new(
             EventSet::IN,
-            self.activate_evt.as_raw_fd() as u64,
+            event_pollable(&self.activate_evt) as usize as u64,
         )]
     }
 }

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -6,10 +6,21 @@
 // found in the THIRD-PARTY file.
 
 mod backend;
+mod custom_stream;
 mod device;
+#[cfg(unix)]
+mod dgram;
 mod event_handler;
+#[cfg(unix)]
+mod muxer;
+#[cfg(windows)]
+#[path = "muxer_windows.rs"]
 mod muxer;
 mod muxer_rxq;
+#[cfg(unix)]
+mod muxer_thread;
+#[cfg(windows)]
+#[path = "muxer_thread_windows.rs"]
 mod muxer_thread;
 #[allow(dead_code)]
 mod packet;
@@ -17,12 +28,17 @@ mod proxy;
 mod reaper;
 #[cfg(target_os = "macos")]
 mod timesync;
+#[cfg(unix)]
 mod tsi_dgram;
+#[cfg(unix)]
 mod tsi_stream;
+#[cfg(unix)]
 mod unix;
 
 pub use self::backend::{
-    VsockConnectRequest, VsockNotifier, VsockPortBackend, VsockShutdown, VsockStreamBackend,
+    VsockConnectRequest, VsockConnectState, VsockDatagramBackend, VsockDatagramPeer,
+    VsockDatagramPortBackend, VsockDatagramRead, VsockNotifier, VsockPollable, VsockPortBackend,
+    VsockShutdown, VsockStreamBackend,
 };
 pub use self::defs::uapi::VIRTIO_ID_VSOCK as TYPE_VSOCK;
 pub use self::defs::TsiFlags;
@@ -80,23 +96,37 @@ mod defs {
     // Kernel side doesn't play nice with us supporting so many bytes
     //pub const CONN_TX_BUF_SIZE: usize = i32::MAX as usize;
     pub const CONN_TX_BUF_SIZE: usize = 8 * 1024 * 1024;
+    #[cfg(unix)]
     pub const SOCK_STREAM: u16 = 1;
+    #[cfg(unix)]
     pub const SOCK_DGRAM: u16 = 2;
 
     /// Misc
+    #[cfg(unix)]
     pub const TSI_PROXY_PORT: u32 = 620;
+    #[cfg(unix)]
     pub const TSI_PROXY_CREATE: u32 = 1024;
+    #[cfg(unix)]
     pub const TSI_CONNECT: u32 = 1025;
+    #[cfg(unix)]
     pub const TSI_GETNAME: u32 = 1026;
+    #[cfg(unix)]
     pub const TSI_SENDTO_ADDR: u32 = 1027;
+    #[cfg(unix)]
     pub const TSI_SENDTO_DATA: u32 = 1028;
+    #[cfg(unix)]
     pub const TSI_LISTEN: u32 = 1029;
+    #[cfg(unix)]
     pub const TSI_ACCEPT: u32 = 1030;
+    #[cfg(unix)]
     pub const TSI_PROXY_RELEASE: u32 = 1031;
 
     // Linux definitions that we need for cross-platform compatibility.
+    #[cfg(unix)]
     pub const LINUX_AF_UNIX: u16 = 1;
+    #[cfg(unix)]
     pub const LINUX_AF_INET: u16 = 2;
+    #[cfg(unix)]
     pub const LINUX_AF_INET6: u16 = 10;
 
     pub mod uapi {

--- a/src/devices/src/virtio/vsock/muxer.rs
+++ b/src/devices/src/virtio/vsock/muxer.rs
@@ -1,11 +1,14 @@
 use std::collections::HashMap;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use super::super::Queue as VirtQueue;
+use super::custom_stream::CustomStreamProxy;
 use super::defs;
 use super::defs::uapi;
+use super::dgram::DatagramProxy;
 use super::muxer_rxq::{rx_to_pkt, MuxerRxQ};
 use super::muxer_thread::MuxerThread;
 use super::packet::{TsiGetnameRsp, VsockPacket};
@@ -17,7 +20,10 @@ use super::tsi_dgram::TsiDgramProxy;
 use super::tsi_stream::TsiStreamProxy;
 use super::unix::UnixProxy;
 use super::VsockError;
-use super::{TsiFlags, VsockConnectRequest, VsockNotifier, VsockPortBackend};
+use super::{
+    TsiFlags, VsockConnectRequest, VsockDatagramPeer, VsockDatagramPortBackend, VsockNotifier,
+    VsockPortBackend,
+};
 use crossbeam_channel::{unbounded, Sender};
 use utils::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 use vm_memory::GuestMemoryMmap;
@@ -72,6 +78,11 @@ pub enum MuxerRx {
         peer_port: u32,
         result: i32,
     },
+    Datagram {
+        local_port: u32,
+        peer_port: u32,
+        data: Vec<u8>,
+    },
 }
 
 pub fn push_packet(
@@ -108,6 +119,9 @@ pub struct VsockMuxer {
     reaper_sender: Option<Sender<u64>>,
     unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
     custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
+    custom_dgram_port_map: Option<HashMap<u32, Arc<dyn VsockDatagramPortBackend>>>,
+    dgram_peer_map: Mutex<HashMap<(u32, u32), u64>>,
+    next_dgram_proxy_id: AtomicU64,
     tsi_flags: TsiFlags,
 }
 
@@ -117,6 +131,7 @@ impl VsockMuxer {
         host_port_map: Option<HashMap<u16, u16>>,
         unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
         custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
+        custom_dgram_port_map: Option<HashMap<u32, Arc<dyn VsockDatagramPortBackend>>>,
         tsi_flags: TsiFlags,
     ) -> Self {
         VsockMuxer {
@@ -131,6 +146,12 @@ impl VsockMuxer {
             reaper_sender: None,
             unix_ipc_port_map,
             custom_port_map,
+            custom_dgram_port_map,
+            dgram_peer_map: Mutex::new(HashMap::new()),
+            // Direct stream proxy ids use the low 32 bits for a non-zero host
+            // port. Keeping those bits zero gives datagram event tokens a
+            // disjoint namespace without changing the legacy stream ids.
+            next_dgram_proxy_id: AtomicU64::new(1),
             tsi_flags,
         }
     }
@@ -509,6 +530,104 @@ impl VsockMuxer {
         }
     }
 
+    fn process_custom_dgram(&self, pkt: &VsockPacket) {
+        let Some(service) = self
+            .custom_dgram_port_map
+            .as_ref()
+            .and_then(|routes| routes.get(&pkt.dst_port()))
+            .cloned()
+        else {
+            return;
+        };
+
+        let peer_key = (pkt.src_port(), pkt.dst_port());
+        if let Some(id) = self.dgram_peer_map.lock().unwrap().get(&peer_key).copied() {
+            let update = self
+                .proxy_map
+                .read()
+                .unwrap()
+                .get(&id)
+                .map(|proxy| proxy.lock().unwrap().sendmsg(pkt));
+            if let Some(update) = update {
+                self.process_proxy_update(id, update);
+                return;
+            }
+            self.dgram_peer_map.lock().unwrap().remove(&peer_key);
+        }
+
+        let Some(mem) = self.mem.as_ref() else {
+            warn!("vsock datagram without guest memory");
+            return;
+        };
+        let Some(queue) = self.queue.as_ref() else {
+            warn!("vsock datagram without receive queue");
+            return;
+        };
+
+        let notifier = match VsockNotifier::new() {
+            Ok(notifier) => notifier,
+            Err(err) => {
+                warn!("failed to create custom vsock datagram notifier: {err}");
+                return;
+            }
+        };
+        let peer = VsockDatagramPeer {
+            guest_cid: pkt.src_cid(),
+            guest_port: pkt.src_port(),
+            host_port: pkt.dst_port(),
+        };
+        let backend = match service.open_peer(peer, notifier.clone()) {
+            Ok(backend) => backend,
+            Err(err) => {
+                warn!(
+                    "custom vsock datagram service rejected port {}: {err}",
+                    pkt.dst_port()
+                );
+                return;
+            }
+        };
+
+        let id = self.next_dgram_proxy_id.fetch_add(1, Ordering::Relaxed) << 32;
+        let mut proxy = DatagramProxy::new(
+            id,
+            self.cid,
+            pkt.dst_port(),
+            pkt.src_port(),
+            backend,
+            notifier,
+            mem.clone(),
+            queue.clone(),
+            self.rxq.clone(),
+        );
+        let poll_fd = proxy.as_raw_fd();
+        if poll_fd < 0 {
+            warn!(
+                "custom vsock datagram service for port {} returned an invalid poll fd",
+                pkt.dst_port()
+            );
+            return;
+        }
+        if let Err(err) = self.epoll.ctl(
+            ControlOperation::Add,
+            poll_fd,
+            &EpollEvent::new(EventSet::IN, id),
+        ) {
+            warn!(
+                "custom vsock datagram service for port {} returned an unusable poll fd: {err}",
+                pkt.dst_port()
+            );
+            return;
+        }
+
+        let update = proxy.sendmsg(pkt);
+        self.proxy_map
+            .write()
+            .unwrap()
+            .insert(id, Mutex::new(Box::new(proxy)));
+        self.dgram_peer_map.lock().unwrap().insert(peer_key, id);
+        self.process_proxy_update(id, update);
+    }
+
     pub(crate) fn send_dgram_pkt(&mut self, pkt: &VsockPacket) -> super::Result<()> {
         debug!(
             "send_dgram_pkt: src_port={} dst_port={}",
@@ -518,6 +637,19 @@ impl VsockMuxer {
 
         if pkt.dst_cid() != uapi::VSOCK_HOST_CID {
             debug!("dropping guest packet for unknown CID: {:?}", pkt.hdr());
+            return Ok(());
+        }
+
+        if self
+            .custom_dgram_port_map
+            .as_ref()
+            .is_some_and(|routes| routes.contains_key(&pkt.dst_port()))
+        {
+            if pkt.op() == uapi::VSOCK_OP_RW {
+                self.process_custom_dgram(pkt);
+            } else {
+                debug!("dropping non-RW packet for direct datagram route");
+            }
             return Ok(());
         }
 
@@ -596,7 +728,7 @@ impl VsockMuxer {
             };
             match service.connect(request, notifier.clone()) {
                 Ok(backend) => {
-                    let proxy = UnixProxy::new_custom(
+                    let mut proxy = match CustomStreamProxy::new(
                         id,
                         self.cid,
                         pkt.dst_port(),
@@ -606,8 +738,31 @@ impl VsockMuxer {
                         mem.clone(),
                         queue.clone(),
                         self.rxq.clone(),
-                    );
-                    let poll_fd = proxy.as_raw_fd();
+                    ) {
+                        Ok(proxy) => proxy,
+                        Err(err) => {
+                            warn!(
+                                "custom vsock service failed to initialize port {}: {err}",
+                                pkt.dst_port()
+                            );
+                            push_packet(
+                                self.cid,
+                                MuxerRx::Reset {
+                                    local_port: pkt.dst_port(),
+                                    peer_port: pkt.src_port(),
+                                },
+                                &self.rxq,
+                                queue,
+                                mem,
+                            );
+                            return;
+                        }
+                    };
+                    let connecting = proxy.is_connecting();
+                    if connecting {
+                        proxy.prepare_connect(pkt);
+                    }
+                    let poll_fd = proxy.pollable();
                     if poll_fd < 0 {
                         warn!(
                             "custom vsock service for port {} returned an invalid poll fd",
@@ -632,7 +787,14 @@ impl VsockMuxer {
                     if let Err(err) = self.epoll.ctl(
                         ControlOperation::Add,
                         poll_fd,
-                        &EpollEvent::new(EventSet::IN, id),
+                        &EpollEvent::new(
+                            if connecting {
+                                EventSet::IN | EventSet::OUT
+                            } else {
+                                EventSet::IN
+                            },
+                            id,
+                        ),
                     ) {
                         self.proxy_map.write().unwrap().remove(&id);
                         warn!(
@@ -651,8 +813,10 @@ impl VsockMuxer {
                         );
                         return;
                     }
-                    if let Some(proxy) = self.proxy_map.read().unwrap().get(&id) {
-                        proxy.lock().unwrap().confirm_connect(pkt);
+                    if !connecting {
+                        if let Some(proxy) = self.proxy_map.read().unwrap().get(&id) {
+                            proxy.lock().unwrap().confirm_connect(pkt);
+                        }
                     }
                 }
                 Err(err) => {

--- a/src/devices/src/virtio/vsock/muxer.rs
+++ b/src/devices/src/virtio/vsock/muxer.rs
@@ -31,7 +31,25 @@ use vm_memory::GuestMemoryMmap;
 use crate::virtio::InterruptTransport;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Bound connectionless peer state per exposed host port. The least recently
+/// used peer is retired before a new peer is opened at the limit.
+const MAX_DGRAM_PEERS_PER_PORT: usize = 256;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
 pub type ProxyMap = Arc<RwLock<HashMap<u64, Mutex<Box<dyn Proxy>>>>>;
+
+#[derive(Clone, Copy)]
+struct DgramPeerEntry {
+    id: u64,
+    last_used: u64,
+}
 
 /// A muxer RX queue item.
 #[derive(Debug)]
@@ -93,17 +111,26 @@ pub fn push_packet(
     mem: &GuestMemoryMmap,
 ) {
     let mut queue = queue_mutex.lock().unwrap();
+    let mut rxq = rxq_mutex.lock().unwrap();
+    if !rxq.is_empty() {
+        rxq.push(rx);
+        return;
+    }
+
     if let Some(head) = queue.pop(mem) {
         if let Ok(mut pkt) = VsockPacket::from_rx_virtq_head(&head) {
-            rx_to_pkt(cid, rx, &mut pkt);
-            if let Err(e) = queue.add_used(mem, head.index, pkt.hdr().len() as u32 + pkt.len()) {
-                error!("failed to add used elements to the queue: {e:?}");
+            if rx_to_pkt(cid, rx, &mut pkt) {
+                if let Err(e) = queue.add_used(mem, head.index, pkt.hdr().len() as u32 + pkt.len())
+                {
+                    error!("failed to add used elements to the queue: {e:?}");
+                }
+            } else {
+                queue.undo_pop();
             }
         }
     } else {
         error!("couldn't push pkt to queue, adding it to rxq");
-        drop(queue);
-        rxq_mutex.lock().unwrap().push(rx);
+        rxq.push(rx);
     }
 }
 
@@ -120,8 +147,9 @@ pub struct VsockMuxer {
     unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
     custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
     custom_dgram_port_map: Option<HashMap<u32, Arc<dyn VsockDatagramPortBackend>>>,
-    dgram_peer_map: Mutex<HashMap<(u32, u32), u64>>,
+    dgram_peer_map: Mutex<HashMap<(u32, u32), DgramPeerEntry>>,
     next_dgram_proxy_id: AtomicU64,
+    next_dgram_activity: AtomicU64,
     tsi_flags: TsiFlags,
 }
 
@@ -152,6 +180,7 @@ impl VsockMuxer {
             // port. Keeping those bits zero gives datagram event tokens a
             // disjoint namespace without changing the legacy stream ids.
             next_dgram_proxy_id: AtomicU64::new(1),
+            next_dgram_activity: AtomicU64::new(1),
             tsi_flags,
         }
     }
@@ -200,21 +229,23 @@ impl VsockMuxer {
     pub(crate) fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> super::Result<()> {
         debug!("recv_stream_pkt");
         if self.rxq.lock().unwrap().is_empty() {
-            // A custom backend notification may have arrived before the guest
-            // supplied an RX descriptor. Re-kick streams now that the guest is
-            // explicitly asking us to fill one, without exposing event fds to
-            // backend implementations.
-            for proxy in self.proxy_map.read().unwrap().values() {
-                proxy.lock().unwrap().kick();
-            }
             return Err(VsockError::NoData);
         }
 
-        if let Some(rx) = self.rxq.lock().unwrap().pop() {
-            rx_to_pkt(self.cid, rx, pkt);
+        let mut rxq = self.rxq.lock().unwrap();
+        while let Some(rx) = rxq.pop() {
+            if rx_to_pkt(self.cid, rx, pkt) {
+                return Ok(());
+            }
         }
+        Err(VsockError::NoData)
+    }
 
-        Ok(())
+    /// Retry proxy work after the caller has released the guest RX queue.
+    pub(crate) fn kick_backends(&self) {
+        for proxy in self.proxy_map.read().unwrap().values() {
+            proxy.lock().unwrap().kick();
+        }
     }
 
     fn push_packet(&self, rx: MuxerRx) {
@@ -234,18 +265,27 @@ impl VsockMuxer {
         };
 
         let mut queue = queue_mutex.lock().unwrap();
+        let mut rxq = self.rxq.lock().unwrap();
+        if !rxq.is_empty() {
+            rxq.push(rx);
+            return;
+        }
+
         if let Some(head) = queue.pop(mem) {
             if let Ok(mut pkt) = VsockPacket::from_rx_virtq_head(&head) {
-                rx_to_pkt(self.cid, rx, &mut pkt);
-                if let Err(e) = queue.add_used(mem, head.index, pkt.hdr().len() as u32 + pkt.len())
-                {
-                    error!("failed to add used elements to the queue: {e:?}");
+                if rx_to_pkt(self.cid, rx, &mut pkt) {
+                    if let Err(e) =
+                        queue.add_used(mem, head.index, pkt.hdr().len() as u32 + pkt.len())
+                    {
+                        error!("failed to add used elements to the queue: {e:?}");
+                    }
+                } else {
+                    queue.undo_pop();
                 }
             }
         } else {
             error!("couldn't push pkt to queue, adding it to rxq");
-            drop(queue);
-            self.rxq.lock().unwrap().push(rx);
+            rxq.push(rx);
         }
     }
 
@@ -270,7 +310,7 @@ impl VsockMuxer {
             ProxyRemoval::Keep => {}
             ProxyRemoval::Immediate => {
                 info!("immediately removing proxy: {id}");
-                self.proxy_map.write().unwrap().remove(&id);
+                self.remove_proxy(id);
             }
             ProxyRemoval::Deferred => {
                 info!("deferring proxy removal: {id}");
@@ -286,6 +326,42 @@ impl VsockMuxer {
             if let Some(interrupt) = &self.interrupt {
                 interrupt.signal_used_queue();
             }
+        }
+    }
+
+    /// Remove polling, proxy ownership, and any connectionless peer index as
+    /// one lifecycle operation.
+    fn remove_proxy(&self, id: u64) {
+        let proxy = self.proxy_map.write().unwrap().remove(&id);
+        if let Some(proxy) = proxy {
+            let pollable = proxy.lock().unwrap().pollable();
+            self.update_polling(id, pollable, EventSet::empty());
+        }
+        self.dgram_peer_map
+            .lock()
+            .unwrap()
+            .retain(|_, entry| entry.id != id);
+    }
+
+    fn evict_oldest_dgram_peer(&self, host_port: u32) {
+        let evicted = {
+            let mut peers = self.dgram_peer_map.lock().unwrap();
+            if peers.keys().filter(|(_, port)| *port == host_port).count()
+                < MAX_DGRAM_PEERS_PER_PORT
+            {
+                None
+            } else {
+                let oldest = peers
+                    .iter()
+                    .filter(|((_, port), _)| *port == host_port)
+                    .min_by_key(|(_, entry)| entry.last_used)
+                    .map(|(key, entry)| (*key, entry.id));
+                oldest.and_then(|(key, id)| peers.remove(&key).map(|_| id))
+            }
+        };
+
+        if let Some(id) = evicted {
+            self.remove_proxy(id);
         }
     }
 
@@ -520,10 +596,14 @@ impl VsockMuxer {
         debug!("DGRAM OP_RW");
         let id = ((pkt.src_port() as u64) << 32) | (defs::TSI_PROXY_PORT as u64);
 
-        if let Some(proxy_lock) = self.proxy_map.read().unwrap().get(&id) {
+        let update = self
+            .proxy_map
+            .read()
+            .unwrap()
+            .get(&id)
+            .map(|proxy| proxy.lock().unwrap().sendmsg(pkt));
+        if let Some(update) = update {
             debug!("DGRAM allowing OP_RW for {}", pkt.src_port());
-            let mut proxy = proxy_lock.lock().unwrap();
-            let update = proxy.sendmsg(pkt);
             self.process_proxy_update(id, update);
         } else {
             debug!("DGRAM ignoring OP_RW for {}", pkt.src_port());
@@ -541,7 +621,15 @@ impl VsockMuxer {
         };
 
         let peer_key = (pkt.src_port(), pkt.dst_port());
-        if let Some(id) = self.dgram_peer_map.lock().unwrap().get(&peer_key).copied() {
+        let activity = self.next_dgram_activity.fetch_add(1, Ordering::Relaxed);
+        let existing = {
+            let mut peers = self.dgram_peer_map.lock().unwrap();
+            peers.get_mut(&peer_key).map(|entry| {
+                entry.last_used = activity;
+                entry.id
+            })
+        };
+        if let Some(id) = existing {
             let update = self
                 .proxy_map
                 .read()
@@ -554,6 +642,8 @@ impl VsockMuxer {
             }
             self.dgram_peer_map.lock().unwrap().remove(&peer_key);
         }
+
+        self.evict_oldest_dgram_peer(pkt.dst_port());
 
         let Some(mem) = self.mem.as_ref() else {
             warn!("vsock datagram without guest memory");
@@ -624,7 +714,13 @@ impl VsockMuxer {
             .write()
             .unwrap()
             .insert(id, Mutex::new(Box::new(proxy)));
-        self.dgram_peer_map.lock().unwrap().insert(peer_key, id);
+        self.dgram_peer_map.lock().unwrap().insert(
+            peer_key,
+            DgramPeerEntry {
+                id,
+                last_used: activity,
+            },
+        );
         self.process_proxy_update(id, update);
     }
 
@@ -682,8 +778,14 @@ impl VsockMuxer {
         debug!("OP_REQUEST");
         let id: u64 = ((pkt.src_port() as u64) << 32) | (pkt.dst_port() as u64);
 
-        if let Some(proxy) = self.proxy_map.read().unwrap().get(&id) {
-            if let Some(update) = proxy.lock().unwrap().confirm_connect(pkt) {
+        let existing = self
+            .proxy_map
+            .read()
+            .unwrap()
+            .get(&id)
+            .map(|proxy| proxy.lock().unwrap().confirm_connect(pkt));
+        if let Some(update) = existing {
+            if let Some(update) = update {
                 self.process_proxy_update(id, update);
             }
             return;
@@ -972,14 +1074,18 @@ impl VsockMuxer {
     fn process_stream_rw(&self, pkt: &VsockPacket) {
         debug!("OP_RW");
         let id: u64 = ((pkt.src_port() as u64) << 32) | (pkt.dst_port() as u64);
-        if let Some(proxy_lock) = self.proxy_map.read().unwrap().get(&id) {
+        let update = self
+            .proxy_map
+            .read()
+            .unwrap()
+            .get(&id)
+            .map(|proxy| proxy.lock().unwrap().sendmsg(pkt));
+        if let Some(update) = update {
             debug!(
                 "allowing OP_RW: src={} dst={}",
                 pkt.src_port(),
                 pkt.dst_port()
             );
-            let mut proxy = proxy_lock.lock().unwrap();
-            let update = proxy.sendmsg(pkt);
             self.process_proxy_update(id, update);
         } else {
             debug!("invalid OP_RW for {}, sending reset", pkt.src_port());
@@ -1010,15 +1116,19 @@ impl VsockMuxer {
     fn process_stream_rst(&self, pkt: &VsockPacket) {
         debug!("OP_RST");
         let id: u64 = ((pkt.src_port() as u64) << 32) | (pkt.dst_port() as u64);
-        if let Some(proxy_lock) = self.proxy_map.read().unwrap().get(&id) {
+        let update = self
+            .proxy_map
+            .read()
+            .unwrap()
+            .get(&id)
+            .map(|proxy| proxy.lock().unwrap().release());
+        if let Some(update) = update {
             debug!(
                 "allowing OP_RST: id={} src={} dst={}",
                 id,
                 pkt.src_port(),
                 pkt.dst_port()
             );
-            let mut proxy = proxy_lock.lock().unwrap();
-            let update = proxy.release();
             self.process_proxy_update(id, update);
         } else {
             debug!("invalid OP_RST for {}", pkt.src_port());
@@ -1048,5 +1158,48 @@ impl VsockMuxer {
             _ => warn!("stream: unhandled op={}", pkt.op()),
         }
         Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn datagram_peer_limit_evicts_the_least_recently_used_peer_per_port() {
+        let muxer = VsockMuxer::new(3, None, None, None, None, TsiFlags::empty());
+        {
+            let mut peers = muxer.dgram_peer_map.lock().unwrap();
+            for source_port in 1..=MAX_DGRAM_PEERS_PER_PORT as u32 {
+                peers.insert(
+                    (source_port, 5000),
+                    DgramPeerEntry {
+                        id: source_port as u64,
+                        last_used: source_port as u64,
+                    },
+                );
+            }
+            peers.insert(
+                (1, 6000),
+                DgramPeerEntry {
+                    id: u32::MAX as u64,
+                    last_used: 0,
+                },
+            );
+        }
+
+        muxer.evict_oldest_dgram_peer(5000);
+
+        let peers = muxer.dgram_peer_map.lock().unwrap();
+        assert!(!peers.contains_key(&(1, 5000)));
+        assert_eq!(
+            peers.keys().filter(|(_, port)| *port == 5000).count(),
+            MAX_DGRAM_PEERS_PER_PORT - 1
+        );
+        assert!(peers.contains_key(&(1, 6000)));
     }
 }

--- a/src/devices/src/virtio/vsock/muxer_rxq.rs
+++ b/src/devices/src/virtio/vsock/muxer_rxq.rs
@@ -20,7 +20,9 @@ use std::collections::VecDeque;
 use super::defs;
 use super::defs::uapi;
 use super::muxer::MuxerRx;
-use super::packet::{TsiAcceptRsp, TsiConnectRsp, TsiListenRsp, VsockPacket};
+use super::packet::VsockPacket;
+#[cfg(unix)]
+use super::packet::{TsiAcceptRsp, TsiConnectRsp, TsiListenRsp};
 
 /// The muxer RX queue.
 pub struct MuxerRxQ {
@@ -107,6 +109,7 @@ pub fn rx_to_pkt(cid: u64, rx: MuxerRx, pkt: &mut VsockPacket) {
                 .set_buf_alloc(0)
                 .set_fwd_cnt(0);
         }
+        #[cfg(unix)]
         MuxerRx::ConnResponse {
             local_port,
             peer_port,
@@ -150,6 +153,7 @@ pub fn rx_to_pkt(cid: u64, rx: MuxerRx, pkt: &mut VsockPacket) {
 
             pkt.set_len(0);
         }
+        #[cfg(unix)]
         MuxerRx::GetnameResponse {
             local_port,
             peer_port,
@@ -193,6 +197,7 @@ pub fn rx_to_pkt(cid: u64, rx: MuxerRx, pkt: &mut VsockPacket) {
                 .set_buf_alloc(defs::CONN_TX_BUF_SIZE as u32)
                 .set_fwd_cnt(fwd_cnt);
         }
+        #[cfg(unix)]
         MuxerRx::ListenResponse {
             local_port,
             peer_port,
@@ -208,6 +213,7 @@ pub fn rx_to_pkt(cid: u64, rx: MuxerRx, pkt: &mut VsockPacket) {
             pkt.write_listen_rsp(TsiListenRsp { result });
             pkt.set_len(pkt.buf().unwrap().len() as u32);
         }
+        #[cfg(unix)]
         MuxerRx::AcceptResponse {
             local_port,
             peer_port,
@@ -222,6 +228,32 @@ pub fn rx_to_pkt(cid: u64, rx: MuxerRx, pkt: &mut VsockPacket) {
 
             pkt.write_accept_rsp(TsiAcceptRsp { result });
             pkt.set_len(pkt.buf().unwrap().len() as u32);
+        }
+        #[cfg(unix)]
+        MuxerRx::Datagram {
+            local_port,
+            peer_port,
+            data,
+        } => {
+            pkt.set_op(uapi::VSOCK_OP_RW)
+                .set_src_cid(uapi::VSOCK_HOST_CID)
+                .set_dst_cid(cid)
+                .set_src_port(local_port)
+                .set_dst_port(peer_port)
+                .set_type(uapi::VSOCK_TYPE_DGRAM)
+                .set_flags(0)
+                .set_buf_alloc(0)
+                .set_fwd_cnt(0);
+
+            let len = pkt
+                .buf_mut()
+                .map(|buf| {
+                    let len = data.len().min(buf.len());
+                    buf[..len].copy_from_slice(&data[..len]);
+                    len
+                })
+                .unwrap_or(0);
+            pkt.set_len(len as u32);
         }
     }
 }

--- a/src/devices/src/virtio/vsock/muxer_rxq.rs
+++ b/src/devices/src/virtio/vsock/muxer_rxq.rs
@@ -92,7 +92,7 @@ impl MuxerRxQ {
     }
 }
 
-pub fn rx_to_pkt(cid: u64, rx: MuxerRx, pkt: &mut VsockPacket) {
+pub fn rx_to_pkt(cid: u64, rx: MuxerRx, pkt: &mut VsockPacket) -> bool {
     match rx {
         MuxerRx::Reset {
             local_port,
@@ -235,6 +235,15 @@ pub fn rx_to_pkt(cid: u64, rx: MuxerRx, pkt: &mut VsockPacket) {
             peer_port,
             data,
         } => {
+            let Some(capacity) = pkt.buf().map(|buf| buf.len()) else {
+                return false;
+            };
+            if data.len() > capacity {
+                // Virtio-vsock datagrams are atomic. A short guest buffer must
+                // drop the message rather than manufacture a truncated one.
+                return false;
+            }
+
             pkt.set_op(uapi::VSOCK_OP_RW)
                 .set_src_cid(uapi::VSOCK_HOST_CID)
                 .set_dst_cid(cid)
@@ -245,15 +254,11 @@ pub fn rx_to_pkt(cid: u64, rx: MuxerRx, pkt: &mut VsockPacket) {
                 .set_buf_alloc(0)
                 .set_fwd_cnt(0);
 
-            let len = pkt
-                .buf_mut()
-                .map(|buf| {
-                    let len = data.len().min(buf.len());
-                    buf[..len].copy_from_slice(&data[..len]);
-                    len
-                })
-                .unwrap_or(0);
-            pkt.set_len(len as u32);
+            let buf = pkt.buf_mut().expect("datagram buffer was validated above");
+            buf[..data.len()].copy_from_slice(&data);
+            pkt.set_len(data.len() as u32);
         }
     }
+
+    true
 }

--- a/src/devices/src/virtio/vsock/muxer_thread.rs
+++ b/src/devices/src/virtio/vsock/muxer_thread.rs
@@ -167,7 +167,7 @@ impl MuxerThread {
                 .unwrap()
                 .insert(id, Mutex::new(Box::new(proxy)));
             if let Some(proxy) = self.proxy_map.read().unwrap().get(&id) {
-                self.update_polling(id, proxy.lock().unwrap().as_raw_fd(), EventSet::IN);
+                self.update_polling(id, proxy.lock().unwrap().pollable(), EventSet::IN);
             };
         }
     }

--- a/src/devices/src/virtio/vsock/muxer_thread_windows.rs
+++ b/src/devices/src/virtio/vsock/muxer_thread_windows.rs
@@ -1,0 +1,118 @@
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use crossbeam_channel::Sender;
+use utils::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
+use vm_memory::GuestMemoryMmap;
+
+use super::super::Queue as VirtQueue;
+use super::muxer::ProxyMap;
+use super::muxer_rxq::MuxerRxQ;
+use super::proxy::{ProxyRemoval, ProxyUpdate};
+use super::VsockPollable;
+use crate::virtio::InterruptTransport;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+pub struct MuxerThread {
+    cid: u64,
+    epoll: Arc<Epoll>,
+    rxq: Arc<Mutex<MuxerRxQ>>,
+    proxy_map: ProxyMap,
+    mem: GuestMemoryMmap,
+    queue: Arc<Mutex<VirtQueue>>,
+    interrupt: InterruptTransport,
+    reaper_sender: Sender<u64>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl MuxerThread {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        cid: u64,
+        epoll: Arc<Epoll>,
+        rxq: Arc<Mutex<MuxerRxQ>>,
+        proxy_map: ProxyMap,
+        mem: GuestMemoryMmap,
+        queue: Arc<Mutex<VirtQueue>>,
+        interrupt: InterruptTransport,
+        reaper_sender: Sender<u64>,
+    ) -> Self {
+        Self {
+            cid,
+            epoll,
+            rxq,
+            proxy_map,
+            mem,
+            queue,
+            interrupt,
+            reaper_sender,
+        }
+    }
+
+    pub fn run(self) {
+        thread::Builder::new()
+            .name("vsock muxer".into())
+            .spawn(|| self.work())
+            .unwrap();
+    }
+
+    fn update_polling(&self, id: u64, pollable: VsockPollable, events: EventSet) {
+        let _ = self
+            .epoll
+            .ctl(ControlOperation::Delete, pollable, &EpollEvent::default());
+        if !events.is_empty() {
+            let _ = self.epoll.ctl(
+                ControlOperation::Add,
+                pollable,
+                &EpollEvent::new(events, id),
+            );
+        }
+    }
+
+    fn process_proxy_update(&self, id: u64, update: ProxyUpdate) {
+        if let Some((poll_id, pollable, events)) = update.polling {
+            self.update_polling(poll_id, pollable, events);
+        }
+        if let Some(credit) = update.push_credit_req {
+            super::muxer::push_packet(self.cid, credit, &self.rxq, &self.queue, &self.mem);
+        }
+        match update.remove_proxy {
+            ProxyRemoval::Keep => {}
+            ProxyRemoval::Deferred => {
+                if self.reaper_sender.send(id).is_err() {
+                    self.proxy_map.write().unwrap().remove(&id);
+                }
+            }
+        }
+        if update.signal_queue {
+            self.interrupt.signal_used_queue();
+        }
+    }
+
+    fn work(self) {
+        loop {
+            let mut events = vec![EpollEvent::new(EventSet::empty(), 0); 32];
+            match self.epoll.wait(events.len(), -1, &mut events) {
+                Ok(count) => {
+                    for event in events.iter().take(count) {
+                        let id = event.data();
+                        let update =
+                            self.proxy_map.read().unwrap().get(&id).map(|proxy| {
+                                proxy.lock().unwrap().process_event(event.event_set())
+                            });
+                        if let Some(update) = update {
+                            self.process_proxy_update(id, update);
+                        }
+                    }
+                }
+                Err(err) => debug!("failed to consume vsock wait event: {err}"),
+            }
+        }
+    }
+}

--- a/src/devices/src/virtio/vsock/muxer_thread_windows.rs
+++ b/src/devices/src/virtio/vsock/muxer_thread_windows.rs
@@ -84,6 +84,9 @@ impl MuxerThread {
         }
         match update.remove_proxy {
             ProxyRemoval::Keep => {}
+            ProxyRemoval::Immediate => {
+                self.proxy_map.write().unwrap().remove(&id);
+            }
             ProxyRemoval::Deferred => {
                 if self.reaper_sender.send(id).is_err() {
                     self.proxy_map.write().unwrap().remove(&id);

--- a/src/devices/src/virtio/vsock/muxer_windows.rs
+++ b/src/devices/src/virtio/vsock/muxer_windows.rs
@@ -1,0 +1,368 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, RwLock};
+
+use crossbeam_channel::{unbounded, Sender};
+use utils::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
+use vm_memory::GuestMemoryMmap;
+
+use super::super::Queue as VirtQueue;
+use super::custom_stream::CustomStreamProxy;
+use super::defs::uapi;
+use super::muxer_rxq::{rx_to_pkt, MuxerRxQ};
+use super::muxer_thread::MuxerThread;
+use super::packet::VsockPacket;
+use super::proxy::{Proxy, ProxyRemoval, ProxyUpdate};
+use super::reaper::ReaperThread;
+use super::{
+    TsiFlags, VsockConnectRequest, VsockDatagramPortBackend, VsockNotifier, VsockPollable,
+    VsockPortBackend,
+};
+use crate::virtio::InterruptTransport;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+pub type ProxyMap = Arc<RwLock<HashMap<u64, Mutex<Box<dyn Proxy>>>>>;
+
+/// A muxer RX queue item used by the direct stream transport on Windows.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum MuxerRx {
+    Reset {
+        local_port: u32,
+        peer_port: u32,
+    },
+    OpRequest {
+        local_port: u32,
+        peer_port: u32,
+    },
+    OpResponse {
+        local_port: u32,
+        peer_port: u32,
+    },
+    CreditRequest {
+        local_port: u32,
+        peer_port: u32,
+        fwd_cnt: u32,
+    },
+    CreditUpdate {
+        local_port: u32,
+        peer_port: u32,
+        fwd_cnt: u32,
+    },
+}
+
+pub struct VsockMuxer {
+    cid: u64,
+    queue: Option<Arc<Mutex<VirtQueue>>>,
+    mem: Option<GuestMemoryMmap>,
+    rxq: Arc<Mutex<MuxerRxQ>>,
+    epoll: Arc<Epoll>,
+    interrupt: Option<InterruptTransport>,
+    proxy_map: ProxyMap,
+    reaper_sender: Option<Sender<u64>>,
+    custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+pub fn push_packet(
+    cid: u64,
+    rx: MuxerRx,
+    rxq_mutex: &Arc<Mutex<MuxerRxQ>>,
+    queue_mutex: &Arc<Mutex<VirtQueue>>,
+    mem: &GuestMemoryMmap,
+) {
+    let mut queue = queue_mutex.lock().unwrap();
+    if let Some(head) = queue.pop(mem) {
+        if let Ok(mut pkt) = VsockPacket::from_rx_virtq_head(&head) {
+            rx_to_pkt(cid, rx, &mut pkt);
+            if let Err(err) = queue.add_used(mem, head.index, pkt.hdr().len() as u32 + pkt.len()) {
+                error!("failed to add used elements to the queue: {err:?}");
+            }
+        }
+    } else {
+        drop(queue);
+        rxq_mutex.lock().unwrap().push(rx);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl VsockMuxer {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        cid: u64,
+        _host_port_map: Option<HashMap<u16, u16>>,
+        _unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
+        custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
+        _custom_dgram_port_map: Option<HashMap<u32, Arc<dyn VsockDatagramPortBackend>>>,
+        _tsi_flags: TsiFlags,
+    ) -> Self {
+        Self {
+            cid,
+            queue: None,
+            mem: None,
+            rxq: Arc::new(Mutex::new(MuxerRxQ::new())),
+            epoll: Arc::new(Epoll::new().unwrap()),
+            interrupt: None,
+            proxy_map: Arc::new(RwLock::new(HashMap::new())),
+            reaper_sender: None,
+            custom_port_map,
+        }
+    }
+
+    pub(crate) fn activate(
+        &mut self,
+        mem: GuestMemoryMmap,
+        queue: Arc<Mutex<VirtQueue>>,
+        interrupt: InterruptTransport,
+    ) {
+        self.queue = Some(queue.clone());
+        self.mem = Some(mem.clone());
+        self.interrupt = Some(interrupt.clone());
+
+        let (sender, receiver) = unbounded();
+        MuxerThread::new(
+            self.cid,
+            self.epoll.clone(),
+            self.rxq.clone(),
+            self.proxy_map.clone(),
+            mem,
+            queue,
+            interrupt,
+            sender.clone(),
+        )
+        .run();
+        self.reaper_sender = Some(sender);
+        ReaperThread::new(receiver, self.proxy_map.clone()).run();
+    }
+
+    pub(crate) fn has_pending_rx(&self) -> bool {
+        !self.rxq.lock().unwrap().is_empty()
+    }
+
+    pub(crate) fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> super::Result<()> {
+        if self.rxq.lock().unwrap().is_empty() {
+            for proxy in self.proxy_map.read().unwrap().values() {
+                proxy.lock().unwrap().kick();
+            }
+            return Err(super::VsockError::NoData);
+        }
+        if let Some(rx) = self.rxq.lock().unwrap().pop() {
+            rx_to_pkt(self.cid, rx, pkt);
+        }
+        Ok(())
+    }
+
+    fn update_polling(&self, id: u64, pollable: VsockPollable, events: EventSet) {
+        let _ = self
+            .epoll
+            .ctl(ControlOperation::Delete, pollable, &EpollEvent::default());
+        if !events.is_empty() {
+            let _ = self.epoll.ctl(
+                ControlOperation::Add,
+                pollable,
+                &EpollEvent::new(events, id),
+            );
+        }
+    }
+
+    fn process_proxy_update(&self, id: u64, update: ProxyUpdate) {
+        if let Some((poll_id, pollable, events)) = update.polling {
+            self.update_polling(poll_id, pollable, events);
+        }
+        match update.remove_proxy {
+            ProxyRemoval::Keep => {}
+            ProxyRemoval::Deferred => {
+                if self
+                    .reaper_sender
+                    .as_ref()
+                    .is_none_or(|sender| sender.send(id).is_err())
+                {
+                    self.proxy_map.write().unwrap().remove(&id);
+                }
+            }
+        }
+        if update.signal_queue {
+            if let Some(interrupt) = &self.interrupt {
+                interrupt.signal_used_queue();
+            }
+        }
+    }
+
+    fn push_reset(&self, pkt: &VsockPacket) {
+        if let (Some(mem), Some(queue)) = (&self.mem, &self.queue) {
+            push_packet(
+                self.cid,
+                MuxerRx::Reset {
+                    local_port: pkt.dst_port(),
+                    peer_port: pkt.src_port(),
+                },
+                &self.rxq,
+                queue,
+                mem,
+            );
+        }
+    }
+
+    fn process_op_request(&self, pkt: &VsockPacket) {
+        let id = ((pkt.src_port() as u64) << 32) | pkt.dst_port() as u64;
+        if let Some(proxy) = self.proxy_map.read().unwrap().get(&id) {
+            if let Some(update) = proxy.lock().unwrap().confirm_connect(pkt) {
+                self.process_proxy_update(id, update);
+            }
+            return;
+        }
+
+        let Some(service) = self
+            .custom_port_map
+            .as_ref()
+            .and_then(|routes| routes.get(&pkt.dst_port()))
+            .cloned()
+        else {
+            self.push_reset(pkt);
+            return;
+        };
+        let (Some(mem), Some(queue)) = (&self.mem, &self.queue) else {
+            return;
+        };
+        let notifier = match VsockNotifier::new() {
+            Ok(notifier) => notifier,
+            Err(err) => {
+                warn!("failed to create custom vsock notifier: {err}");
+                self.push_reset(pkt);
+                return;
+            }
+        };
+        let request = VsockConnectRequest {
+            guest_cid: pkt.src_cid(),
+            guest_port: pkt.src_port(),
+            host_port: pkt.dst_port(),
+        };
+        let backend = match service.connect(request, notifier.clone()) {
+            Ok(backend) => backend,
+            Err(err) => {
+                warn!(
+                    "custom vsock service rejected port {}: {err}",
+                    pkt.dst_port()
+                );
+                self.push_reset(pkt);
+                return;
+            }
+        };
+        let mut proxy = match CustomStreamProxy::new(
+            id,
+            self.cid,
+            pkt.dst_port(),
+            pkt.src_port(),
+            backend,
+            notifier,
+            mem.clone(),
+            queue.clone(),
+            self.rxq.clone(),
+        ) {
+            Ok(proxy) => proxy,
+            Err(err) => {
+                warn!(
+                    "custom vsock service failed to initialize port {}: {err}",
+                    pkt.dst_port()
+                );
+                self.push_reset(pkt);
+                return;
+            }
+        };
+        let connecting = proxy.is_connecting();
+        if connecting {
+            proxy.prepare_connect(pkt);
+        }
+        let pollable = proxy.pollable();
+        if pollable.is_null() {
+            warn!("custom vsock service returned a null waitable handle");
+            self.push_reset(pkt);
+            return;
+        }
+        // Publish the proxy before registering its handle. A named-pipe worker
+        // can complete immediately, and the muxer thread must be able to find
+        // the proxy if the wait wakes as soon as the handle is registered.
+        self.proxy_map
+            .write()
+            .unwrap()
+            .insert(id, Mutex::new(Box::new(proxy)));
+        if let Err(err) = self.epoll.ctl(
+            ControlOperation::Add,
+            pollable,
+            &EpollEvent::new(EventSet::IN, id),
+        ) {
+            self.proxy_map.write().unwrap().remove(&id);
+            warn!("custom vsock service returned an unusable waitable handle: {err}");
+            self.push_reset(pkt);
+            return;
+        }
+        if !connecting {
+            if let Some(proxy) = self.proxy_map.read().unwrap().get(&id) {
+                proxy.lock().unwrap().confirm_connect(pkt);
+            }
+        }
+    }
+
+    fn with_proxy_update(&self, pkt: &VsockPacket, f: impl FnOnce(&mut dyn Proxy) -> ProxyUpdate) {
+        let id = ((pkt.src_port() as u64) << 32) | pkt.dst_port() as u64;
+        let update = self
+            .proxy_map
+            .read()
+            .unwrap()
+            .get(&id)
+            .map(|proxy| f(proxy.lock().unwrap().as_mut()));
+        if let Some(update) = update {
+            self.process_proxy_update(id, update);
+        }
+    }
+
+    pub(crate) fn send_stream_pkt(&mut self, pkt: &VsockPacket) -> super::Result<()> {
+        if pkt.dst_cid() != uapi::VSOCK_HOST_CID {
+            return Ok(());
+        }
+        match pkt.op() {
+            uapi::VSOCK_OP_REQUEST => self.process_op_request(pkt),
+            uapi::VSOCK_OP_RESPONSE => {
+                self.with_proxy_update(pkt, |proxy| proxy.process_op_response(pkt));
+            }
+            uapi::VSOCK_OP_SHUTDOWN => {
+                let id = ((pkt.src_port() as u64) << 32) | pkt.dst_port() as u64;
+                if let Some(proxy) = self.proxy_map.read().unwrap().get(&id) {
+                    proxy.lock().unwrap().shutdown(pkt);
+                }
+            }
+            uapi::VSOCK_OP_CREDIT_UPDATE => {
+                self.with_proxy_update(pkt, |proxy| proxy.update_peer_credit(pkt));
+            }
+            uapi::VSOCK_OP_RW => {
+                let id = ((pkt.src_port() as u64) << 32) | pkt.dst_port() as u64;
+                let found = self.proxy_map.read().unwrap().contains_key(&id);
+                if found {
+                    self.with_proxy_update(pkt, |proxy| proxy.sendmsg(pkt));
+                } else {
+                    self.push_reset(pkt);
+                }
+            }
+            uapi::VSOCK_OP_RST => {
+                self.with_proxy_update(pkt, |proxy| proxy.release());
+            }
+            _ => warn!("stream: unhandled op={}", pkt.op()),
+        }
+        Ok(())
+    }
+
+    pub(crate) fn send_dgram_pkt(&mut self, _pkt: &VsockPacket) -> super::Result<()> {
+        // Windows does not advertise VIRTIO_VSOCK_F_DGRAM, so a conforming guest
+        // never reaches this path. Drop malformed traffic without affecting streams.
+        Ok(())
+    }
+}

--- a/src/devices/src/virtio/vsock/muxer_windows.rs
+++ b/src/devices/src/virtio/vsock/muxer_windows.rs
@@ -78,16 +78,26 @@ pub fn push_packet(
     mem: &GuestMemoryMmap,
 ) {
     let mut queue = queue_mutex.lock().unwrap();
+    let mut rxq = rxq_mutex.lock().unwrap();
+    if !rxq.is_empty() {
+        rxq.push(rx);
+        return;
+    }
+
     if let Some(head) = queue.pop(mem) {
         if let Ok(mut pkt) = VsockPacket::from_rx_virtq_head(&head) {
-            rx_to_pkt(cid, rx, &mut pkt);
-            if let Err(err) = queue.add_used(mem, head.index, pkt.hdr().len() as u32 + pkt.len()) {
-                error!("failed to add used elements to the queue: {err:?}");
+            if rx_to_pkt(cid, rx, &mut pkt) {
+                if let Err(err) =
+                    queue.add_used(mem, head.index, pkt.hdr().len() as u32 + pkt.len())
+                {
+                    error!("failed to add used elements to the queue: {err:?}");
+                }
+            } else {
+                queue.undo_pop();
             }
         }
     } else {
-        drop(queue);
-        rxq_mutex.lock().unwrap().push(rx);
+        rxq.push(rx);
     }
 }
 
@@ -150,15 +160,22 @@ impl VsockMuxer {
 
     pub(crate) fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> super::Result<()> {
         if self.rxq.lock().unwrap().is_empty() {
-            for proxy in self.proxy_map.read().unwrap().values() {
-                proxy.lock().unwrap().kick();
-            }
             return Err(super::VsockError::NoData);
         }
-        if let Some(rx) = self.rxq.lock().unwrap().pop() {
-            rx_to_pkt(self.cid, rx, pkt);
+        let mut rxq = self.rxq.lock().unwrap();
+        while let Some(rx) = rxq.pop() {
+            if rx_to_pkt(self.cid, rx, pkt) {
+                return Ok(());
+            }
         }
-        Ok(())
+        Err(super::VsockError::NoData)
+    }
+
+    /// Retry proxy work after the caller has released the guest RX queue.
+    pub(crate) fn kick_backends(&self) {
+        for proxy in self.proxy_map.read().unwrap().values() {
+            proxy.lock().unwrap().kick();
+        }
     }
 
     fn update_polling(&self, id: u64, pollable: VsockPollable, events: EventSet) {
@@ -180,6 +197,9 @@ impl VsockMuxer {
         }
         match update.remove_proxy {
             ProxyRemoval::Keep => {}
+            ProxyRemoval::Immediate => {
+                self.proxy_map.write().unwrap().remove(&id);
+            }
             ProxyRemoval::Deferred => {
                 if self
                     .reaper_sender
@@ -214,8 +234,14 @@ impl VsockMuxer {
 
     fn process_op_request(&self, pkt: &VsockPacket) {
         let id = ((pkt.src_port() as u64) << 32) | pkt.dst_port() as u64;
-        if let Some(proxy) = self.proxy_map.read().unwrap().get(&id) {
-            if let Some(update) = proxy.lock().unwrap().confirm_connect(pkt) {
+        let existing = self
+            .proxy_map
+            .read()
+            .unwrap()
+            .get(&id)
+            .map(|proxy| proxy.lock().unwrap().confirm_connect(pkt));
+        if let Some(update) = existing {
+            if let Some(update) = update {
                 self.process_proxy_update(id, update);
             }
             return;

--- a/src/devices/src/virtio/vsock/packet.rs
+++ b/src/devices/src/virtio/vsock/packet.rs
@@ -17,6 +17,7 @@
 /// to temporary buffers, before passing it on to the vsock backend.
 use std::convert::TryInto;
 use std::ffi::CStr;
+#[cfg(unix)]
 use std::net::{Ipv4Addr, SocketAddrV4};
 #[cfg(target_os = "macos")]
 use std::net::{Ipv6Addr, SocketAddrV6};
@@ -25,6 +26,7 @@ use std::result;
 
 #[cfg(target_os = "linux")]
 use nix::sys::socket::{sockaddr, AddressFamily};
+#[cfg(unix)]
 use nix::sys::socket::{SockaddrLike, SockaddrStorage};
 use utils::byte_order;
 use vm_memory::{self, Address, GuestAddress, GuestMemory, GuestMemoryError};
@@ -98,6 +100,7 @@ const HDROFF_BUF_ALLOC: usize = 36;
 // we have successfully written to a backing Unix socket.
 const HDROFF_FWD_CNT: usize = 40;
 
+#[cfg(unix)]
 #[repr(C)]
 pub struct TsiProxyCreate {
     pub peer_port: u32,
@@ -105,17 +108,20 @@ pub struct TsiProxyCreate {
     pub _type: u16,
 }
 
+#[cfg(unix)]
 #[repr(C)]
 pub struct TsiConnectReq {
     pub peer_port: u32,
     pub addr: SockaddrStorage,
 }
 
+#[cfg(unix)]
 #[repr(C)]
 pub struct TsiConnectRsp {
     pub result: i32,
 }
 
+#[cfg(unix)]
 #[repr(C)]
 pub struct TsiGetnameReq {
     pub peer_port: u32,
@@ -123,6 +129,7 @@ pub struct TsiGetnameReq {
     pub peer: u32,
 }
 
+#[cfg(unix)]
 #[repr(C)]
 #[derive(Debug)]
 pub struct TsiGetnameRsp {
@@ -131,6 +138,7 @@ pub struct TsiGetnameRsp {
     pub addr: SockaddrStorage,
 }
 
+#[cfg(unix)]
 impl Default for TsiGetnameRsp {
     fn default() -> Self {
         let addr: SockaddrStorage = SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0).into();
@@ -143,6 +151,7 @@ impl Default for TsiGetnameRsp {
     }
 }
 
+#[cfg(unix)]
 #[repr(C)]
 #[derive(Debug)]
 pub struct TsiSendtoAddr {
@@ -150,6 +159,7 @@ pub struct TsiSendtoAddr {
     pub addr: SockaddrStorage,
 }
 
+#[cfg(unix)]
 #[repr(C)]
 #[derive(Debug)]
 pub struct TsiListenReq {
@@ -159,12 +169,14 @@ pub struct TsiListenReq {
     pub addr: SockaddrStorage,
 }
 
+#[cfg(unix)]
 #[repr(C)]
 #[derive(Debug)]
 pub struct TsiListenRsp {
     pub result: i32,
 }
 
+#[cfg(unix)]
 #[repr(C)]
 #[derive(Debug)]
 pub struct TsiAcceptReq {
@@ -172,12 +184,14 @@ pub struct TsiAcceptReq {
     pub flags: u32,
 }
 
+#[cfg(unix)]
 #[repr(C)]
 #[derive(Debug)]
 pub struct TsiAcceptRsp {
     pub result: i32,
 }
 
+#[cfg(unix)]
 #[repr(C)]
 pub struct TsiReleaseReq {
     pub peer_port: u32,
@@ -545,6 +559,7 @@ impl VsockPacket {
         }
     }
 
+    #[cfg(unix)]
     pub fn read_proxy_create(&self) -> Option<TsiProxyCreate> {
         if self.buf_size >= 6 {
             let peer_port: u32 = byte_order::read_le_u32(&self.buf().unwrap()[0..]);
@@ -561,6 +576,7 @@ impl VsockPacket {
         }
     }
 
+    #[cfg(unix)]
     pub fn read_connect_req(&self) -> Option<TsiConnectReq> {
         if self.buf_size >= 4 {
             let buf = self.buf().unwrap();
@@ -574,6 +590,7 @@ impl VsockPacket {
         }
     }
 
+    #[cfg(unix)]
     pub fn write_connect_rsp(&mut self, rsp: TsiConnectRsp) {
         if self.buf_size >= 4 {
             if let Some(buf) = self.buf_mut() {
@@ -582,6 +599,7 @@ impl VsockPacket {
         }
     }
 
+    #[cfg(unix)]
     pub fn read_getname_req(&self) -> Option<TsiGetnameReq> {
         if self.buf_size >= 12 {
             let peer_port: u32 = byte_order::read_le_u32(&self.buf().unwrap()[0..]);
@@ -597,6 +615,7 @@ impl VsockPacket {
         }
     }
 
+    #[cfg(unix)]
     pub fn write_getname_rsp(&mut self, rsp: TsiGetnameRsp) {
         if self.buf_size >= 132 {
             if let Some(buf) = self.buf_mut() {
@@ -625,6 +644,7 @@ impl VsockPacket {
         }
     }
 
+    #[cfg(unix)]
     pub fn read_sendto_addr(&self) -> Option<TsiSendtoAddr> {
         if self.buf_size >= 4 {
             let buf = self.buf().unwrap();
@@ -638,6 +658,7 @@ impl VsockPacket {
         }
     }
 
+    #[cfg(unix)]
     pub fn read_listen_req(&self) -> Option<TsiListenReq> {
         if self.buf_size >= 12 {
             let buf = self.buf().unwrap();
@@ -658,6 +679,7 @@ impl VsockPacket {
         }
     }
 
+    #[cfg(unix)]
     pub fn write_listen_rsp(&mut self, rsp: TsiListenRsp) {
         if self.buf_size >= 4 {
             if let Some(buf) = self.buf_mut() {
@@ -666,6 +688,7 @@ impl VsockPacket {
         }
     }
 
+    #[cfg(unix)]
     pub fn read_accept_req(&self) -> Option<TsiAcceptReq> {
         if self.buf_size >= 8 {
             let peer_port: u32 = byte_order::read_le_u32(&self.buf().unwrap()[0..]);
@@ -677,6 +700,7 @@ impl VsockPacket {
         }
     }
 
+    #[cfg(unix)]
     pub fn write_accept_rsp(&mut self, rsp: TsiAcceptRsp) {
         if self.buf_size >= 4 {
             if let Some(buf) = self.buf_mut() {
@@ -685,6 +709,7 @@ impl VsockPacket {
         }
     }
 
+    #[cfg(unix)]
     pub fn read_release_req(&self) -> Option<TsiReleaseReq> {
         if self.buf_size >= 8 {
             let peer_port: u32 = byte_order::read_le_u32(&self.buf().unwrap()[0..]);

--- a/src/devices/src/virtio/vsock/packet.rs
+++ b/src/devices/src/virtio/vsock/packet.rs
@@ -352,6 +352,16 @@ impl VsockPacket {
         })
     }
 
+    /// Return exactly the data length declared in the packet header rather
+    /// than the potentially larger backing descriptor.
+    pub(crate) fn payload(&self) -> Option<&[u8]> {
+        let len = self.len() as usize;
+        if len == 0 {
+            return Some(&[]);
+        }
+        self.buf()?.get(..len)
+    }
+
     /// Provides in-place, byte-slice, mutable access to the vsock packet data buffer.
     ///
     /// Note: control packets (e.g. connection request or reset) have no data buffer associated.

--- a/src/devices/src/virtio/vsock/proxy.rs
+++ b/src/devices/src/virtio/vsock/proxy.rs
@@ -1,10 +1,17 @@
+#[cfg(unix)]
 use std::collections::HashMap;
+#[cfg(unix)]
 use std::fmt;
+#[cfg(unix)]
 use std::os::fd::OwnedFd;
-use std::os::unix::io::{AsRawFd, RawFd};
 
 use super::muxer::MuxerRx;
+#[cfg(windows)]
+use super::packet::VsockPacket;
+#[cfg(unix)]
 use super::packet::{TsiAcceptReq, TsiConnectReq, TsiListenReq, TsiSendtoAddr, VsockPacket};
+use super::VsockPollable;
+#[cfg(unix)]
 use nix::sys::socket::AddressFamily;
 use utils::epoll::EventSet;
 
@@ -16,6 +23,7 @@ pub enum RecvPkt {
     WaitForCredit,
 }
 
+#[cfg(unix)]
 #[allow(dead_code)]
 #[derive(Debug)]
 pub enum ProxyError {
@@ -27,13 +35,17 @@ pub enum ProxyError {
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]
 pub enum ProxyStatus {
+    #[cfg(unix)]
     Idle,
     Connecting,
     Connected,
+    #[cfg(unix)]
     Listening,
     Closed,
     WaitingCreditUpdate,
+    #[cfg(unix)]
     ReverseInit,
+    #[cfg(unix)]
     WaitingOnAccept,
 }
 
@@ -41,10 +53,12 @@ pub enum ProxyStatus {
 pub enum ProxyRemoval {
     #[default]
     Keep,
+    #[cfg(unix)]
     Immediate,
     Deferred,
 }
 
+#[cfg(unix)]
 #[derive(Default)]
 pub enum NewProxyType {
     #[default]
@@ -56,41 +70,55 @@ pub enum NewProxyType {
 pub struct ProxyUpdate {
     pub signal_queue: bool,
     pub remove_proxy: ProxyRemoval,
-    pub polling: Option<(u64, RawFd, EventSet)>,
+    pub polling: Option<(u64, VsockPollable, EventSet)>,
+    #[cfg(unix)]
     pub new_proxy: Option<(u32, OwnedFd, AddressFamily, NewProxyType)>,
+    #[cfg(unix)]
     pub push_accept: Option<(u64, u64)>,
     pub push_credit_req: Option<MuxerRx>,
 }
 
+#[cfg(unix)]
 impl fmt::Display for ProxyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{self:?}")
     }
 }
 
-pub trait Proxy: Send + AsRawFd {
+pub trait Proxy: Send {
+    #[cfg(unix)]
     fn id(&self) -> u64;
+    fn pollable(&self) -> VsockPollable;
     #[allow(dead_code)]
     fn status(&self) -> ProxyStatus;
+    #[cfg(unix)]
     fn connect(&mut self, pkt: &VsockPacket, req: TsiConnectReq) -> ProxyUpdate;
     fn confirm_connect(&mut self, _pkt: &VsockPacket) -> Option<ProxyUpdate> {
         None
     }
+    #[cfg(unix)]
     fn getpeername(&mut self, pkt: &VsockPacket);
     fn sendmsg(&mut self, pkt: &VsockPacket) -> ProxyUpdate;
+    #[cfg(unix)]
     fn sendto_addr(&mut self, req: TsiSendtoAddr) -> ProxyUpdate;
+    #[cfg(unix)]
     fn sendto_data(&mut self, _pkt: &VsockPacket) {}
+    #[cfg(unix)]
     fn listen(
         &mut self,
         pkt: &VsockPacket,
         req: TsiListenReq,
         host_port_map: &Option<HashMap<u16, u16>>,
     ) -> ProxyUpdate;
+    #[cfg(unix)]
     fn accept(&mut self, req: TsiAcceptReq) -> ProxyUpdate;
     fn update_peer_credit(&mut self, pkt: &VsockPacket) -> ProxyUpdate;
+    #[cfg(unix)]
     fn push_op_request(&self) {}
     fn process_op_response(&mut self, pkt: &VsockPacket) -> ProxyUpdate;
+    #[cfg(unix)]
     fn enqueue_accept(&mut self) {}
+    #[cfg(unix)]
     fn push_accept_rsp(&self, _result: i32) {}
     fn shutdown(&mut self, _pkt: &VsockPacket) {}
     fn release(&mut self) -> ProxyUpdate;

--- a/src/devices/src/virtio/vsock/proxy.rs
+++ b/src/devices/src/virtio/vsock/proxy.rs
@@ -53,7 +53,6 @@ pub enum ProxyStatus {
 pub enum ProxyRemoval {
     #[default]
     Keep,
-    #[cfg(unix)]
     Immediate,
     Deferred,
 }

--- a/src/devices/src/virtio/vsock/tsi_dgram.rs
+++ b/src/devices/src/virtio/vsock/tsi_dgram.rs
@@ -235,6 +235,10 @@ impl Proxy for TsiDgramProxy {
         self.id
     }
 
+    fn pollable(&self) -> RawFd {
+        self.as_raw_fd()
+    }
+
     fn status(&self) -> ProxyStatus {
         self.status
     }

--- a/src/devices/src/virtio/vsock/tsi_stream.rs
+++ b/src/devices/src/virtio/vsock/tsi_stream.rs
@@ -462,6 +462,10 @@ impl Proxy for TsiStreamProxy {
         self.id
     }
 
+    fn pollable(&self) -> RawFd {
+        self.as_raw_fd()
+    }
+
     fn status(&self) -> ProxyStatus {
         self.status
     }

--- a/src/devices/src/virtio/vsock/unix.rs
+++ b/src/devices/src/virtio/vsock/unix.rs
@@ -25,7 +25,6 @@ use super::muxer::{push_packet, MuxerRx};
 use super::muxer_rxq::MuxerRxQ;
 use super::packet::{TsiAcceptReq, TsiConnectReq, TsiListenReq, TsiSendtoAddr, VsockPacket};
 use super::proxy::{NewProxyType, Proxy, ProxyError, ProxyStatus, ProxyUpdate};
-use super::{VsockNotifier, VsockShutdown, VsockStreamBackend};
 use utils::epoll::EventSet;
 
 use vm_memory::GuestMemoryMmap;
@@ -53,22 +52,13 @@ pub struct UnixProxy {
 
 enum StreamEndpoint {
     Unix(OwnedFd),
-    Custom {
-        backend: Box<dyn VsockStreamBackend>,
-        notifier: VsockNotifier,
-    },
 }
 
 impl StreamEndpoint {
-    fn is_custom(&self) -> bool {
-        matches!(self, Self::Custom { .. })
-    }
-
     fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
             Self::Unix(fd) => recv(fd.as_raw_fd(), buf, MsgFlags::MSG_DONTWAIT)
                 .map_err(|err| io::Error::from_raw_os_error(err as i32)),
-            Self::Custom { backend, .. } => backend.read(buf),
         }
     }
 
@@ -82,7 +72,6 @@ impl StreamEndpoint {
                 send(fd.as_raw_fd(), buf, flags)
                     .map_err(|err| io::Error::from_raw_os_error(err as i32))
             }
-            Self::Custom { backend, .. } => backend.write(buf),
         }
     }
 
@@ -90,11 +79,6 @@ impl StreamEndpoint {
         match self {
             Self::Unix(fd) => shutdown(fd.as_raw_fd(), how)
                 .map_err(|err| io::Error::from_raw_os_error(err as i32)),
-            Self::Custom { backend, .. } => backend.shutdown(match how {
-                Shutdown::Read => VsockShutdown::Read,
-                Shutdown::Write => VsockShutdown::Write,
-                Shutdown::Both => VsockShutdown::Both,
-            }),
         }
     }
 }
@@ -103,7 +87,6 @@ impl AsRawFd for StreamEndpoint {
     fn as_raw_fd(&self) -> RawFd {
         match self {
             Self::Unix(fd) => fd.as_raw_fd(),
-            Self::Custom { notifier, .. } => notifier.event().as_raw_fd(),
         }
     }
 }
@@ -182,40 +165,6 @@ impl UnixProxy {
             rx_cnt: Wrapping(0),
             pending_write: VecDeque::new(),
         })
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_custom(
-        id: u64,
-        cid: u64,
-        local_port: u32,
-        peer_port: u32,
-        backend: Box<dyn VsockStreamBackend>,
-        notifier: VsockNotifier,
-        mem: GuestMemoryMmap,
-        queue: Arc<Mutex<VirtQueue>>,
-        rxq: Arc<Mutex<MuxerRxQ>>,
-    ) -> Self {
-        UnixProxy {
-            id,
-            cid,
-            local_port,
-            peer_port,
-            control_port: 0,
-            endpoint: StreamEndpoint::Custom { backend, notifier },
-            status: ProxyStatus::Connected,
-            mem,
-            queue,
-            rxq,
-            peer_buf_alloc: 0,
-            peer_fwd_cnt: Wrapping(0),
-            path: PathBuf::new(),
-            tx_cnt: Wrapping(0),
-            last_tx_cnt_sent: Wrapping(0),
-            push_cnt: Wrapping(0),
-            rx_cnt: Wrapping(0),
-            pending_write: VecDeque::new(),
-        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -465,18 +414,10 @@ impl UnixProxy {
     }
 
     fn connected_poll_events(&self) -> EventSet {
-        if self.endpoint.is_custom() || self.pending_write.is_empty() {
+        if self.pending_write.is_empty() {
             EventSet::IN
         } else {
             EventSet::IN | EventSet::OUT
-        }
-    }
-
-    fn clear_custom_notification(&self) {
-        if let StreamEndpoint::Custom { notifier, .. } = &self.endpoint {
-            if let Err(err) = notifier.clear() {
-                warn!("failed to clear custom vsock notification: {err}");
-            }
         }
     }
 
@@ -500,6 +441,10 @@ impl UnixProxy {
 impl Proxy for UnixProxy {
     fn id(&self) -> u64 {
         self.id
+    }
+
+    fn pollable(&self) -> RawFd {
+        self.as_raw_fd()
     }
 
     fn status(&self) -> ProxyStatus {
@@ -757,7 +702,6 @@ impl Proxy for UnixProxy {
         if evset.contains(EventSet::IN) {
             debug!("process_event: IN");
             if self.status == ProxyStatus::Connected {
-                self.clear_custom_notification();
                 if !self.pending_write.is_empty() {
                     if let Err(err) = self.flush_pending_write() {
                         warn!("vsock backend write failed: {err}");
@@ -809,7 +753,6 @@ impl Proxy for UnixProxy {
                     StreamEndpoint::Unix(fd) => {
                         getsockopt(fd, sockopt::SocketError).unwrap_or(libc::EIO)
                     }
-                    StreamEndpoint::Custom { .. } => 0,
                 };
                 if connect_error != 0 {
                     warn!("Unix vsock connect failed asynchronously: errno {connect_error}");
@@ -855,14 +798,6 @@ impl Proxy for UnixProxy {
 
         update
     }
-
-    fn kick(&self) {
-        if let StreamEndpoint::Custom { notifier, .. } = &self.endpoint {
-            if let Err(err) = notifier.notify() {
-                warn!("failed to kick custom vsock backend: {err}");
-            }
-        }
-    }
 }
 
 impl AsRawFd for UnixProxy {
@@ -900,6 +835,9 @@ impl UnixAcceptorProxy {
 impl Proxy for UnixAcceptorProxy {
     fn id(&self) -> u64 {
         self.id
+    }
+    fn pollable(&self) -> RawFd {
+        self.as_raw_fd()
     }
     fn status(&self) -> ProxyStatus {
         ProxyStatus::WaitingOnAccept
@@ -969,90 +907,5 @@ impl Proxy for UnixAcceptorProxy {
 impl AsRawFd for UnixAcceptorProxy {
     fn as_raw_fd(&self) -> RawFd {
         self.fd.as_raw_fd()
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
-// Tests
-//--------------------------------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    use vm_memory::GuestAddress;
-
-    use super::*;
-
-    struct TestStreamState {
-        blocked: AtomicBool,
-        written: Mutex<Vec<u8>>,
-        shutdown: Mutex<Option<VsockShutdown>>,
-    }
-
-    struct TestStream {
-        state: Arc<TestStreamState>,
-    }
-
-    impl VsockStreamBackend for TestStream {
-        fn read(&self, _buf: &mut [u8]) -> io::Result<usize> {
-            Err(io::Error::from(io::ErrorKind::WouldBlock))
-        }
-
-        fn write(&self, buf: &[u8]) -> io::Result<usize> {
-            let mut written = self.state.written.lock().unwrap();
-            if self.state.blocked.load(Ordering::Relaxed) && written.len() >= 2 {
-                return Err(io::Error::from(io::ErrorKind::WouldBlock));
-            }
-            let count = if self.state.blocked.load(Ordering::Relaxed) {
-                buf.len().min(2)
-            } else {
-                buf.len()
-            };
-            written.extend_from_slice(&buf[..count]);
-            Ok(count)
-        }
-
-        fn shutdown(&self, how: VsockShutdown) -> io::Result<()> {
-            *self.state.shutdown.lock().unwrap() = Some(how);
-            Ok(())
-        }
-    }
-
-    #[test]
-    fn custom_stream_buffers_partial_writes_without_losing_bytes() {
-        let state = Arc::new(TestStreamState {
-            blocked: AtomicBool::new(true),
-            written: Mutex::new(Vec::new()),
-            shutdown: Mutex::new(None),
-        });
-        let backend = TestStream {
-            state: Arc::clone(&state),
-        };
-        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
-        let mut proxy = UnixProxy::new_custom(
-            1,
-            3,
-            5000,
-            4000,
-            Box::new(backend),
-            VsockNotifier::new().unwrap(),
-            mem,
-            Arc::new(Mutex::new(VirtQueue::new(256))),
-            Arc::new(Mutex::new(MuxerRxQ::new())),
-        );
-
-        proxy.pending_write.extend(b"hello");
-        proxy.flush_pending_write().unwrap();
-        assert_eq!(&*state.written.lock().unwrap(), b"he");
-        assert_eq!(proxy.pending_write.len(), 3);
-
-        state.blocked.store(false, Ordering::Relaxed);
-        proxy.flush_pending_write().unwrap();
-        assert_eq!(&*state.written.lock().unwrap(), b"hello");
-        assert!(proxy.pending_write.is_empty());
-
-        proxy.endpoint.shutdown(Shutdown::Both).unwrap();
-        assert_eq!(*state.shutdown.lock().unwrap(), Some(VsockShutdown::Both));
     }
 }

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -1,6 +1,5 @@
 //! VM Builder for creating and configuring microVMs using nested builders.
 
-#[cfg(not(target_os = "windows"))]
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicI32;
 use std::sync::Arc;
@@ -25,7 +24,6 @@ use super::builders::FsConfig;
 use super::builders::{ConsoleBuilder, ExecBuilder, KernelBuilder, MachineBuilder};
 #[cfg(feature = "net")]
 use super::builders::{NetBuilder, NetConfig};
-#[cfg(not(target_os = "windows"))]
 use super::builders::{VsockBuilder, VsockRoute};
 
 use super::error::{BuildError, ConfigError, Error, Result};
@@ -67,7 +65,6 @@ use vmm::vmm_config::net::NetworkInterfaceConfig;
 /// ```
 pub struct VmBuilder {
     machine: MachineBuilder,
-    #[cfg(not(target_os = "windows"))]
     vsock: VsockBuilder,
     kernel: KernelBuilder,
     #[cfg_attr(feature = "tee", allow(dead_code))]
@@ -97,7 +94,6 @@ impl VmBuilder {
     pub fn new() -> Self {
         Self {
             machine: MachineBuilder::new(),
-            #[cfg(not(target_os = "windows"))]
             vsock: VsockBuilder::new(),
             kernel: KernelBuilder::new(),
             #[cfg(not(feature = "tee"))]
@@ -134,7 +130,6 @@ impl VmBuilder {
     /// Configure host services exposed through virtio-vsock.
     ///
     /// A route or enabled TSI transport automatically attaches the device.
-    #[cfg(not(target_os = "windows"))]
     pub fn vsock(mut self, f: impl FnOnce(VsockBuilder) -> VsockBuilder) -> Self {
         self.vsock = f(self.vsock);
         self
@@ -364,31 +359,44 @@ impl VmBuilder {
         #[cfg(target_os = "windows")]
         if self.machine.enable_inet_hijack {
             return Err(Error::Config(ConfigError::Vsock(
-                "virtio-vsock is not supported on Windows".to_string(),
+                "TSI INET hijack is not supported on Windows".to_string(),
             )));
         }
 
         #[cfg(not(target_os = "windows"))]
-        let (vsock_unix_ipc_port_map, vsock_custom_port_map, vsock_host_port_map) = {
-            let mut occupied_ports = HashSet::new();
+        let (
+            vsock_unix_ipc_port_map,
+            vsock_custom_port_map,
+            vsock_custom_dgram_port_map,
+            vsock_host_port_map,
+        ) = {
+            let mut occupied_stream_ports = HashSet::new();
+            let mut occupied_dgram_ports = HashSet::new();
             let mut unix_routes = HashMap::new();
             let mut custom_routes = HashMap::new();
+            let mut custom_dgram_routes = HashMap::new();
 
             for route in self.vsock.routes {
                 let (port, path) = match &route {
                     VsockRoute::UnixConnect { port, path }
                     | VsockRoute::UnixListen { port, path } => (*port, Some(path)),
-                    VsockRoute::Custom { port, .. } => (*port, None),
+                    VsockRoute::Custom { port, .. } | VsockRoute::CustomDatagram { port, .. } => {
+                        (*port, None)
+                    }
                 };
 
-                if port == 0 {
+                if port == 0 || port == u32::MAX {
                     return Err(Error::Config(ConfigError::Vsock(
-                        "route port must be non-zero".to_string(),
+                        "route port must be between 1 and u32::MAX - 1".to_string(),
                     )));
                 }
+                let occupied_ports = match &route {
+                    VsockRoute::CustomDatagram { .. } => &mut occupied_dgram_ports,
+                    _ => &mut occupied_stream_ports,
+                };
                 if !occupied_ports.insert(port) {
                     return Err(Error::Config(ConfigError::Vsock(format!(
-                        "duplicate route for host port {port}"
+                        "duplicate route for host port and socket type: {port}"
                     ))));
                 }
                 if path.is_some_and(|path| path.as_os_str().is_empty()) {
@@ -406,6 +414,9 @@ impl VmBuilder {
                     }
                     VsockRoute::Custom { port, backend } => {
                         custom_routes.insert(port, backend);
+                    }
+                    VsockRoute::CustomDatagram { port, backend } => {
+                        custom_dgram_routes.insert(port, backend);
                     }
                 }
             }
@@ -442,8 +453,30 @@ impl VmBuilder {
             (
                 (!unix_routes.is_empty()).then_some(unix_routes),
                 (!custom_routes.is_empty()).then_some(custom_routes),
+                (!custom_dgram_routes.is_empty()).then_some(custom_dgram_routes),
                 (!host_map.is_empty()).then_some(host_map),
             )
+        };
+
+        #[cfg(target_os = "windows")]
+        let vsock_custom_port_map = {
+            let mut occupied_ports = HashSet::new();
+            let mut custom_routes = HashMap::new();
+            for route in self.vsock.routes {
+                let VsockRoute::Custom { port, backend } = route;
+                if port == 0 || port == u32::MAX {
+                    return Err(Error::Config(ConfigError::Vsock(
+                        "route port must be between 1 and u32::MAX - 1".to_string(),
+                    )));
+                }
+                if !occupied_ports.insert(port) {
+                    return Err(Error::Config(ConfigError::Vsock(format!(
+                        "duplicate stream route for host port: {port}"
+                    ))));
+                }
+                custom_routes.insert(port, backend);
+            }
+            (!custom_routes.is_empty()).then_some(custom_routes)
         };
 
         #[cfg(not(target_os = "windows"))]
@@ -740,8 +773,9 @@ impl VmBuilder {
             enable_inet_hijack,
             #[cfg(not(target_os = "windows"))]
             vsock_unix_ipc_port_map,
-            #[cfg(not(target_os = "windows"))]
             vsock_custom_port_map,
+            #[cfg(not(target_os = "windows"))]
+            vsock_custom_dgram_port_map,
             #[cfg(not(target_os = "windows"))]
             vsock_host_port_map,
         ))
@@ -906,6 +940,37 @@ mod tests {
         assert!(
             matches!(err, Error::Config(ConfigError::Vsock(message)) if message.contains("duplicate route"))
         );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn build_allows_stream_and_datagram_on_same_port() {
+        use std::io;
+
+        use devices::virtio::vsock::{
+            VsockDatagramBackend, VsockDatagramPeer, VsockDatagramPortBackend, VsockNotifier,
+        };
+
+        struct RejectDatagrams;
+
+        impl VsockDatagramPortBackend for RejectDatagrams {
+            fn open_peer(
+                &self,
+                _peer: VsockDatagramPeer,
+                _notifier: VsockNotifier,
+            ) -> io::Result<Box<dyn VsockDatagramBackend>> {
+                Err(io::Error::from(io::ErrorKind::ConnectionRefused))
+            }
+        }
+
+        VmBuilder::new()
+            .vsock(|vsock| {
+                vsock
+                    .unix_connect(5000, "/tmp/stream.sock")
+                    .custom_dgram(5000, Arc::new(RejectDatagrams))
+            })
+            .build()
+            .expect("socket type disambiguates equal port numbers");
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -44,6 +44,17 @@ use std::os::fd::IntoRawFd;
 use vmm::vmm_config::net::NetworkInterfaceConfig;
 
 //--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(not(target_os = "windows"))]
+const VSOCK_TIMESYNC_PORT: u32 = 123;
+#[cfg(not(target_os = "windows"))]
+const TSI_CONTROL_PORT_START: u32 = 1024;
+#[cfg(not(target_os = "windows"))]
+const TSI_CONTROL_PORT_END: u32 = 1031;
+
+//--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
 
@@ -390,6 +401,13 @@ impl VmBuilder {
                         "route port must be between 1 and u32::MAX - 1".to_string(),
                     )));
                 }
+                if matches!(&route, VsockRoute::CustomDatagram { .. })
+                    && port == VSOCK_TIMESYNC_PORT
+                {
+                    return Err(Error::Config(ConfigError::Vsock(format!(
+                        "datagram route port {port} is reserved for guest time synchronization"
+                    ))));
+                }
                 let occupied_ports = match &route {
                     VsockRoute::CustomDatagram { .. } => &mut occupied_dgram_ports,
                     _ => &mut occupied_stream_ports,
@@ -423,6 +441,20 @@ impl VmBuilder {
 
             let enable_inet_hijack =
                 self.machine.enable_inet_hijack || self.vsock.enable_inet_hijack;
+            #[cfg(feature = "net")]
+            let tsi_inet_active = enable_inet_hijack && self.net.configs.is_empty();
+            #[cfg(not(feature = "net"))]
+            let tsi_inet_active = enable_inet_hijack;
+            if tsi_inet_active {
+                if let Some(port) = custom_dgram_routes
+                    .keys()
+                    .find(|port| (TSI_CONTROL_PORT_START..=TSI_CONTROL_PORT_END).contains(port))
+                {
+                    return Err(Error::Config(ConfigError::Vsock(format!(
+                        "datagram route port {port} conflicts with the active TSI control transport"
+                    ))));
+                }
+            }
             if !self.vsock.tcp_listen_remaps.is_empty() && !enable_inet_hijack {
                 return Err(Error::Config(ConfigError::Vsock(
                     "TCP listen remaps require TSI INET hijack".to_string(),
@@ -871,8 +903,30 @@ fn validate_cmdline_env(key: &str, value: &str) -> std::result::Result<(), &'sta
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(target_os = "windows"))]
+    use std::io;
+
+    #[cfg(not(target_os = "windows"))]
+    use devices::virtio::vsock::{
+        VsockDatagramBackend, VsockDatagramPeer, VsockDatagramPortBackend, VsockNotifier,
+    };
+
     use super::*;
     use crate::api::builders::HostCpuId;
+
+    #[cfg(not(target_os = "windows"))]
+    struct RejectDatagrams;
+
+    #[cfg(not(target_os = "windows"))]
+    impl VsockDatagramPortBackend for RejectDatagrams {
+        fn open_peer(
+            &self,
+            _peer: VsockDatagramPeer,
+            _notifier: VsockNotifier,
+        ) -> io::Result<Box<dyn VsockDatagramBackend>> {
+            Err(io::Error::from(io::ErrorKind::ConnectionRefused))
+        }
+    }
 
     #[test]
     fn build_rejects_invalid_machine_config() {
@@ -945,24 +999,6 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[test]
     fn build_allows_stream_and_datagram_on_same_port() {
-        use std::io;
-
-        use devices::virtio::vsock::{
-            VsockDatagramBackend, VsockDatagramPeer, VsockDatagramPortBackend, VsockNotifier,
-        };
-
-        struct RejectDatagrams;
-
-        impl VsockDatagramPortBackend for RejectDatagrams {
-            fn open_peer(
-                &self,
-                _peer: VsockDatagramPeer,
-                _notifier: VsockNotifier,
-            ) -> io::Result<Box<dyn VsockDatagramBackend>> {
-                Err(io::Error::from(io::ErrorKind::ConnectionRefused))
-            }
-        }
-
         VmBuilder::new()
             .vsock(|vsock| {
                 vsock
@@ -971,6 +1007,42 @@ mod tests {
             })
             .build()
             .expect("socket type disambiguates equal port numbers");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn build_rejects_reserved_timesync_datagram_port() {
+        let err = match VmBuilder::new()
+            .vsock(|vsock| vsock.custom_dgram(123, Arc::new(RejectDatagrams)))
+            .build()
+        {
+            Ok(_) => panic!("time synchronization owns datagram port 123"),
+            Err(err) => err,
+        };
+
+        assert!(
+            matches!(err, Error::Config(ConfigError::Vsock(message)) if message.contains("reserved"))
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn build_rejects_datagram_routes_over_active_tsi_control_ports() {
+        let err = match VmBuilder::new()
+            .vsock(|vsock| {
+                vsock
+                    .inet_hijack(true)
+                    .custom_dgram(1024, Arc::new(RejectDatagrams))
+            })
+            .build()
+        {
+            Ok(_) => panic!("active TSI owns its datagram control ports"),
+            Err(err) => err,
+        };
+
+        assert!(
+            matches!(err, Error::Config(ConfigError::Vsock(message)) if message.contains("active TSI"))
+        );
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -17,12 +17,12 @@ use crate::backends::fs::DynFileSystem;
 use std::os::fd::OwnedFd;
 #[cfg(not(target_os = "windows"))]
 use std::os::fd::RawFd;
-#[cfg(not(target_os = "windows"))]
 use std::sync::Arc;
 
 #[cfg(feature = "net")]
 use crate::backends::net::NetBackend;
 #[cfg(not(target_os = "windows"))]
+use crate::backends::vsock::VsockDatagramPortBackend;
 use crate::backends::vsock::VsockPortBackend;
 
 //--------------------------------------------------------------------------------------------------
@@ -79,28 +79,29 @@ pub struct MachineBuilder {
 ///         .custom(6000, Arc::new(my_service))
 /// });
 /// ```
-#[cfg(not(target_os = "windows"))]
 #[derive(Default)]
 pub struct VsockBuilder {
     pub(crate) routes: Vec<VsockRoute>,
+    #[cfg(not(target_os = "windows"))]
     pub(crate) tcp_listen_remaps: Vec<(u16, u16)>,
+    #[cfg(not(target_os = "windows"))]
     pub(crate) enable_inet_hijack: bool,
 }
 
 /// One typed host-side route for a guest vsock destination port.
-#[cfg(not(target_os = "windows"))]
 pub(crate) enum VsockRoute {
-    UnixConnect {
-        port: u32,
-        path: PathBuf,
-    },
-    UnixListen {
-        port: u32,
-        path: PathBuf,
-    },
+    #[cfg(not(target_os = "windows"))]
+    UnixConnect { port: u32, path: PathBuf },
+    #[cfg(not(target_os = "windows"))]
+    UnixListen { port: u32, path: PathBuf },
     Custom {
         port: u32,
         backend: Arc<dyn VsockPortBackend>,
+    },
+    #[cfg(not(target_os = "windows"))]
+    CustomDatagram {
+        port: u32,
+        backend: Arc<dyn VsockDatagramPortBackend>,
     },
 }
 
@@ -557,7 +558,6 @@ impl MachineBuilder {
 // Methods: Vsock Builder
 //--------------------------------------------------------------------------------------------------
 
-#[cfg(not(target_os = "windows"))]
 impl VsockBuilder {
     /// Create an empty vsock service builder.
     pub fn new() -> Self {
@@ -565,6 +565,7 @@ impl VsockBuilder {
     }
 
     /// Route guest connections to `port` into an existing host Unix socket.
+    #[cfg(not(target_os = "windows"))]
     pub fn unix_connect(mut self, port: u32, path: impl AsRef<Path>) -> Self {
         self.routes.push(VsockRoute::UnixConnect {
             port,
@@ -574,6 +575,7 @@ impl VsockBuilder {
     }
 
     /// Listen on a host Unix socket and inject accepted streams into guest `port`.
+    #[cfg(not(target_os = "windows"))]
     pub fn unix_listen(mut self, port: u32, path: impl AsRef<Path>) -> Self {
         self.routes.push(VsockRoute::UnixListen {
             port,
@@ -592,16 +594,26 @@ impl VsockBuilder {
         self
     }
 
+    /// Serve guest datagrams to `port` with a custom message-oriented backend.
+    #[cfg(not(target_os = "windows"))]
+    pub fn custom_dgram(mut self, port: u32, backend: Arc<dyn VsockDatagramPortBackend>) -> Self {
+        self.routes
+            .push(VsockRoute::CustomDatagram { port, backend });
+        self
+    }
+
     /// Remap a guest TCP listen port to a host port through TSI.
     ///
     /// This requires [`inet_hijack(true)`](Self::inet_hijack); validation
     /// rejects remaps that would otherwise be silently ignored.
+    #[cfg(not(target_os = "windows"))]
     pub fn tcp_listen_remap(mut self, guest_port: u16, host_port: u16) -> Self {
         self.tcp_listen_remaps.push((guest_port, host_port));
         self
     }
 
     /// Enable or disable TSI interception of guest INET sockets.
+    #[cfg(not(target_os = "windows"))]
     pub fn inet_hijack(mut self, enabled: bool) -> Self {
         self.enable_inet_hijack = enabled;
         self

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -47,7 +47,6 @@ pub use builders::DiskImageFormat;
 pub use builders::FsBuilder;
 #[cfg(feature = "net")]
 pub use builders::NetBuilder;
-#[cfg(not(target_os = "windows"))]
 pub use builders::VsockBuilder;
 pub use builders::{ConsoleBuilder, ExecBuilder, HostCpuId, KernelBuilder, MachineBuilder};
 pub use error::{BuildError, ConfigError, Error, Result, RuntimeError};

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -1,6 +1,5 @@
 //! VM handle for entering microVMs.
 
-#[cfg(not(target_os = "windows"))]
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::path::PathBuf;
@@ -15,6 +14,7 @@ use std::ffi::CString;
 
 use crossbeam_channel::unbounded;
 #[cfg(not(target_os = "windows"))]
+use devices::virtio::vsock::VsockDatagramPortBackend;
 use devices::virtio::vsock::VsockPortBackend;
 use log::error;
 use polly::event_manager::EventManager;
@@ -25,7 +25,6 @@ use vmm::resources::VmResources;
 use vmm::vmm_config::kernel_bundle::InitrdBundle;
 use vmm::vmm_config::kernel_bundle::KernelBundle;
 use vmm::vmm_config::kernel_cmdline::KernelCmdlineConfig;
-#[cfg(not(target_os = "windows"))]
 use vmm::vmm_config::vsock::VsockDeviceConfig;
 
 use super::error::{BuildError, Error, Result, RuntimeError};
@@ -69,8 +68,9 @@ pub struct Vm {
     enable_inet_hijack: bool,
     #[cfg(not(target_os = "windows"))]
     vsock_unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
-    #[cfg(not(target_os = "windows"))]
     vsock_custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
+    #[cfg(not(target_os = "windows"))]
+    vsock_custom_dgram_port_map: Option<HashMap<u32, Arc<dyn VsockDatagramPortBackend>>>,
     #[cfg(not(target_os = "windows"))]
     vsock_host_port_map: Option<HashMap<u16, u16>>,
     /// Keeps the libkrunfw library loaded so kernel memory pointers remain valid.
@@ -155,8 +155,9 @@ impl Vm {
         #[cfg(not(target_os = "windows"))] vsock_unix_ipc_port_map: Option<
             HashMap<u32, (PathBuf, bool)>,
         >,
-        #[cfg(not(target_os = "windows"))] vsock_custom_port_map: Option<
-            HashMap<u32, Arc<dyn VsockPortBackend>>,
+        vsock_custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
+        #[cfg(not(target_os = "windows"))] vsock_custom_dgram_port_map: Option<
+            HashMap<u32, Arc<dyn VsockDatagramPortBackend>>,
         >,
         #[cfg(not(target_os = "windows"))] vsock_host_port_map: Option<HashMap<u16, u16>>,
     ) -> Self {
@@ -178,8 +179,9 @@ impl Vm {
             enable_inet_hijack,
             #[cfg(not(target_os = "windows"))]
             vsock_unix_ipc_port_map,
-            #[cfg(not(target_os = "windows"))]
             vsock_custom_port_map,
+            #[cfg(not(target_os = "windows"))]
+            vsock_custom_dgram_port_map,
             #[cfg(not(target_os = "windows"))]
             vsock_host_port_map,
             _krunfw_library: None,
@@ -415,6 +417,7 @@ impl Vm {
 
         if self.vsock_unix_ipc_port_map.is_none()
             && self.vsock_custom_port_map.is_none()
+            && self.vsock_custom_dgram_port_map.is_none()
             && tsi_flags.is_empty()
         {
             return Ok(());
@@ -426,6 +429,7 @@ impl Vm {
             host_port_map: self.vsock_host_port_map.take(),
             unix_ipc_port_map: self.vsock_unix_ipc_port_map.take(),
             custom_port_map: self.vsock_custom_port_map.take(),
+            custom_dgram_port_map: self.vsock_custom_dgram_port_map.take(),
             tsi_flags,
         };
 
@@ -438,8 +442,22 @@ impl Vm {
 
     #[cfg(target_os = "windows")]
     fn configure_vsock(&mut self) -> Result<()> {
-        // Unsupported requests are rejected by VmBuilder::build; keep VM
-        // startup free of placeholder devices on Windows.
+        if self.vsock_custom_port_map.is_none() {
+            return Ok(());
+        }
+
+        self.vmr
+            .set_vsock_device(VsockDeviceConfig {
+                vsock_id: "vsock0".to_string(),
+                guest_cid: 3,
+                host_port_map: None,
+                unix_ipc_port_map: None,
+                custom_port_map: self.vsock_custom_port_map.take(),
+                tsi_flags: vmm::resources::TsiFlags::empty(),
+            })
+            .map_err(|err| {
+                Error::Build(BuildError::DeviceRegistration(format!("vsock: {err:?}")))
+            })?;
         Ok(())
     }
 
@@ -668,6 +686,7 @@ mod tests {
             false,
             #[cfg(not(target_os = "windows"))]
             None,
+            None,
             #[cfg(not(target_os = "windows"))]
             None,
             #[cfg(not(target_os = "windows"))]
@@ -692,6 +711,7 @@ mod tests {
             EventFd::new(EFD_NONBLOCK).unwrap(),
             Arc::new(AtomicI32::new(i32::MAX)),
             enable_inet_hijack,
+            None,
             None,
             None,
             None,

--- a/src/krun/src/backends/mod.rs
+++ b/src/krun/src/backends/mod.rs
@@ -32,7 +32,6 @@ pub mod fs;
 #[cfg(feature = "net")]
 pub mod net;
 
-#[cfg(not(target_os = "windows"))]
 pub mod vsock;
 
 //--------------------------------------------------------------------------------------------------

--- a/src/krun/src/backends/vsock.rs
+++ b/src/krun/src/backends/vsock.rs
@@ -4,5 +4,10 @@
 //! responsibility for the transport protocol, flow control, and interrupts.
 
 pub use devices::virtio::vsock::{
-    VsockConnectRequest, VsockNotifier, VsockPortBackend, VsockShutdown, VsockStreamBackend,
+    VsockConnectRequest, VsockConnectState, VsockNotifier, VsockPortBackend, VsockShutdown,
+    VsockStreamBackend,
+};
+#[cfg(not(target_os = "windows"))]
+pub use devices::virtio::vsock::{
+    VsockDatagramBackend, VsockDatagramPeer, VsockDatagramPortBackend, VsockDatagramRead,
 };

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -49,7 +49,6 @@ pub use api::builders::FsBuilder;
 pub use api::builders::NetBuilder;
 #[cfg(feature = "blk")]
 pub use api::builders::SyncMode;
-#[cfg(not(target_os = "windows"))]
 pub use api::builders::VsockBuilder;
 pub use api::builders::{ConsoleBuilder, ExecBuilder, HostCpuId, KernelBuilder, MachineBuilder};
 pub use api::error::{BuildError, ConfigError, Error, Result, RuntimeError};
@@ -71,7 +70,6 @@ pub use backends::fs::DynFileSystem;
 #[cfg(feature = "net")]
 pub use backends::net::NetBackend;
 
-#[cfg(not(target_os = "windows"))]
 pub use backends::vsock::{
     VsockConnectRequest, VsockNotifier, VsockPortBackend, VsockShutdown, VsockStreamBackend,
 };

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -2857,6 +2857,7 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
                 host_port_map: ctx_cfg.tsi_port_map,
                 unix_ipc_port_map: ctx_cfg.unix_ipc_port_map.clone(),
                 custom_port_map: None,
+                custom_dgram_port_map: None,
                 tsi_flags: *tsi_flags,
             };
             ctx_cfg.vmr.set_vsock_device(vsock_device_config).unwrap();
@@ -2884,6 +2885,7 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
                     host_port_map,
                     unix_ipc_port_map: ctx_cfg.unix_ipc_port_map.clone(),
                     custom_port_map: None,
+                    custom_dgram_port_map: None,
                     tsi_flags,
                 };
                 ctx_cfg.vmr.set_vsock_device(vsock_device_config).unwrap();

--- a/src/utils/src/event.rs
+++ b/src/utils/src/event.rs
@@ -103,6 +103,12 @@ pub struct WaitContext {
     sources: Vec<RegisteredSource>,
 }
 
+// Windows HANDLE values are process-wide opaque identifiers. WaitContext never
+// dereferences them, and callers synchronize mutation, so moving a context to
+// its dedicated event-loop thread is safe.
+#[cfg(windows)]
+unsafe impl Send for WaitContext {}
+
 #[derive(Clone, Copy, Debug)]
 struct RegisteredSource {
     source: EventSource,

--- a/src/utils/src/event.rs
+++ b/src/utils/src/event.rs
@@ -16,18 +16,20 @@ use bitflags::bitflags;
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, RawFd};
 #[cfg(windows)]
-use std::os::windows::io::RawHandle;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle};
 
 #[cfg(unix)]
 use crate::eventfd::{EventFd, EFD_NONBLOCK};
 
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::{
-    CloseHandle, FALSE, HANDLE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
+    CloseHandle, DuplicateHandle, DUPLICATE_SAME_ACCESS, FALSE, HANDLE, WAIT_FAILED, WAIT_OBJECT_0,
+    WAIT_TIMEOUT,
 };
 #[cfg(windows)]
 use windows_sys::Win32::System::Threading::{
-    CreateEventW, ResetEvent, SetEvent, WaitForMultipleObjects, WaitForSingleObject,
+    CreateEventW, GetCurrentProcess, ResetEvent, SetEvent, WaitForMultipleObjects,
+    WaitForSingleObject,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -98,7 +100,7 @@ pub struct WaitEvent {
 }
 
 /// Context that waits on registered event sources.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct WaitContext {
     sources: Vec<RegisteredSource>,
 }
@@ -367,10 +369,32 @@ fn wait_platform(
         return Ok(0);
     }
 
-    let mut handles = Vec::with_capacity(sources.len());
+    // Wait on duplicated handles so callers can unregister and close their
+    // originals immediately after waking the control source. Windows leaves a
+    // wait undefined if one of its raw handles is closed concurrently.
+    let process = unsafe { GetCurrentProcess() };
+    let mut owned_handles = Vec::with_capacity(sources.len());
     for source in sources {
         match source.source.raw {
-            RawEventSource::WaitableHandle(handle) => handles.push(handle as HANDLE),
+            RawEventSource::WaitableHandle(handle) => {
+                let mut duplicate = std::ptr::null_mut();
+                let result = unsafe {
+                    DuplicateHandle(
+                        process,
+                        handle as HANDLE,
+                        process,
+                        &mut duplicate,
+                        0,
+                        FALSE,
+                        DUPLICATE_SAME_ACCESS,
+                    )
+                };
+                if result == FALSE {
+                    return Err(io::Error::last_os_error());
+                }
+                // SAFETY: DuplicateHandle returned a new owned process handle.
+                owned_handles.push(unsafe { OwnedHandle::from_raw_handle(duplicate) });
+            }
             RawEventSource::CompletionHandle(_) => {
                 return Err(io::Error::new(
                     io::ErrorKind::Unsupported,
@@ -379,6 +403,10 @@ fn wait_platform(
             }
         }
     }
+    let handles = owned_handles
+        .iter()
+        .map(|handle| handle.as_raw_handle() as HANDLE)
+        .collect::<Vec<_>>();
 
     let timeout = if timeout_ms < 0 {
         INFINITE_TIMEOUT

--- a/src/utils/src/windows/epoll.rs
+++ b/src/utils/src/windows/epoll.rs
@@ -7,10 +7,18 @@ use std::collections::HashMap;
 use std::io;
 use std::os::windows::io::{AsRawHandle, RawHandle};
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use bitflags::bitflags;
 
-use crate::event::{EventSource, WaitContext, WaitEvent};
+use crate::event::{EventNotifier, EventSource, WaitContext, WaitEvent};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Internal token used to rebuild a blocking wait after a registration change.
+const CONTROL_TOKEN: u64 = u64::MAX;
 
 #[repr(i32)]
 pub enum ControlOperation {
@@ -46,6 +54,7 @@ pub struct Epoll {
     // Store opaque handle values as integers so the synchronized registry is
     // safely movable with an event loop thread.
     registrations: Mutex<HashMap<usize, u64>>,
+    control: EventNotifier,
 }
 
 impl EpollEvent {
@@ -81,9 +90,17 @@ impl std::fmt::Debug for EpollEvent {
 
 impl Epoll {
     pub fn new() -> io::Result<Self> {
+        let control = EventNotifier::new()?;
+        let mut context = WaitContext::new();
+        context.add(
+            control.event_source(CONTROL_TOKEN),
+            crate::event::EventSet::IN,
+        )?;
+
         Ok(Self {
-            context: Mutex::new(WaitContext::new()),
+            context: Mutex::new(context),
             registrations: Mutex::new(HashMap::new()),
+            control,
         })
     }
 
@@ -96,8 +113,14 @@ impl Epoll {
         let mut context = self.context.lock().unwrap();
         let mut registrations = self.registrations.lock().unwrap();
 
-        match operation {
+        let result = match operation {
             ControlOperation::Add => {
+                if event.data == CONTROL_TOKEN {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "event token is reserved for epoll control",
+                    ));
+                }
                 context.add(
                     EventSource::waitable_handle(handle, event.data),
                     event_set_to_wait_event_set(event.event_set()),
@@ -120,7 +143,15 @@ impl Epoll {
                 })?;
                 context.delete(token)
             }
+        };
+
+        // Wake any waiter so it can rebuild its handle snapshot. The context
+        // lock is intentionally still held here, preventing the waiter from
+        // draining this notification before the mutation is visible.
+        if result.is_ok() {
+            self.control.wake()?;
         }
+        result
     }
 
     pub fn wait(
@@ -129,19 +160,49 @@ impl Epoll {
         timeout: i32,
         events: &mut [EpollEvent],
     ) -> io::Result<usize> {
-        let mut wait_events = vec![WaitEvent::default(); max_events.min(events.len())];
-        let count = self
-            .context
-            .lock()
-            .unwrap()
-            .wait(timeout, &mut wait_events)?;
-
-        for (index, event) in wait_events.into_iter().take(count).enumerate() {
-            events[index] =
-                EpollEvent::new(wait_event_set_to_event_set(event.events()), event.token());
+        let output_capacity = max_events.min(events.len());
+        if output_capacity == 0 {
+            return Ok(0);
         }
 
-        Ok(count)
+        let deadline = (timeout >= 0).then(|| {
+            Instant::now()
+                .checked_add(Duration::from_millis(timeout as u64))
+                .unwrap_or_else(Instant::now)
+        });
+
+        loop {
+            // Drain and snapshot under the same lock used by ctl(). A control
+            // mutation after this point will signal the notifier contained in
+            // the snapshot and force another iteration.
+            let snapshot = {
+                let context = self.context.lock().unwrap();
+                self.control.drain()?;
+                context.clone()
+            };
+            let wait_timeout = remaining_timeout(timeout, deadline);
+            let mut wait_events = vec![WaitEvent::default(); output_capacity + 1];
+            let count = snapshot.wait(wait_timeout, &mut wait_events)?;
+
+            let mut written = 0;
+            let mut control_ready = false;
+            for event in wait_events.into_iter().take(count) {
+                if event.token() == CONTROL_TOKEN {
+                    control_ready = true;
+                    continue;
+                }
+                if written == output_capacity {
+                    break;
+                }
+                events[written] =
+                    EpollEvent::new(wait_event_set_to_event_set(event.events()), event.token());
+                written += 1;
+            }
+
+            if written > 0 || !control_ready || wait_timeout == 0 {
+                return Ok(written);
+            }
+        }
     }
 }
 
@@ -180,4 +241,79 @@ fn wait_event_set_to_event_set(events: crate::event::EventSet) -> EventSet {
         epoll_events |= EventSet::READ_HANG_UP;
     }
     epoll_events
+}
+
+fn remaining_timeout(timeout: i32, deadline: Option<Instant>) -> i32 {
+    let Some(deadline) = deadline else {
+        return timeout;
+    };
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        return 0;
+    }
+
+    remaining.as_millis().clamp(1, i32::MAX as u128) as i32
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{mpsc, Arc};
+    use std::thread;
+
+    use crate::event::RawEventSource;
+
+    use super::*;
+
+    #[test]
+    fn registration_wakes_a_blocked_waiter_without_locking_ctl() {
+        let epoll = Arc::new(Epoll::new().unwrap());
+        let waiter_epoll = Arc::clone(&epoll);
+        let (wait_tx, wait_rx) = mpsc::channel();
+        let waiter = thread::spawn(move || {
+            let mut events = [EpollEvent::default(); 1];
+            let result = waiter_epoll
+                .wait(events.len(), -1, &mut events)
+                .map(|count| (count, events[0].data()));
+            wait_tx.send(result).unwrap();
+        });
+
+        // Give the waiter time to enter its infinite wait with only the
+        // internal control event registered.
+        thread::sleep(Duration::from_millis(20));
+
+        let notifier = EventNotifier::new().unwrap();
+        let handle = match notifier.event_source(7).raw() {
+            RawEventSource::WaitableHandle(handle) => handle as usize,
+            RawEventSource::CompletionHandle(_) => unreachable!(),
+        };
+        let ctl_epoll = Arc::clone(&epoll);
+        let (ctl_tx, ctl_rx) = mpsc::channel();
+        thread::spawn(move || {
+            ctl_tx
+                .send(ctl_epoll.ctl(
+                    ControlOperation::Add,
+                    handle as RawHandle,
+                    &EpollEvent::new(EventSet::IN, 7),
+                ))
+                .unwrap();
+        });
+
+        ctl_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("ctl must not block behind the wait thread")
+            .unwrap();
+        notifier.wake().unwrap();
+
+        let (count, token) = wait_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("registered event should wake the rebuilt wait set")
+            .unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(token, 7);
+        waiter.join().unwrap();
+    }
 }

--- a/src/utils/src/windows/epoll.rs
+++ b/src/utils/src/windows/epoll.rs
@@ -43,7 +43,9 @@ pub struct EpollEvent {
 #[derive(Debug)]
 pub struct Epoll {
     context: Mutex<WaitContext>,
-    registrations: Mutex<HashMap<RawHandle, u64>>,
+    // Store opaque handle values as integers so the synchronized registry is
+    // safely movable with an event loop thread.
+    registrations: Mutex<HashMap<usize, u64>>,
 }
 
 impl EpollEvent {
@@ -100,17 +102,20 @@ impl Epoll {
                     EventSource::waitable_handle(handle, event.data),
                     event_set_to_wait_event_set(event.event_set()),
                 )?;
-                registrations.insert(handle, event.data);
+                registrations.insert(handle as usize, event.data);
                 Ok(())
             }
             ControlOperation::Modify => {
-                let token = registrations.get(&handle).copied().ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::NotFound, "handle is not registered")
-                })?;
+                let token = registrations
+                    .get(&(handle as usize))
+                    .copied()
+                    .ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::NotFound, "handle is not registered")
+                    })?;
                 context.modify(token, event_set_to_wait_event_set(event.event_set()))
             }
             ControlOperation::Delete => {
-                let token = registrations.remove(&handle).ok_or_else(|| {
+                let token = registrations.remove(&(handle as usize)).ok_or_else(|| {
                     io::Error::new(io::ErrorKind::NotFound, "handle is not registered")
                 })?;
                 context.delete(token)

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -77,8 +77,8 @@ use devices::legacy::{KvmGicV2, KvmGicV3};
 #[cfg(target_os = "windows")]
 use devices::virtio::{port_io, PortDescription};
 #[cfg(not(target_os = "windows"))]
-use devices::virtio::{port_io, PortDescription, Vsock};
-use devices::virtio::{MmioTransport, VirtioDevice};
+use devices::virtio::{port_io, PortDescription};
+use devices::virtio::{MmioTransport, VirtioDevice, Vsock};
 
 #[cfg(feature = "tee")]
 use kbs_types::Tee;
@@ -1862,15 +1862,17 @@ pub fn build_microvm(
     #[cfg(feature = "blk")]
     trace.mark("block.ready");
 
-    #[cfg(not(target_os = "windows"))]
     if let Some(vsock) = vm_resources.vsock.get() {
-        attach_unixsock_vsock_device(&mut vmm, vsock, event_manager, intc.clone())?;
-        let tsi_flags = vm_resources.vsock.tsi_flags();
-        if tsi_flags.contains(TsiFlags::HIJACK_INET) {
-            vmm.kernel_cmdline.insert_str("tsi_hijack")?;
-        }
-        if tsi_flags.contains(TsiFlags::HIJACK_UNIX) {
-            vmm.kernel_cmdline.insert_str("tsi_hijack_unix")?;
+        attach_vsock_device(&mut vmm, vsock, event_manager, intc.clone())?;
+        #[cfg(not(target_os = "windows"))]
+        {
+            let tsi_flags = vm_resources.vsock.tsi_flags();
+            if tsi_flags.contains(TsiFlags::HIJACK_INET) {
+                vmm.kernel_cmdline.insert_str("tsi_hijack")?;
+            }
+            if tsi_flags.contains(TsiFlags::HIJACK_UNIX) {
+                vmm.kernel_cmdline.insert_str("tsi_hijack_unix")?;
+            }
         }
         trace.mark("vsock.ready");
     } else {
@@ -3864,23 +3866,22 @@ fn attach_net_devices(
     Ok(())
 }
 
-#[cfg(not(target_os = "windows"))]
-fn attach_unixsock_vsock_device(
+fn attach_vsock_device(
     vmm: &mut Vmm,
-    unix_vsock: &Arc<Mutex<Vsock>>,
+    vsock: &Arc<Mutex<Vsock>>,
     event_manager: &mut EventManager,
     intc: IrqChip,
 ) -> std::result::Result<(), StartMicrovmError> {
     use self::StartMicrovmError::*;
 
     event_manager
-        .add_subscriber(unix_vsock.clone())
+        .add_subscriber(vsock.clone())
         .map_err(RegisterEvent)?;
 
-    let id = String::from(unix_vsock.lock().unwrap().id());
+    let id = String::from(vsock.lock().unwrap().id());
 
     // The device mutex mustn't be locked here otherwise it will deadlock.
-    attach_mmio_device(vmm, id, intc, unix_vsock.clone()).map_err(RegisterVsockDevice)?;
+    attach_mmio_device(vmm, id, intc, vsock.clone()).map_err(RegisterVsockDevice)?;
 
     Ok(())
 }

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -4,75 +4,28 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::path::PathBuf;
-#[cfg(not(target_os = "windows"))]
 use std::sync::{Arc, Mutex};
 
 #[cfg(not(target_os = "windows"))]
+use devices::virtio::vsock::VsockDatagramPortBackend;
 use devices::virtio::vsock::VsockPortBackend;
-#[cfg(not(target_os = "windows"))]
-use devices::virtio::{TsiFlags, Vsock, VsockError};
+pub use devices::virtio::TsiFlags;
+use devices::virtio::{Vsock, VsockError};
 
-#[cfg(target_os = "windows")]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct TsiFlags(u32);
-
-#[cfg(target_os = "windows")]
-impl TsiFlags {
-    pub const HIJACK_INET: Self = Self(1 << 0);
-    pub const HIJACK_UNIX: Self = Self(1 << 1);
-
-    pub fn empty() -> Self {
-        Self(0)
-    }
-
-    pub fn from_bits(bits: u32) -> Option<Self> {
-        let supported = Self::HIJACK_INET.0 | Self::HIJACK_UNIX.0;
-        if bits & !supported == 0 {
-            Some(Self(bits))
-        } else {
-            None
-        }
-    }
-
-    pub fn contains(self, other: Self) -> bool {
-        self.0 & other.0 == other.0
-    }
-
-    pub fn is_empty(self) -> bool {
-        self.0 == 0
-    }
-}
-
-#[cfg(target_os = "windows")]
-impl std::ops::BitOrAssign for TsiFlags {
-    fn bitor_assign(&mut self, rhs: Self) {
-        self.0 |= rhs.0;
-    }
-}
-
-#[cfg(not(target_os = "windows"))]
 type MutexVsock = Arc<Mutex<Vsock>>;
-#[cfg(target_os = "windows")]
-type MutexVsock = ();
 
 /// Errors associated with `NetworkInterfaceConfig`.
 #[derive(Debug)]
 pub enum VsockConfigError {
     /// Failed to create the vsock device.
-    #[cfg(not(target_os = "windows"))]
     CreateVsockDevice(VsockError),
-    #[cfg(target_os = "windows")]
-    UnsupportedOnWindows,
 }
 
 impl fmt::Display for VsockConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::VsockConfigError::*;
         match *self {
-            #[cfg(not(target_os = "windows"))]
             CreateVsockDevice(ref e) => write!(f, "Cannot create vsock device: {e:?}"),
-            #[cfg(target_os = "windows")]
-            UnsupportedOnWindows => write!(f, "Vsock device support is not implemented on Windows"),
         }
     }
 }
@@ -92,8 +45,10 @@ pub struct VsockDeviceConfig {
     /// An optional map of guest port to host UNIX domain sockets for IPC.
     pub unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
     /// Optional custom in-process services keyed by host vsock port.
-    #[cfg(not(target_os = "windows"))]
     pub custom_port_map: Option<HashMap<u32, Arc<dyn VsockPortBackend>>>,
+    /// Optional custom message-oriented services keyed by host vsock port.
+    #[cfg(not(target_os = "windows"))]
+    pub custom_dgram_port_map: Option<HashMap<u32, Arc<dyn VsockDatagramPortBackend>>>,
     /// TSI feature flags
     pub tsi_flags: TsiFlags,
 }
@@ -106,11 +61,18 @@ impl fmt::Debug for VsockDeviceConfig {
             .field("guest_cid", &self.guest_cid)
             .field("host_port_map", &self.host_port_map)
             .field("unix_ipc_port_map", &self.unix_ipc_port_map);
-        #[cfg(not(target_os = "windows"))]
         debug.field(
             "custom_ports",
             &self
                 .custom_port_map
+                .as_ref()
+                .map(|services| services.keys().collect::<Vec<_>>()),
+        );
+        #[cfg(not(target_os = "windows"))]
+        debug.field(
+            "custom_dgram_ports",
+            &self
+                .custom_dgram_port_map
                 .as_ref()
                 .map(|services| services.keys().collect::<Vec<_>>()),
         );
@@ -140,20 +102,11 @@ impl VsockBuilder {
 
     /// Inserts a Vsock in the store.
     /// If an entry already exists, it will overwrite it.
-    #[cfg(not(target_os = "windows"))]
     pub fn insert(&mut self, cfg: VsockDeviceConfig) -> Result<()> {
         self.tsi_flags = cfg.tsi_flags;
         self.inner = Some(VsockWrapper {
             vsock: Arc::new(Mutex::new(Self::create_vsock(cfg)?)),
         });
-        Ok(())
-    }
-
-    /// Inserts a placeholder Vsock configuration on Windows.
-    #[cfg(target_os = "windows")]
-    pub fn insert(&mut self, cfg: VsockDeviceConfig) -> Result<()> {
-        self.tsi_flags = cfg.tsi_flags;
-        self.inner = Some(VsockWrapper { vsock: () });
         Ok(())
     }
 
@@ -167,13 +120,18 @@ impl VsockBuilder {
     }
 
     /// Creates a Vsock device from a VsockDeviceConfig.
-    #[cfg(not(target_os = "windows"))]
     pub fn create_vsock(cfg: VsockDeviceConfig) -> Result<Vsock> {
+        #[cfg(not(target_os = "windows"))]
+        let custom_dgram_port_map = cfg.custom_dgram_port_map;
+        #[cfg(target_os = "windows")]
+        let custom_dgram_port_map = None;
+
         Vsock::new(
             u64::from(cfg.guest_cid),
             cfg.host_port_map,
             cfg.unix_ipc_port_map,
             cfg.custom_port_map,
+            custom_dgram_port_map,
             cfg.tsi_flags,
         )
         .map_err(VsockConfigError::CreateVsockDevice)
@@ -213,6 +171,7 @@ pub(crate) mod tests {
             host_port_map: None,
             unix_ipc_port_map: None,
             custom_port_map: None,
+            custom_dgram_port_map: None,
             tsi_flags: TsiFlags::empty(),
         }
     }

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -14,11 +14,24 @@ use devices::virtio::{Vsock, VsockError};
 
 type MutexVsock = Arc<Mutex<Vsock>>;
 
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(not(target_os = "windows"))]
+const VSOCK_TIMESYNC_PORT: u32 = 123;
+#[cfg(not(target_os = "windows"))]
+const TSI_CONTROL_PORT_START: u32 = 1024;
+#[cfg(not(target_os = "windows"))]
+const TSI_CONTROL_PORT_END: u32 = 1031;
+
 /// Errors associated with `NetworkInterfaceConfig`.
 #[derive(Debug)]
 pub enum VsockConfigError {
     /// Failed to create the vsock device.
     CreateVsockDevice(VsockError),
+    /// A custom datagram route overlaps a device-owned protocol port.
+    ReservedDatagramPort { port: u32, owner: &'static str },
 }
 
 impl fmt::Display for VsockConfigError {
@@ -26,6 +39,12 @@ impl fmt::Display for VsockConfigError {
         use self::VsockConfigError::*;
         match *self {
             CreateVsockDevice(ref e) => write!(f, "Cannot create vsock device: {e:?}"),
+            ReservedDatagramPort { port, owner } => {
+                write!(
+                    f,
+                    "Cannot route vsock datagram port {port}: reserved for {owner}"
+                )
+            }
         }
     }
 }
@@ -122,6 +141,27 @@ impl VsockBuilder {
     /// Creates a Vsock device from a VsockDeviceConfig.
     pub fn create_vsock(cfg: VsockDeviceConfig) -> Result<Vsock> {
         #[cfg(not(target_os = "windows"))]
+        if let Some(routes) = &cfg.custom_dgram_port_map {
+            if routes.contains_key(&VSOCK_TIMESYNC_PORT) {
+                return Err(VsockConfigError::ReservedDatagramPort {
+                    port: VSOCK_TIMESYNC_PORT,
+                    owner: "guest time synchronization",
+                });
+            }
+            if !cfg.tsi_flags.is_empty() {
+                if let Some(port) = routes
+                    .keys()
+                    .find(|port| (TSI_CONTROL_PORT_START..=TSI_CONTROL_PORT_END).contains(port))
+                {
+                    return Err(VsockConfigError::ReservedDatagramPort {
+                        port: *port,
+                        owner: "the active TSI control transport",
+                    });
+                }
+            }
+        }
+
+        #[cfg(not(target_os = "windows"))]
         let custom_dgram_port_map = cfg.custom_dgram_port_map;
         #[cfg(target_os = "windows")]
         let custom_dgram_port_map = None;
@@ -140,8 +180,26 @@ impl VsockBuilder {
 
 #[cfg(all(test, not(target_os = "windows")))]
 pub(crate) mod tests {
+    use std::io;
+
+    use devices::virtio::vsock::{
+        VsockDatagramBackend, VsockDatagramPeer, VsockDatagramPortBackend, VsockNotifier,
+    };
+
     use super::*;
     use utils::tempfile::TempFile;
+
+    struct RejectDatagrams;
+
+    impl VsockDatagramPortBackend for RejectDatagrams {
+        fn open_peer(
+            &self,
+            _peer: VsockDatagramPeer,
+            _notifier: VsockNotifier,
+        ) -> io::Result<Box<dyn VsockDatagramBackend>> {
+            Err(io::Error::from(io::ErrorKind::ConnectionRefused))
+        }
+    }
 
     // Placeholder for the path where a socket file will be created.
     // The socket file will be removed when the scope ends.
@@ -202,5 +260,23 @@ pub(crate) mod tests {
             io::Error::from_raw_os_error(0),
         ));
         let _ = format!("{err}{err:?}");
+    }
+
+    #[test]
+    fn create_vsock_rejects_reserved_datagram_ports() {
+        let tmp_sock_file = TempSockFile::new(TempFile::new().unwrap());
+        let mut config = default_config(&tmp_sock_file);
+        config.custom_dgram_port_map = Some(HashMap::from([(
+            VSOCK_TIMESYNC_PORT,
+            Arc::new(RejectDatagrams) as Arc<dyn VsockDatagramPortBackend>,
+        )]));
+
+        assert!(matches!(
+            VsockBuilder::create_vsock(config),
+            Err(VsockConfigError::ReservedDatagramPort {
+                port: VSOCK_TIMESYNC_PORT,
+                ..
+            })
+        ));
     }
 }


### PR DESCRIPTION
## TL;DR
Add public host backend interfaces for virtio-vsock streams and datagrams so embedders can connect guest ports to their own local IPC transports on Unix and Windows.

## Description
- Expose `VsockPortBackend` and `VsockStreamBackend` for nonblocking host byte streams, with readiness supplied by a native pollable or `VsockNotifier`.
- Expose Unix-only `VsockDatagramPortBackend` and `VsockDatagramBackend` interfaces with stable per-peer routing and message-boundary preservation.
- Keep virtio-vsock framing, stream credit accounting, shutdown, resets, queues, and interrupts inside libkrun.
- Add a Windows muxer and handle-based event polling so custom stream adapters such as named pipes can use the same API.
- Validate duplicate routes while allowing a stream route and datagram route to share the same destination port.

```rust
use std::sync::Arc;
use msb_krun::VmBuilder;

let builder = VmBuilder::new().vsock(|vsock| {
    vsock
        .custom(5000, Arc::new(stream_backend))
        .custom_dgram(5001, Arc::new(datagram_backend))
});
```

## Test Plan
- [x] `cargo fmt --all -- --check` exits 0
- [x] `cargo test -p msb_krun --lib` passes 17 tests
- [x] `cargo test -p msb_krun_devices virtio::vsock` passes 2 focused tests
- [x] `cargo clippy --target aarch64-pc-windows-msvc -p msb_krun -p msb_krun_devices --lib -- -D warnings` exits 0
- [x] macOS guest stream and datagram round trips reach host Unix sockets through CID 2
- [x] Windows ARM64 guest stream round trip reaches a host named pipe through CID 2