### PR TITLE
feat(block): support live writeback pressure limits

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -48,7 +48,7 @@ use super::writeback::{
 };
 use super::{
     super::{ActivateResult, DeviceQueue, DeviceState, QueueConfig, VirtioDevice, TYPE_BLOCK},
-    Error, NUM_QUEUES, QUEUE_CONFIG, SECTOR_SHIFT, SECTOR_SIZE,
+    Error, WritebackLimit, NUM_QUEUES, QUEUE_CONFIG, SECTOR_SHIFT, SECTOR_SIZE,
 };
 
 use crate::virtio::{
@@ -732,8 +732,36 @@ impl Block {
         writeback_limit_bytes: Option<u64>,
         metrics: BlockMetricsWriter,
     ) -> io::Result<Block> {
+        Self::new_with_writeback_limit_handle(
+            id,
+            partuuid,
+            cache_type,
+            disk_image_path,
+            disk_image_format,
+            is_disk_read_only,
+            direct_io,
+            sync_mode,
+            writeback_limit_bytes.map(WritebackLimit::new),
+            metrics,
+        )
+    }
+
+    /// Create a virtio block device with an optional live buffered-writeback budget.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_writeback_limit_handle(
+        id: String,
+        partuuid: Option<String>,
+        cache_type: CacheType,
+        disk_image_path: String,
+        disk_image_format: ImageType,
+        is_disk_read_only: bool,
+        direct_io: bool,
+        sync_mode: SyncMode,
+        writeback_limit: Option<WritebackLimit>,
+        metrics: BlockMetricsWriter,
+    ) -> io::Result<Block> {
         // Keep zero equivalent to the builder's disabled state for callers of this lower-level API.
-        let writeback_limit_bytes = writeback_limit_bytes.filter(|bytes| *bytes != 0);
+        let writeback_limit = writeback_limit.filter(|limit| limit.maximum_bytes() != 0);
 
         if matches!(disk_image_format, ImageType::Vmdk) && !is_disk_read_only {
             return Err(io::Error::new(
@@ -742,7 +770,9 @@ impl Block {
             ));
         }
 
-        if let Some(_hard_budget_bytes) = writeback_limit_bytes {
+        if let Some(_hard_budget_bytes) =
+            writeback_limit.as_ref().map(WritebackLimit::maximum_bytes)
+        {
             #[cfg(target_os = "linux")]
             if _hard_budget_bytes < MINIMUM_WRITEBACK_BUDGET_BYTES {
                 return Err(io::Error::new(
@@ -804,10 +834,10 @@ impl Block {
         };
 
         #[cfg(target_os = "linux")]
-        let writeback_config = match writeback_limit_bytes {
-            Some(hard_budget_bytes) => Some(BufferedWritebackConfig::new(
+        let writeback_config = match writeback_limit {
+            Some(limit) => Some(BufferedWritebackConfig::new(
                 Arc::new(disk_image.try_clone()?),
-                hard_budget_bytes,
+                limit,
             )?),
             None => None,
         };

--- a/src/devices/src/virtio/block/limit.rs
+++ b/src/devices/src/virtio/block/limit.rs
@@ -1,0 +1,84 @@
+// Copyright 2026 The Microsandbox Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// A cloneable live limit for one or more buffered-writeback controllers.
+///
+/// The maximum is fixed when the handle is created. Callers may lower the active target while a
+/// VM is running and later raise it back up to that maximum. Controllers observe changes before
+/// admitting each new backing-file mutation.
+#[derive(Clone, Debug)]
+pub struct WritebackLimit {
+    maximum_bytes: u64,
+    target_bytes: Arc<AtomicU64>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl WritebackLimit {
+    /// Creates a live limit whose initial target is also its immutable maximum.
+    pub fn new(maximum_bytes: u64) -> Self {
+        Self {
+            maximum_bytes,
+            target_bytes: Arc::new(AtomicU64::new(maximum_bytes)),
+        }
+    }
+
+    /// Returns the immutable maximum configured for this handle.
+    pub fn maximum_bytes(&self) -> u64 {
+        self.maximum_bytes
+    }
+
+    /// Returns the currently requested pressure target.
+    pub fn target_bytes(&self) -> u64 {
+        self.target_bytes.load(Ordering::Acquire)
+    }
+
+    /// Changes the live pressure target without rebuilding or pausing the VM.
+    ///
+    /// A target must be non-zero and cannot exceed the immutable maximum. Linux controllers round
+    /// a sub-page target up to one host page so every disk can continue to make forward progress.
+    pub fn set_target_bytes(&self, target_bytes: u64) -> io::Result<()> {
+        if target_bytes == 0 || target_bytes > self.maximum_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "writeback target must be between 1 and {} bytes",
+                    self.maximum_bytes
+                ),
+            ));
+        }
+        self.target_bytes.store(target_bytes, Ordering::Release);
+        Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::WritebackLimit;
+
+    #[test]
+    fn target_is_shared_but_cannot_escape_the_maximum() {
+        let limit = WritebackLimit::new(1024);
+        let observer = limit.clone();
+
+        limit.set_target_bytes(512).unwrap();
+        assert_eq!(observer.target_bytes(), 512);
+        assert!(limit.set_target_bytes(0).is_err());
+        assert!(limit.set_target_bytes(1025).is_err());
+        assert_eq!(observer.target_bytes(), 512);
+    }
+}

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -1,7 +1,12 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use vm_memory::GuestMemoryError;
+
+use super::QueueConfig;
+
 pub mod device;
+mod limit;
 #[cfg(windows)]
 mod windows;
 mod worker;
@@ -9,10 +14,7 @@ mod worker;
 mod writeback;
 
 pub use self::device::{Block, CacheType};
-
-use vm_memory::GuestMemoryError;
-
-use super::QueueConfig;
+pub use self::limit::WritebackLimit;
 
 pub const CONFIG_SPACE_SIZE: usize = 8;
 pub const SECTOR_SHIFT: u8 = 9;

--- a/src/devices/src/virtio/block/writeback.rs
+++ b/src/devices/src/virtio/block/writeback.rs
@@ -14,6 +14,8 @@ use std::thread::{self, JoinHandle};
 use crossbeam_channel::{bounded, Receiver, Sender, TryRecvError};
 use log::warn;
 
+use super::WritebackLimit;
+
 //--------------------------------------------------------------------------------------------------
 // Constants
 //--------------------------------------------------------------------------------------------------
@@ -133,7 +135,7 @@ struct SyncFileRangeBackend {
 #[derive(Clone)]
 pub(crate) struct BufferedWritebackConfig {
     file: Arc<File>,
-    hard_budget_bytes: u64,
+    limit: WritebackLimit,
     page_size: u64,
     health: Arc<SharedHealth>,
 }
@@ -147,7 +149,7 @@ pub(crate) struct BufferedWritebackConfig {
 /// by the existing full backing-image sync, including the data-retrieval metadata required by the
 /// host filesystem.
 pub(crate) struct BufferedWritebackController {
-    hard_budget_bytes: u64,
+    limit: WritebackLimit,
     page_size: u64,
     tracked: ExtentSet,
     current_generation: u64,
@@ -383,12 +385,12 @@ impl WritebackBackend for SyncFileRangeBackend {
 
 #[cfg(target_os = "linux")]
 impl BufferedWritebackConfig {
-    pub(crate) fn new(file: Arc<File>, hard_budget_bytes: u64) -> io::Result<Self> {
+    pub(crate) fn new(file: Arc<File>, limit: WritebackLimit) -> io::Result<Self> {
         let page_size = host_page_size()?;
-        validate_policy(hard_budget_bytes, page_size)?;
+        validate_policy(limit.maximum_bytes(), page_size)?;
         Ok(Self {
             file,
-            hard_budget_bytes,
+            limit,
             page_size,
             health: Arc::new(SharedHealth::new()),
         })
@@ -405,7 +407,7 @@ impl BufferedWritebackConfig {
             Arc::new(SyncFileRangeBackend {
                 file: Arc::clone(&self.file),
             }),
-            self.hard_budget_bytes,
+            self.limit.clone(),
             self.page_size,
             Arc::clone(&self.health),
         )
@@ -434,7 +436,7 @@ impl BufferedWritebackController {
     ) -> io::Result<Self> {
         Self::spawn_with_health(
             backend,
-            hard_budget_bytes,
+            WritebackLimit::new(hard_budget_bytes),
             page_size,
             Arc::new(SharedHealth::new()),
         )
@@ -442,10 +444,11 @@ impl BufferedWritebackController {
 
     fn spawn_with_health(
         backend: Arc<dyn WritebackBackend>,
-        hard_budget_bytes: u64,
+        limit: WritebackLimit,
         page_size: u64,
         health: Arc<SharedHealth>,
     ) -> io::Result<Self> {
+        let hard_budget_bytes = limit.maximum_bytes();
         validate_policy(hard_budget_bytes, page_size)?;
         let queue_capacity = queue_capacity(hard_budget_bytes);
         let (job_sender, job_receiver) = bounded(queue_capacity);
@@ -458,7 +461,7 @@ impl BufferedWritebackController {
             })?;
 
         Ok(Self {
-            hard_budget_bytes,
+            limit,
             page_size,
             tracked: ExtentSet::default(),
             current_generation: 0,
@@ -501,7 +504,31 @@ impl BufferedWritebackController {
             self.reap_completions_while_latching();
             self.check_error()?;
 
-            if let Some((length, range)) = self.plannable_prefix(offset, requested_bytes)? {
+            let active_budget_bytes = self.active_budget_bytes();
+            if self.tracked.bytes > active_budget_bytes {
+                // A live decrease cannot revoke bytes already mutated. Retire the current
+                // generation and stop admitting even hot rewrites until completed writeback has
+                // brought this controller beneath its new target.
+                if !self.current_extents.is_empty() {
+                    if let Err(error) = self.submit_current_generation() {
+                        self.latch_error(&error);
+                        return Err(self
+                            .latched_error
+                            .as_ref()
+                            .expect("submission failure must latch an error")
+                            .to_io_error());
+                    }
+                    continue;
+                }
+                if self.has_in_flight_generations() {
+                    self.wait_for_completion()?;
+                    continue;
+                }
+            }
+
+            if let Some((length, range)) =
+                self.plannable_prefix(offset, requested_bytes, active_budget_bytes)?
+            {
                 let id = self.next_reservation;
                 self.next_reservation = self
                     .next_reservation
@@ -635,6 +662,7 @@ impl BufferedWritebackController {
         &self,
         offset: u64,
         requested_bytes: u64,
+        active_budget_bytes: u64,
     ) -> io::Result<Option<(u64, DirtyRange)>> {
         let first_page = DirtyRange::for_write(offset, 1, self.page_size)?
             .expect("non-empty requested write must have a range");
@@ -644,7 +672,7 @@ impl BufferedWritebackController {
             return Ok(None);
         }
 
-        let capped_length = requested_bytes.min(self.hard_budget_bytes);
+        let capped_length = requested_bytes.min(active_budget_bytes);
         let mut low = 0;
         let mut high = capped_length;
 
@@ -656,12 +684,12 @@ impl BufferedWritebackController {
                 .current_extents
                 .bytes
                 .checked_add(self.current_extents.additional_bytes(range))
-                .is_some_and(|bytes| bytes <= self.hard_budget_bytes);
+                .is_some_and(|bytes| bytes <= active_budget_bytes);
             let fits_hard = self
                 .tracked
                 .bytes
                 .checked_add(self.tracked.additional_bytes(range))
-                .is_some_and(|bytes| bytes <= self.hard_budget_bytes);
+                .is_some_and(|bytes| bytes <= active_budget_bytes);
             if fits_generation && fits_hard {
                 low = candidate;
             } else {
@@ -687,8 +715,8 @@ impl BufferedWritebackController {
             .tracked
             .bytes
             .checked_add(self.tracked.additional_bytes(range));
-        if projected_generation.is_none_or(|bytes| bytes > self.hard_budget_bytes)
-            || projected_hard.is_none_or(|bytes| bytes > self.hard_budget_bytes)
+        if projected_generation.is_none_or(|bytes| bytes > self.limit.maximum_bytes())
+            || projected_hard.is_none_or(|bytes| bytes > self.limit.maximum_bytes())
         {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -869,6 +897,12 @@ impl BufferedWritebackController {
             )),
             None => Ok(()),
         }
+    }
+
+    fn active_budget_bytes(&self) -> u64 {
+        // An extremely oversubscribed host still leaves every controller one page of progress.
+        // The configured maximum is page-aligned by validation, so this cannot exceed it.
+        self.limit.target_bytes().max(self.page_size)
     }
 }
 
@@ -1460,6 +1494,83 @@ mod tests {
     }
 
     #[test]
+    fn live_target_caps_new_reservations_and_can_grow_again() {
+        let backend = Arc::new(FakeBackend::default());
+        let limit = WritebackLimit::new(MINIMUM_WRITEBACK_BUDGET_BYTES);
+        limit.set_target_bytes(TEST_PAGE_SIZE * 2).unwrap();
+        let mut controller = BufferedWritebackController::spawn_with_health(
+            backend,
+            limit.clone(),
+            TEST_PAGE_SIZE,
+            Arc::new(SharedHealth::new()),
+        )
+        .unwrap();
+
+        let reservation = controller
+            .plan_write(0, MINIMUM_WRITEBACK_BUDGET_BYTES)
+            .unwrap();
+        assert_eq!(reservation.len(), TEST_PAGE_SIZE * 2);
+        controller
+            .finish_write(reservation, WritebackOutcome::Written(TEST_PAGE_SIZE * 2))
+            .unwrap();
+
+        limit.set_target_bytes(TEST_PAGE_SIZE * 3).unwrap();
+        let reservation = controller
+            .plan_write(TEST_PAGE_SIZE * 2, TEST_PAGE_SIZE * 4)
+            .unwrap();
+        assert_eq!(reservation.len(), TEST_PAGE_SIZE);
+        controller
+            .finish_write(reservation, WritebackOutcome::Written(TEST_PAGE_SIZE))
+            .unwrap();
+    }
+
+    #[test]
+    fn live_shrink_retires_existing_bytes_before_admitting_hot_rewrite() {
+        let backend = Arc::new(FakeBackend::default());
+        let limit = WritebackLimit::new(MINIMUM_WRITEBACK_BUDGET_BYTES);
+        let mut controller = BufferedWritebackController::spawn_with_health(
+            backend.clone(),
+            limit.clone(),
+            TEST_PAGE_SIZE,
+            Arc::new(SharedHealth::new()),
+        )
+        .unwrap();
+
+        let reservation = controller.plan_write(0, TEST_PAGE_SIZE * 3).unwrap();
+        controller
+            .finish_write(reservation, WritebackOutcome::Written(TEST_PAGE_SIZE * 3))
+            .unwrap();
+        limit.set_target_bytes(TEST_PAGE_SIZE).unwrap();
+
+        let rewrite = controller.plan_write(0, TEST_PAGE_SIZE).unwrap();
+        assert_eq!(backend.start_calls.lock().unwrap().len(), 1);
+        assert!(controller.tracked.bytes <= TEST_PAGE_SIZE);
+        controller
+            .finish_write(rewrite, WritebackOutcome::Written(TEST_PAGE_SIZE))
+            .unwrap();
+    }
+
+    #[test]
+    fn live_shrink_does_not_invalidate_an_existing_reservation() {
+        let backend = Arc::new(FakeBackend::default());
+        let limit = WritebackLimit::new(MINIMUM_WRITEBACK_BUDGET_BYTES);
+        let mut controller = BufferedWritebackController::spawn_with_health(
+            backend,
+            limit.clone(),
+            TEST_PAGE_SIZE,
+            Arc::new(SharedHealth::new()),
+        )
+        .unwrap();
+
+        let reservation = controller.plan_write(0, TEST_PAGE_SIZE * 2).unwrap();
+        limit.set_target_bytes(TEST_PAGE_SIZE).unwrap();
+        controller
+            .finish_write(reservation, WritebackOutcome::Written(TEST_PAGE_SIZE * 2))
+            .unwrap();
+        assert_eq!(controller.tracked.bytes, TEST_PAGE_SIZE * 2);
+    }
+
+    #[test]
     fn planner_allows_only_one_pending_reservation() {
         let backend = Arc::new(FakeBackend::default());
         let mut controller = BufferedWritebackController::spawn(
@@ -1497,7 +1608,7 @@ mod tests {
             controller.current_extents.insert(range);
             controller.tracked.insert(range);
         }
-        assert!(controller.current_extents.bytes < controller.hard_budget_bytes);
+        assert!(controller.current_extents.bytes < controller.limit.maximum_bytes());
 
         let next_offset = MAX_EXTENTS_PER_GENERATION as u64 * TEST_PAGE_SIZE * 2;
         let reservation = controller.plan_write(next_offset, 512).unwrap();

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -720,11 +720,13 @@ impl VmBuilder {
                 sync_mode,
             };
 
-            vmr.add_block_device_with_writeback_limit(
-                blk_config,
-                configured_disk.writeback_limit_bytes,
-            )
-            .map_err(|e| Error::Config(ConfigError::Block(e.to_string())))?;
+            let writeback_limit = configured_disk.writeback_limit.or_else(|| {
+                configured_disk
+                    .writeback_limit_bytes
+                    .map(devices::virtio::block::WritebackLimit::new)
+            });
+            vmr.add_block_device_with_writeback_limit_handle(blk_config, writeback_limit)
+                .map_err(|e| Error::Config(ConfigError::Block(e.to_string())))?;
         }
 
         // Format execution configuration
@@ -1219,5 +1221,28 @@ mod tests {
         assert!(!builder.disk.configs[1].config.direct_io);
         assert_eq!(builder.disk.configs[1].config.sync, SyncMode::Full);
         assert_eq!(builder.disk.configs[1].writeback_limit_bytes, None);
+    }
+
+    #[cfg(feature = "blk")]
+    #[test]
+    fn disk_builder_keeps_live_writeback_handle_shared_and_per_disk() {
+        use crate::api::builders::WritebackLimit;
+
+        let limit = WritebackLimit::new(256 * 1024 * 1024);
+        let builder = VmBuilder::new()
+            .disk(|d| d.path("/a.raw").writeback_limit(limit.clone()))
+            .disk(|d| d.path("/b.raw"));
+
+        let configured = builder.disk.configs[0]
+            .writeback_limit
+            .as_ref()
+            .expect("first disk must retain its live limit");
+        assert_eq!(configured.maximum_bytes(), 256 * 1024 * 1024);
+        assert_eq!(configured.target_bytes(), 256 * 1024 * 1024);
+        assert_eq!(builder.disk.configs[0].writeback_limit_bytes, None);
+        assert!(builder.disk.configs[1].writeback_limit.is_none());
+
+        limit.set_target_bytes(128 * 1024 * 1024).unwrap();
+        assert_eq!(configured.target_bytes(), 128 * 1024 * 1024);
     }
 }

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -10,6 +10,9 @@ use devices::virtio::console::port_io::{
 use vmm::resources::PortConfig;
 pub use vmm::vmm_config::machine_config::HostCpuId;
 
+#[cfg(feature = "blk")]
+pub use devices::virtio::block::WritebackLimit;
+
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 use crate::backends::fs::DynFileSystem;
 
@@ -378,6 +381,7 @@ pub struct DiskBuilder {
     current_direct_io: bool,
     current_sync: SyncMode,
     current_writeback_limit_bytes: Option<u64>,
+    current_writeback_limit: Option<WritebackLimit>,
 }
 
 /// Configuration for a single block device.
@@ -401,6 +405,7 @@ pub struct DiskConfig {
 pub(crate) struct ConfiguredDisk {
     pub(crate) config: DiskConfig,
     pub(crate) writeback_limit_bytes: Option<u64>,
+    pub(crate) writeback_limit: Option<WritebackLimit>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1047,6 +1052,7 @@ impl DiskBuilder {
             current_direct_io: false,
             current_sync: SyncMode::Full,
             current_writeback_limit_bytes: None,
+            current_writeback_limit: None,
         }
     }
 
@@ -1083,6 +1089,7 @@ impl DiskBuilder {
                     sync: self.current_sync,
                 },
                 writeback_limit_bytes: self.current_writeback_limit_bytes,
+                writeback_limit: self.current_writeback_limit.clone(),
             });
             self.current_read_only = false;
             self.current_format = DiskImageFormat::Raw;
@@ -1090,6 +1097,7 @@ impl DiskBuilder {
             self.current_direct_io = false;
             self.current_sync = SyncMode::Full;
             self.current_writeback_limit_bytes = None;
+            self.current_writeback_limit = None;
         }
 
         self.current_path = Some(path.as_ref().to_path_buf());
@@ -1135,6 +1143,17 @@ impl DiskBuilder {
     /// Invalid combinations fail explicitly when the VM is built.
     pub fn writeback_limit_bytes(mut self, bytes: u64) -> Self {
         self.current_writeback_limit_bytes = (bytes > 0).then_some(bytes);
+        self.current_writeback_limit = None;
+        self
+    }
+
+    /// Attach a live writeback limit to the current disk.
+    ///
+    /// Clones of the handle may change the pressure target while the VM is running. The immutable
+    /// maximum receives the same validation as [`Self::writeback_limit_bytes`].
+    pub fn writeback_limit(mut self, limit: WritebackLimit) -> Self {
+        self.current_writeback_limit_bytes = None;
+        self.current_writeback_limit = Some(limit);
         self
     }
 
@@ -1152,6 +1171,7 @@ impl DiskBuilder {
                     sync: self.current_sync,
                 },
                 writeback_limit_bytes: self.current_writeback_limit_bytes,
+                writeback_limit: self.current_writeback_limit.take(),
             });
         }
         self

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -48,6 +48,8 @@ pub use builders::FsBuilder;
 #[cfg(feature = "net")]
 pub use builders::NetBuilder;
 pub use builders::VsockBuilder;
+#[cfg(feature = "blk")]
+pub use builders::WritebackLimit;
 pub use builders::{ConsoleBuilder, ExecBuilder, HostCpuId, KernelBuilder, MachineBuilder};
 pub use error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use exit_handle::ExitHandle;

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -50,6 +50,8 @@ pub use api::builders::NetBuilder;
 #[cfg(feature = "blk")]
 pub use api::builders::SyncMode;
 pub use api::builders::VsockBuilder;
+#[cfg(feature = "blk")]
+pub use api::builders::WritebackLimit;
 pub use api::builders::{ConsoleBuilder, ExecBuilder, HostCpuId, KernelBuilder, MachineBuilder};
 pub use api::error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use api::exit_handle::ExitHandle;

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -484,6 +484,17 @@ impl VmResources {
             .insert_with_writeback_limit(config, writeback_limit_bytes, self.metrics.clone())
     }
 
+    /// Adds a block device with an optional live dirty-data budget.
+    #[cfg(feature = "blk")]
+    pub fn add_block_device_with_writeback_limit_handle(
+        &mut self,
+        config: BlockDeviceConfig,
+        writeback_limit: Option<devices::virtio::block::WritebackLimit>,
+    ) -> Result<BlockConfigError> {
+        self.block
+            .insert_with_writeback_limit_handle(config, writeback_limit, self.metrics.clone())
+    }
+
     /// Sets a vsock device to be attached when the VM starts.
     pub fn set_vsock_device(&mut self, config: VsockDeviceConfig) -> Result<VsockConfigError> {
         self.vsock.insert(config)

--- a/src/vmm/src/vmm_config/block.rs
+++ b/src/vmm/src/vmm_config/block.rs
@@ -72,9 +72,23 @@ impl BlockBuilder {
         writeback_limit_bytes: Option<u64>,
         metrics: MetricsWriter,
     ) -> Result<()> {
-        let block_dev = Arc::new(Mutex::new(Self::create_block_with_writeback_limit(
+        self.insert_with_writeback_limit_handle(
             config,
-            writeback_limit_bytes,
+            writeback_limit_bytes.map(devices::virtio::block::WritebackLimit::new),
+            metrics,
+        )
+    }
+
+    /// Inserts a block device with a live buffered dirty-data budget.
+    pub fn insert_with_writeback_limit_handle(
+        &mut self,
+        config: BlockDeviceConfig,
+        writeback_limit: Option<devices::virtio::block::WritebackLimit>,
+        metrics: MetricsWriter,
+    ) -> Result<()> {
+        let block_dev = Arc::new(Mutex::new(Self::create_block_with_writeback_limit_handle(
+            config,
+            writeback_limit,
             metrics,
         )?));
         self.list.push_back(block_dev);
@@ -87,8 +101,21 @@ impl BlockBuilder {
         writeback_limit_bytes: Option<u64>,
         metrics: MetricsWriter,
     ) -> Result<Block> {
+        Self::create_block_with_writeback_limit_handle(
+            config,
+            writeback_limit_bytes.map(devices::virtio::block::WritebackLimit::new),
+            metrics,
+        )
+    }
+
+    /// Creates a block device with an optional live buffered dirty-data budget.
+    pub fn create_block_with_writeback_limit_handle(
+        config: BlockDeviceConfig,
+        writeback_limit: Option<devices::virtio::block::WritebackLimit>,
+        metrics: MetricsWriter,
+    ) -> Result<Block> {
         let device_metrics = metrics.register_block_device(config.block_id.clone());
-        devices::virtio::Block::new_with_writeback_limit(
+        devices::virtio::Block::new_with_writeback_limit_handle(
             config.block_id,
             None,
             config.cache_type,
@@ -97,7 +124,7 @@ impl BlockBuilder {
             config.is_disk_read_only,
             config.direct_io,
             config.sync_mode,
-            writeback_limit_bytes,
+            writeback_limit,
             device_metrics,
         )
         .map_err(BlockConfigError::CreateBlockDevice)


### PR DESCRIPTION
## TL;DR

Add a cloneable live writeback-limit handle so a host coordinator can reduce or restore each disk's dirty-data target while the VM remains running.

## Description

- Preserve the configured per-disk maximum while allowing a live pressure target below it.
- Observe target changes before each buffered backing-file mutation.
- When a target shrinks below current dirty ownership, retire accounted ranges and pause subsequent writes until the controller converges below the target.
- Preserve reservations already issued before a shrink instead of turning a valid in-flight write into a permanent controller error.
- Keep the existing fixed-byte builder API and add a handle-based API for coordinators.
- Retain exact extent accounting, latched failures, and the existing guest-visible full-sync durability boundary.

## Test Plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy -p msb_krun --features blk --lib -- -D warnings`
- [x] `cargo test -p msb_krun_devices --features blk --lib writeback`
- [x] `cargo test -p msb_krun --features blk --lib disk_builder`
- [ ] `cargo test` — local macOS environment cannot generate `msb_krun_input` bindings because its Homebrew clang cannot locate the SDK `inttypes.h`; CI covers the supported matrix.
