### PR TITLE
feat(memory): add resolved NUMA placement

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Windows passthrough error test
         run: cargo test --locked --manifest-path src/devices/Cargo.toml read_translates_zero_copy_win32_errors
 
+      # This calls VirtualAlloc2 on the native runner, not just the cross-compiled wrapper.
+      - name: Windows NUMA allocation test
+        run: cargo test --locked --manifest-path src/vmm/Cargo.toml windows_numa_mapping_allocates_accessible_memory
+
       - name: Windows device Clippy
         run: cargo clippy --locked --manifest-path src/devices/Cargo.toml -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,7 +1839,7 @@ checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
 [[package]]
 name = "vm-memory"
 version = "0.18.0"
-source = "git+https://github.com/superradcompany/vm-memory.git?rev=d0275cbcd968cef46d30299fde61a891d92fc43b#d0275cbcd968cef46d30299fde61a891d92fc43b"
+source = "git+https://github.com/superradcompany/vm-memory.git?rev=25d20cba63d46ae598022e18e8a5157667b7a30d#25d20cba63d46ae598022e18e8a5157667b7a30d"
 dependencies = [
  "libc",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,8 +1839,7 @@ checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
 [[package]]
 name = "vm-memory"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b55e753c7725603745cb32b2287ef7ef3da05c03c7702cda3fa8abe25ae0465"
+source = "git+https://github.com/superradcompany/vm-memory.git?rev=d0275cbcd968cef46d30299fde61a891d92fc43b#d0275cbcd968cef46d30299fde61a891d92fc43b"
 dependencies = [
  "libc",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
+ "msb-vm-memory",
  "msb_krun_aws_nitro",
  "msb_krun_devices",
  "msb_krun_display",
@@ -761,7 +762,6 @@ dependencies = [
  "nitro-enclaves 0.5.0",
  "once_cell",
  "rand",
- "vm-memory",
 ]
 
 [[package]]
@@ -876,21 +876,32 @@ dependencies = [
 
 [[package]]
 name = "msb-imago"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0720fa987e398d5fb5345d575d1a97a74cb0eaf645355088a21285607895422c"
+checksum = "8563624d245da0b51b13959708758f06d1412cacdd17000b001f5ccae80cf6af"
 dependencies = [
  "async-trait",
  "cfg-if",
  "libc",
  "miniz_oxide",
+ "msb-vm-memory",
  "nix 0.30.1",
  "page_size",
  "rustc_version",
  "tokio",
  "tracing",
- "vm-memory",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "msb-vm-memory"
+version = "0.18.0-msb.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c31dfbf17e640f6d661ae17e098b87c019821fe3eb4aba0e9eeada4ba678096"
+dependencies = [
+ "libc",
+ "thiserror 2.0.18",
+ "winapi",
 ]
 
 [[package]]
@@ -903,6 +914,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
+ "msb-vm-memory",
  "msb_krun_aws_nitro",
  "msb_krun_devices",
  "msb_krun_display",
@@ -912,7 +924,6 @@ dependencies = [
  "msb_krun_utils",
  "msb_krun_vmm",
  "nitro-enclaves 0.6.1",
- "vm-memory",
 ]
 
 [[package]]
@@ -922,11 +933,11 @@ dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
+ "msb-vm-memory",
  "msb_krun_arch_gen",
  "msb_krun_smbios",
  "msb_krun_utils",
  "tdx",
- "vm-memory",
 ]
 
 [[package]]
@@ -971,6 +982,7 @@ dependencies = [
  "log",
  "lru",
  "msb-imago",
+ "msb-vm-memory",
  "msb_krun_arch",
  "msb_krun_display",
  "msb_krun_hvf",
@@ -985,7 +997,6 @@ dependencies = [
  "tokio",
  "virtio-bindings",
  "vm-fdt",
- "vm-memory",
  "windows-sys 0.61.2",
  "zerocopy",
 ]
@@ -1027,8 +1038,8 @@ dependencies = [
 name = "msb_krun_kernel"
 version = "0.1.28"
 dependencies = [
+ "msb-vm-memory",
  "msb_krun_utils",
- "vm-memory",
 ]
 
 [[package]]
@@ -1060,7 +1071,7 @@ dependencies = [
 name = "msb_krun_smbios"
 version = "0.1.28"
 dependencies = [
- "vm-memory",
+ "msb-vm-memory",
 ]
 
 [[package]]
@@ -1093,6 +1104,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
+ "msb-vm-memory",
  "msb_krun_arch",
  "msb_krun_arch_gen",
  "msb_krun_cpuid",
@@ -1107,7 +1119,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tdx",
- "vm-memory",
  "windows-sys 0.61.2",
  "zstd",
 ]
@@ -1835,16 +1846,6 @@ name = "vm-fdt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
-
-[[package]]
-name = "vm-memory"
-version = "0.18.0"
-source = "git+https://github.com/superradcompany/vm-memory.git?rev=25d20cba63d46ae598022e18e8a5157667b7a30d#25d20cba63d46ae598022e18e8a5157667b7a30d"
-dependencies = [
- "libc",
- "thiserror 2.0.18",
- "winapi",
-]
 
 [[package]]
 name = "vmm-sys-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,11 @@ default-members = ["src/libkrun", "src/krun_input", "src/krun", "examples/rust_v
 exclude = ["examples/gtk_display"]
 resolver = "2"
 
+# Keep every vm-memory consumer, including msb-imago, on msb-vm-memory. Cargo treats the upstream
+# and compatibility packages as different type identities even though they expose the same API.
 [profile.dev]
 #panic = "abort"
 
 [profile.release]
 #panic = "abort"
 lto = true
-
-# Remove this patch once vm-memory exposes the Windows NUMA-aware mapping constructor in a release.
-[patch.crates-io]
-vm-memory = { git = "https://github.com/superradcompany/vm-memory.git", rev = "25d20cba63d46ae598022e18e8a5157667b7a30d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ lto = true
 
 # Remove this patch once vm-memory exposes the Windows NUMA-aware mapping constructor in a release.
 [patch.crates-io]
-vm-memory = { git = "https://github.com/superradcompany/vm-memory.git", rev = "d0275cbcd968cef46d30299fde61a891d92fc43b" }
+vm-memory = { git = "https://github.com/superradcompany/vm-memory.git", rev = "25d20cba63d46ae598022e18e8a5157667b7a30d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ resolver = "2"
 [profile.release]
 #panic = "abort"
 lto = true
+
+# Remove this patch once vm-memory exposes the Windows NUMA-aware mapping constructor in a release.
+[patch.crates-io]
+vm-memory = { git = "https://github.com/superradcompany/vm-memory.git", rev = "d0275cbcd968cef46d30299fde61a891d92fc43b" }

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -15,7 +15,7 @@ efi = []
 
 [dependencies]
 libc = ">=0.2.39"
-vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
+vm-memory = { package = "msb-vm-memory", version = "=0.18.0-msb.1", default-features = false, features = ["backend-mmap"] }
 
 arch_gen = { package = "msb_krun_arch_gen", version = "0.1.28", path = "../arch_gen" }
 smbios = { package = "msb_krun_smbios", version = "0.1.28", path = "../smbios" }

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -32,7 +32,7 @@ pw = { package = "pipewire", version = "0.8.0", optional = true }
 rand = "0.9.2"
 thiserror = { version = "2.0", optional = true }
 virtio-bindings = "0.2.0"
-vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
+vm-memory = { package = "msb-vm-memory", version = "=0.18.0-msb.1", default-features = false, features = ["backend-mmap"] }
 zerocopy = { version = "0.8.26", optional = true, features = ["derive"] }
 krun_display = { package = "msb_krun_display", version = "0.1.28", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
 krun_input = { package = "msb_krun_input", version = "0.1.28", path = "../krun_input", features = ["bindgen_clang_runtime"], optional = true }
@@ -41,7 +41,7 @@ arch = { package = "msb_krun_arch", version = "0.1.28", path = "../arch" }
 utils = { package = "msb_krun_utils", version = "0.1.28", path = "../utils" }
 polly = { package = "msb_krun_polly", version = "0.1.28", path = "../polly" }
 rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.28", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
-imago = { package = "msb-imago", version = "0.1.4", features = ["sync-wrappers", "vm-memory"] }
+imago = { package = "msb-imago", version = "0.1.5", features = ["sync-wrappers", "vm-memory"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 hvf = { package = "msb_krun_hvf", version = "0.1.28", path = "../hvf" }

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -7,6 +7,6 @@ description = "Kernel loading utilities for msb_krun microVMs"
 repository = "https://github.com/containers/libkrun"
 
 [dependencies]
-vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
+vm-memory = { package = "msb-vm-memory", version = "=0.18.0-msb.1", default-features = false, features = ["backend-mmap"] }
 
 utils = { package = "msb_krun_utils", version = "0.1.28", path = "../utils" }

--- a/src/krun/Cargo.toml
+++ b/src/krun/Cargo.toml
@@ -41,6 +41,6 @@ hvf = { package = "msb_krun_hvf", version = "0.1.28", path = "../hvf" }
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"
-vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
+vm-memory = { package = "msb-vm-memory", version = "=0.18.0-msb.1", default-features = false, features = ["backend-mmap"] }
 aws-nitro = { package = "msb_krun_aws_nitro", version = "0.1.28", path = "../aws_nitro", optional = true }
 nitro-enclaves = { version = "0.6.0", optional = true }

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -1,5 +1,7 @@
 //! VM Builder for creating and configuring microVMs using nested builders.
 
+#[cfg(not(feature = "tee"))]
+use std::collections::BTreeSet;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicI32;
 use std::sync::Arc;
@@ -21,6 +23,8 @@ use super::builders::DiskBuilder;
 use super::builders::FsBuilder;
 #[cfg(not(feature = "tee"))]
 use super::builders::FsConfig;
+#[cfg(not(feature = "tee"))]
+use super::builders::HostMemoryPolicy;
 use super::builders::{ConsoleBuilder, ExecBuilder, KernelBuilder, MachineBuilder};
 #[cfg(feature = "net")]
 use super::builders::{NetBuilder, NetConfig};
@@ -53,6 +57,8 @@ const VSOCK_TIMESYNC_PORT: u32 = 123;
 const TSI_CONTROL_PORT_START: u32 = 1024;
 #[cfg(not(target_os = "windows"))]
 const TSI_CONTROL_PORT_END: u32 = 1031;
+#[cfg(not(feature = "tee"))]
+const MAX_HOST_NUMA_NODE_ID: u32 = u16::MAX as u32;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -531,6 +537,8 @@ impl VmBuilder {
             }
         }
 
+        validate_numa_topology(&self.machine)?;
+
         // Build VmResources
         let mut vmr = VmResources::default();
 
@@ -550,6 +558,7 @@ impl VmBuilder {
         {
             vmr.vcpu_affinity = self.machine.vcpu_affinity;
         }
+        vmr.numa_topology = self.machine.numa_topology;
 
         // Reserved CPU capacity is realized through the private msb-cpu device:
         // the guest driver converges on the requested online count and the
@@ -882,6 +891,176 @@ fn map_vm_config_error(machine: &MachineBuilder, err: VmConfigError) -> Error {
     }
 }
 
+fn validate_numa_topology(machine: &MachineBuilder) -> Result<()> {
+    if machine.numa_topology.is_none() {
+        return Ok(());
+    }
+
+    // Confidential-computing memory is constructed by a separate backend. Until that backend can
+    // realize the same host-memory contract, reject placement instead of accepting and ignoring it.
+    #[cfg(feature = "tee")]
+    return Err(Error::Config(ConfigError::NumaUnsupported(
+        "host memory placement is unavailable with TEE memory".into(),
+    )));
+
+    #[cfg(not(feature = "tee"))]
+    validate_numa_topology_inner(
+        machine,
+        machine
+            .numa_topology
+            .as_ref()
+            .expect("the topology was checked above"),
+    )
+}
+
+#[cfg(not(feature = "tee"))]
+fn validate_numa_topology_inner(
+    machine: &MachineBuilder,
+    topology: &super::builders::NumaTopology,
+) -> Result<()> {
+    if topology.nodes.is_empty() {
+        return Err(Error::Config(ConfigError::InvalidNumaTopology(
+            "at least one guest node is required".into(),
+        )));
+    }
+
+    // The first implementation deliberately enables truthful one-node locality before guest
+    // SRAT/FDT support. A multi-node request must fail rather than silently creating a UMA guest.
+    if topology.nodes.len() != 1 {
+        return Err(Error::Config(ConfigError::NumaUnsupported(
+            "multi-node guest firmware is not enabled in this build".into(),
+        )));
+    }
+
+    let max_vcpus = machine.max_vcpus.unwrap_or(machine.vcpus);
+    let max_memory_mib = machine.max_memory_mib.unwrap_or(machine.memory_mib);
+    let mut vcpus = BTreeSet::new();
+    let mut boot_memory_mib = 0usize;
+    let mut maximum_memory_mib = 0usize;
+
+    for (expected_id, node) in topology.nodes.iter().enumerate() {
+        if usize::from(node.guest_node_id) != expected_id {
+            return Err(Error::Config(ConfigError::InvalidNumaTopology(
+                "guest node IDs must be dense and start at zero".into(),
+            )));
+        }
+        if node.max_memory_mib < node.memory_mib {
+            return Err(Error::Config(ConfigError::InvalidNumaTopology(format!(
+                "node {} maximum memory is below boot memory",
+                node.guest_node_id
+            ))));
+        }
+        if node.memory_mib % 2 != 0 || node.max_memory_mib % 2 != 0 {
+            return Err(Error::Config(ConfigError::InvalidNumaTopology(format!(
+                "node {} memory must be aligned to 2 MiB",
+                node.guest_node_id
+            ))));
+        }
+        boot_memory_mib = boot_memory_mib
+            .checked_add(node.memory_mib)
+            .ok_or_else(|| {
+                Error::Config(ConfigError::InvalidNumaTopology(
+                    "boot memory total overflows".into(),
+                ))
+            })?;
+        maximum_memory_mib = maximum_memory_mib
+            .checked_add(node.max_memory_mib)
+            .ok_or_else(|| {
+                Error::Config(ConfigError::InvalidNumaTopology(
+                    "maximum memory total overflows".into(),
+                ))
+            })?;
+
+        for &vcpu in &node.vcpu_indices {
+            if vcpu >= max_vcpus || !vcpus.insert(vcpu) {
+                return Err(Error::Config(ConfigError::InvalidNumaTopology(format!(
+                    "vCPU index {vcpu} is duplicated or outside 0..{max_vcpus}"
+                ))));
+            }
+        }
+
+        match &node.host_memory {
+            HostMemoryPolicy::Inherit => {}
+            HostMemoryPolicy::Bind { host_nodes } => {
+                if host_nodes.is_empty() {
+                    return Err(Error::Config(ConfigError::InvalidNumaTopology(
+                        "a bind policy requires at least one host node".into(),
+                    )));
+                }
+                if host_nodes
+                    .iter()
+                    .any(|&host_node| host_node > MAX_HOST_NUMA_NODE_ID)
+                {
+                    return Err(Error::Config(ConfigError::InvalidNumaTopology(format!(
+                        "host NUMA node IDs must not exceed {MAX_HOST_NUMA_NODE_ID}"
+                    ))));
+                }
+                #[cfg(not(target_os = "linux"))]
+                return Err(Error::Config(ConfigError::NumaUnsupported(
+                    "bound host memory requires Linux".into(),
+                )));
+            }
+            HostMemoryPolicy::Preferred { host_node } => {
+                if *host_node > MAX_HOST_NUMA_NODE_ID {
+                    return Err(Error::Config(ConfigError::InvalidNumaTopology(format!(
+                        "host NUMA node IDs must not exceed {MAX_HOST_NUMA_NODE_ID}"
+                    ))));
+                }
+                #[cfg(not(target_os = "windows"))]
+                return Err(Error::Config(ConfigError::NumaUnsupported(
+                    "preferred host memory requires Windows".into(),
+                )));
+            }
+        }
+    }
+
+    if vcpus.len() != usize::from(max_vcpus) || vcpus.iter().copied().ne(0..max_vcpus) {
+        return Err(Error::Config(ConfigError::InvalidNumaTopology(format!(
+            "vCPU membership must cover every index in 0..{max_vcpus} exactly once"
+        ))));
+    }
+    if boot_memory_mib != machine.memory_mib {
+        return Err(Error::Config(ConfigError::InvalidNumaTopology(format!(
+            "boot memory totals {boot_memory_mib} MiB, expected {} MiB",
+            machine.memory_mib
+        ))));
+    }
+    if maximum_memory_mib != max_memory_mib {
+        return Err(Error::Config(ConfigError::InvalidNumaTopology(format!(
+            "maximum memory totals {maximum_memory_mib} MiB, expected {max_memory_mib} MiB"
+        ))));
+    }
+
+    let node_count = topology.nodes.len();
+    let expected_distances = node_count.checked_mul(node_count).ok_or_else(|| {
+        Error::Config(ConfigError::InvalidNumaTopology(
+            "guest node count overflows the distance matrix".into(),
+        ))
+    })?;
+    if topology.distances.len() != expected_distances {
+        return Err(Error::Config(ConfigError::InvalidNumaTopology(
+            "distance entries must cover the full square matrix".into(),
+        )));
+    }
+    let mut distances = BTreeSet::new();
+    for distance in &topology.distances {
+        if usize::from(distance.from) >= node_count
+            || usize::from(distance.to) >= node_count
+            || !distances.insert((distance.from, distance.to))
+        {
+            return Err(Error::Config(ConfigError::InvalidNumaTopology(
+                "distance coordinates are duplicated or outside the guest node range".into(),
+            )));
+        }
+        if distance.from == distance.to && distance.value != 10 {
+            return Err(Error::Config(ConfigError::InvalidNumaTopology(
+                "local NUMA distance must equal 10".into(),
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Check that one exec env pair can be carried as a quoted `KEY="value"` kernel-cmdline word: printable ASCII only (the vmm cmdline layer rejects everything else, and the kernel
 /// would misparse it anyway), no double quotes (they would terminate the kernel's quote parsing mid-value), and no whitespace in the key (the kernel splits words on unquoted
 /// whitespace, so a spaced key silently becomes two parameters).
@@ -914,7 +1093,45 @@ mod tests {
     };
 
     use super::*;
-    use crate::api::builders::HostCpuId;
+    use crate::api::builders::{
+        HostCpuId, HostMemoryPolicy, NumaDistance, NumaNodeConfig, NumaTopology,
+    };
+
+    fn one_node_topology(vcpus: Vec<u8>, memory_mib: usize) -> NumaTopology {
+        NumaTopology {
+            nodes: vec![NumaNodeConfig {
+                guest_node_id: 0,
+                vcpu_indices: vcpus,
+                memory_mib,
+                max_memory_mib: memory_mib,
+                host_memory: HostMemoryPolicy::Inherit,
+            }],
+            distances: vec![NumaDistance {
+                from: 0,
+                to: 0,
+                value: 10,
+            }],
+        }
+    }
+
+    #[cfg(feature = "tee")]
+    #[test]
+    fn build_rejects_numa_topology_with_tee_memory() {
+        let err = VmBuilder::new()
+            .machine(|machine| {
+                machine
+                    .memory_mib(512)
+                    .numa_topology(one_node_topology(vec![0], 512))
+            })
+            .build()
+            .err()
+            .expect("TEE memory must not silently ignore host placement");
+
+        assert!(matches!(
+            err,
+            Error::Config(ConfigError::NumaUnsupported(_))
+        ));
+    }
 
     #[cfg(not(target_os = "windows"))]
     struct RejectDatagrams;
@@ -1101,6 +1318,181 @@ mod tests {
             }) => {}
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[cfg(not(feature = "tee"))]
+    #[test]
+    fn build_accepts_consistent_one_node_topology() {
+        VmBuilder::new()
+            .machine(|machine| {
+                machine
+                    .vcpus(2)
+                    .memory_mib(512)
+                    .numa_topology(one_node_topology(vec![0, 1], 512))
+            })
+            .build()
+            .expect("consistent one-node topology should build");
+    }
+
+    #[cfg(not(feature = "tee"))]
+    #[test]
+    fn build_rejects_incomplete_numa_vcpu_membership() {
+        let err = VmBuilder::new()
+            .machine(|machine| {
+                machine
+                    .vcpus(2)
+                    .memory_mib(512)
+                    .numa_topology(one_node_topology(vec![0], 512))
+            })
+            .build()
+            .err()
+            .expect("partial vCPU topology should fail");
+
+        assert!(matches!(
+            err,
+            Error::Config(ConfigError::InvalidNumaTopology(_))
+        ));
+    }
+
+    #[cfg(not(feature = "tee"))]
+    #[test]
+    fn build_rejects_numa_memory_total_mismatch() {
+        let err = VmBuilder::new()
+            .machine(|machine| {
+                machine
+                    .vcpus(1)
+                    .memory_mib(1024)
+                    .numa_topology(one_node_topology(vec![0], 512))
+            })
+            .build()
+            .err()
+            .expect("mismatched memory topology should fail");
+
+        assert!(matches!(
+            err,
+            Error::Config(ConfigError::InvalidNumaTopology(_))
+        ));
+    }
+
+    #[cfg(not(feature = "tee"))]
+    #[test]
+    fn build_accepts_one_node_live_memory_capacity() {
+        let mut topology = one_node_topology(vec![0, 1], 512);
+        topology.nodes[0].max_memory_mib = 1024;
+
+        VmBuilder::new()
+            .machine(|machine| {
+                machine
+                    .vcpus(2)
+                    .memory_mib(512)
+                    .max_memory_mib(1024)
+                    .numa_topology(topology)
+            })
+            .build()
+            .expect("one-node growth should retain the creation-time placement");
+    }
+
+    #[cfg(not(feature = "tee"))]
+    #[test]
+    fn build_rejects_excessive_host_numa_node_id() {
+        let mut topology = one_node_topology(vec![0], 512);
+        topology.nodes[0].host_memory = HostMemoryPolicy::Bind {
+            host_nodes: vec![u32::from(u16::MAX) + 1],
+        };
+        let err = VmBuilder::new()
+            .machine(|machine| machine.memory_mib(512).numa_topology(topology))
+            .build()
+            .err()
+            .expect("an excessive host node ID should fail before allocating a node mask");
+
+        assert!(matches!(
+            err,
+            Error::Config(ConfigError::InvalidNumaTopology(_))
+        ));
+    }
+
+    #[cfg(all(not(feature = "tee"), not(target_os = "windows")))]
+    #[test]
+    fn build_rejects_windows_preferred_memory_policy() {
+        let mut topology = one_node_topology(vec![0], 512);
+        topology.nodes[0].host_memory = HostMemoryPolicy::Preferred { host_node: 0 };
+        let err = VmBuilder::new()
+            .machine(|machine| machine.memory_mib(512).numa_topology(topology))
+            .build()
+            .err()
+            .expect("preferred-node backing is Windows-only");
+
+        assert!(matches!(
+            err,
+            Error::Config(ConfigError::NumaUnsupported(_))
+        ));
+    }
+
+    #[cfg(all(not(feature = "tee"), target_os = "windows"))]
+    #[test]
+    fn build_accepts_windows_preferred_memory_policy() {
+        let mut topology = one_node_topology(vec![0], 512);
+        topology.nodes[0].host_memory = HostMemoryPolicy::Preferred { host_node: 0 };
+
+        VmBuilder::new()
+            .machine(|machine| machine.memory_mib(512).numa_topology(topology))
+            .build()
+            .expect("Windows should accept preferred-node backing");
+    }
+
+    #[cfg(not(feature = "tee"))]
+    #[test]
+    fn build_rejects_multi_node_topology_until_guest_tables_land() {
+        let topology = NumaTopology {
+            nodes: vec![
+                NumaNodeConfig {
+                    guest_node_id: 0,
+                    vcpu_indices: vec![0],
+                    memory_mib: 256,
+                    max_memory_mib: 256,
+                    host_memory: HostMemoryPolicy::Inherit,
+                },
+                NumaNodeConfig {
+                    guest_node_id: 1,
+                    vcpu_indices: vec![1],
+                    memory_mib: 256,
+                    max_memory_mib: 256,
+                    host_memory: HostMemoryPolicy::Inherit,
+                },
+            ],
+            distances: vec![
+                NumaDistance {
+                    from: 0,
+                    to: 0,
+                    value: 10,
+                },
+                NumaDistance {
+                    from: 0,
+                    to: 1,
+                    value: 20,
+                },
+                NumaDistance {
+                    from: 1,
+                    to: 0,
+                    value: 20,
+                },
+                NumaDistance {
+                    from: 1,
+                    to: 1,
+                    value: 10,
+                },
+            ],
+        };
+        let err = VmBuilder::new()
+            .machine(|machine| machine.vcpus(2).memory_mib(512).numa_topology(topology))
+            .build()
+            .err()
+            .expect("multi-node topology should fail closed");
+
+        assert!(matches!(
+            err,
+            Error::Config(ConfigError::NumaUnsupported(_))
+        ));
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "windows")))]

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -1336,6 +1336,20 @@ mod tests {
 
     #[cfg(not(feature = "tee"))]
     #[test]
+    fn build_accepts_fluent_one_node_topology() {
+        VmBuilder::new()
+            .machine(|machine| {
+                machine
+                    .vcpus(2)
+                    .memory_mib(512)
+                    .numa(|numa| numa.node(|node| node.vcpus([0, 1]).memory_mib(512)))
+            })
+            .build()
+            .expect("the fluent builder should produce a valid resolved topology");
+    }
+
+    #[cfg(not(feature = "tee"))]
+    #[test]
     fn build_rejects_incomplete_numa_vcpu_membership() {
         let err = VmBuilder::new()
             .machine(|machine| {

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -995,9 +995,12 @@ fn validate_numa_topology_inner(
                         "host NUMA node IDs must not exceed {MAX_HOST_NUMA_NODE_ID}"
                     ))));
                 }
-                #[cfg(not(target_os = "linux"))]
+                #[cfg(not(all(
+                    target_os = "linux",
+                    any(target_arch = "x86_64", target_arch = "aarch64")
+                )))]
                 return Err(Error::Config(ConfigError::NumaUnsupported(
-                    "bound host memory requires Linux".into(),
+                    "bound host memory requires Linux on x86_64 or AArch64".into(),
                 )));
             }
             HostMemoryPolicy::Preferred { host_node } => {
@@ -1006,9 +1009,12 @@ fn validate_numa_topology_inner(
                         "host NUMA node IDs must not exceed {MAX_HOST_NUMA_NODE_ID}"
                     ))));
                 }
-                #[cfg(not(target_os = "windows"))]
+                #[cfg(not(all(
+                    target_os = "windows",
+                    any(target_arch = "x86_64", target_arch = "aarch64")
+                )))]
                 return Err(Error::Config(ConfigError::NumaUnsupported(
-                    "preferred host memory requires Windows".into(),
+                    "preferred host memory requires Windows on x86_64 or AArch64".into(),
                 )));
             }
         }
@@ -1422,6 +1428,26 @@ mod tests {
         assert!(matches!(
             err,
             Error::Config(ConfigError::InvalidNumaTopology(_))
+        ));
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "riscv64", not(feature = "tee")))]
+    #[test]
+    fn build_rejects_bound_numa_memory_on_riscv64() {
+        let mut topology = one_node_topology(vec![0], 512);
+        topology.nodes[0].host_memory = HostMemoryPolicy::Bind {
+            host_nodes: vec![0],
+        };
+
+        let error = VmBuilder::new()
+            .machine(|machine| machine.memory_mib(512).numa_topology(topology))
+            .build()
+            .err()
+            .expect("RISC-V must retain inherited memory placement");
+
+        assert!(matches!(
+            error,
+            Error::Config(ConfigError::NumaUnsupported(_))
         ));
     }
 

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -65,6 +65,25 @@ pub struct MachineBuilder {
     pub(crate) numa_topology: Option<NumaTopology>,
 }
 
+/// Builder for a resolved guest NUMA topology.
+///
+/// Guest node IDs are assigned by insertion order. Local distance entries are generated with the
+/// standard value `10`, so callers only need to provide non-local distances for multi-node guests.
+#[derive(Debug, Clone, Default)]
+pub struct NumaBuilder {
+    nodes: Vec<NumaNodeConfig>,
+    distances: Vec<NumaDistance>,
+}
+
+/// Builder for one guest NUMA node.
+#[derive(Debug, Clone)]
+pub struct NumaNodeBuilder {
+    vcpu_indices: Vec<u8>,
+    memory_mib: usize,
+    max_memory_mib: Option<usize>,
+    host_memory: HostMemoryPolicy,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Types: Vsock Builder
 //--------------------------------------------------------------------------------------------------
@@ -477,6 +496,35 @@ impl MachineBuilder {
         self
     }
 
+    /// Configure a resolved guest NUMA topology with the fluent API.
+    ///
+    /// Use [`numa_topology`](Self::numa_topology) when the caller already has a fully resolved
+    /// topology value.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use msb_krun::VmBuilder;
+    /// VmBuilder::new().machine(|machine| {
+    ///     machine
+    ///         .vcpus(2)
+    ///         .memory_mib(4096)
+    ///         .max_memory_mib(8192)
+    ///         .numa(|numa| {
+    ///             numa.node(|node| {
+    ///                 node.vcpus([0, 1])
+    ///                     .memory_mib(4096)
+    ///                     .max_memory_mib(8192)
+    ///                     .bind_host_nodes([0])
+    ///             })
+    ///         })
+    /// });
+    /// ```
+    pub fn numa(mut self, configure: impl FnOnce(NumaBuilder) -> NumaBuilder) -> Self {
+        self.numa_topology = Some(configure(NumaBuilder::new()).finish());
+        self
+    }
+
     /// Set the maximum guest memory in MiB reserved for future memory hotplug.
     ///
     /// Currently configuration plumbing only: capacity above
@@ -569,6 +617,129 @@ impl MachineBuilder {
     pub fn enable_inet_hijack(mut self, enabled: bool) -> Self {
         self.enable_inet_hijack = enabled;
         self
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods: NUMA Builder
+//--------------------------------------------------------------------------------------------------
+
+impl NumaBuilder {
+    /// Create an empty resolved topology builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add one guest node. Its dense guest node ID is its insertion index.
+    pub fn node(mut self, configure: impl FnOnce(NumaNodeBuilder) -> NumaNodeBuilder) -> Self {
+        let guest_node_id = u16::try_from(self.nodes.len()).unwrap_or(u16::MAX);
+        self.nodes
+            .push(configure(NumaNodeBuilder::new()).finish(guest_node_id));
+        self
+    }
+
+    /// Set one directed non-local guest distance.
+    ///
+    /// Local entries are generated automatically with value `10`. A later call for the same pair
+    /// replaces the earlier value.
+    pub fn distance(mut self, from: u16, to: u16, value: u8) -> Self {
+        if let Some(distance) = self
+            .distances
+            .iter_mut()
+            .find(|distance| distance.from == from && distance.to == to)
+        {
+            distance.value = value;
+        } else {
+            self.distances.push(NumaDistance { from, to, value });
+        }
+        self
+    }
+
+    fn finish(mut self) -> NumaTopology {
+        for node in &self.nodes {
+            if !self.distances.iter().any(|distance| {
+                distance.from == node.guest_node_id && distance.to == node.guest_node_id
+            }) {
+                self.distances.push(NumaDistance {
+                    from: node.guest_node_id,
+                    to: node.guest_node_id,
+                    value: 10,
+                });
+            }
+        }
+
+        NumaTopology {
+            nodes: self.nodes,
+            distances: self.distances,
+        }
+    }
+}
+
+impl NumaNodeBuilder {
+    /// Create an empty guest node with inherited host-memory placement.
+    pub fn new() -> Self {
+        Self {
+            vcpu_indices: Vec::new(),
+            memory_mib: 0,
+            max_memory_mib: None,
+            host_memory: HostMemoryPolicy::Inherit,
+        }
+    }
+
+    /// Assign the possible vCPU indices belonging to this guest node.
+    pub fn vcpus(mut self, indices: impl IntoIterator<Item = u8>) -> Self {
+        self.vcpu_indices = indices.into_iter().collect();
+        self
+    }
+
+    /// Set the memory available on this node at boot, in MiB.
+    pub fn memory_mib(mut self, mib: usize) -> Self {
+        self.memory_mib = mib;
+        self
+    }
+
+    /// Set the maximum memory promised to this node after live growth, in MiB.
+    ///
+    /// This defaults to the node's boot memory.
+    pub fn max_memory_mib(mut self, mib: usize) -> Self {
+        self.max_memory_mib = Some(mib);
+        self
+    }
+
+    /// Preserve the operating system's ordinary host-memory policy.
+    pub fn inherit_host_memory(mut self) -> Self {
+        self.host_memory = HostMemoryPolicy::Inherit;
+        self
+    }
+
+    /// Bind future Linux page faults to the selected absolute host NUMA node IDs.
+    pub fn bind_host_nodes(mut self, nodes: impl IntoIterator<Item = u32>) -> Self {
+        self.host_memory = HostMemoryPolicy::Bind {
+            host_nodes: nodes.into_iter().collect(),
+        };
+        self
+    }
+
+    /// Prefer one Windows NUMA node while allowing the host to fall back under pressure.
+    pub fn prefer_host_node(mut self, node: u32) -> Self {
+        self.host_memory = HostMemoryPolicy::Preferred { host_node: node };
+        self
+    }
+
+    /// Set an already resolved host-memory policy.
+    pub fn host_memory(mut self, policy: HostMemoryPolicy) -> Self {
+        self.host_memory = policy;
+        self
+    }
+
+    fn finish(self, guest_node_id: u16) -> NumaNodeConfig {
+        NumaNodeConfig {
+            guest_node_id,
+            vcpu_indices: self.vcpu_indices,
+            memory_mib: self.memory_mib,
+            max_memory_mib: self.max_memory_mib.unwrap_or(self.memory_mib),
+            host_memory: self.host_memory,
+        }
     }
 }
 
@@ -1192,8 +1363,14 @@ impl DiskBuilder {
 }
 
 //--------------------------------------------------------------------------------------------------
-// Trait Implementations: Disk Builder
+// Trait Implementations: Builders
 //--------------------------------------------------------------------------------------------------
+
+impl Default for NumaNodeBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(feature = "blk")]
 impl Default for DiskBuilder {
@@ -1256,6 +1433,50 @@ mod tests {
             .vcpu_affinity(affinity.clone());
 
         assert_eq!(builder.vcpu_affinity, Some(affinity));
+    }
+
+    #[test]
+    fn machine_builder_resolves_fluent_numa_topology() {
+        let topology = MachineBuilder::new()
+            .numa(|numa| {
+                numa.node(|node| {
+                    node.vcpus([0, 1])
+                        .memory_mib(4096)
+                        .max_memory_mib(8192)
+                        .bind_host_nodes([2, 3])
+                })
+            })
+            .numa_topology
+            .unwrap();
+
+        assert_eq!(
+            topology,
+            NumaTopology {
+                nodes: vec![NumaNodeConfig {
+                    guest_node_id: 0,
+                    vcpu_indices: vec![0, 1],
+                    memory_mib: 4096,
+                    max_memory_mib: 8192,
+                    host_memory: HostMemoryPolicy::Bind {
+                        host_nodes: vec![2, 3],
+                    },
+                }],
+                distances: vec![NumaDistance {
+                    from: 0,
+                    to: 0,
+                    value: 10,
+                }],
+            }
+        );
+    }
+
+    #[test]
+    fn numa_node_max_memory_defaults_to_boot_memory() {
+        let topology = NumaBuilder::new()
+            .node(|node| node.vcpus([0]).memory_mib(512))
+            .finish();
+
+        assert_eq!(topology.nodes[0].max_memory_mib, 512);
     }
 
     #[test]

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -8,6 +8,7 @@ use devices::virtio::console::port_io::{
     ConsolePortBackend, ConsolePortBackendInputAdapter, ConsolePortBackendOutputAdapter,
 };
 use vmm::resources::PortConfig;
+pub use vmm::resources::{HostMemoryPolicy, NumaDistance, NumaNodeConfig, NumaTopology};
 pub use vmm::vmm_config::machine_config::HostCpuId;
 
 #[cfg(feature = "blk")]
@@ -61,6 +62,7 @@ pub struct MachineBuilder {
     pub(crate) msb_metrics: bool,
     pub(crate) enable_inet_hijack: bool,
     pub(crate) vcpu_affinity: Option<Vec<HostCpuId>>,
+    pub(crate) numa_topology: Option<NumaTopology>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -429,6 +431,7 @@ impl MachineBuilder {
             msb_metrics: true,
             enable_inet_hijack: false,
             vcpu_affinity: None,
+            numa_topology: None,
         }
     }
 
@@ -461,6 +464,16 @@ impl MachineBuilder {
     /// with [`max_vcpus`](Self::max_vcpus). This is supported on Linux and Windows hosts.
     pub fn vcpu_affinity(mut self, affinity: Vec<HostCpuId>) -> Self {
         self.vcpu_affinity = Some(affinity);
+        self
+    }
+
+    /// Supply a resolved guest NUMA topology and host-memory policy.
+    ///
+    /// Guest node IDs, vCPU membership, memory totals and distances are validated by
+    /// [`VmBuilder::build`](crate::VmBuilder::build). Omitting this option retains the ordinary
+    /// guest-memory construction path.
+    pub fn numa_topology(mut self, topology: NumaTopology) -> Self {
+        self.numa_topology = Some(topology);
         self
     }
 

--- a/src/krun/src/api/error.rs
+++ b/src/krun/src/api/error.rs
@@ -51,6 +51,12 @@ pub enum ConfigError {
     /// The selected host processor group is not supported on the current platform.
     InvalidHostCpuGroup(u16),
 
+    /// The resolved NUMA topology is internally inconsistent.
+    InvalidNumaTopology(String),
+
+    /// The requested resolved NUMA topology cannot be realized by this build or host.
+    NumaUnsupported(String),
+
     /// Missing kernel configuration.
     MissingKernel,
 
@@ -142,6 +148,12 @@ impl fmt::Display for ConfigError {
             }
             ConfigError::InvalidHostCpuGroup(group) => {
                 write!(f, "host processor group {group} is not supported")
+            }
+            ConfigError::InvalidNumaTopology(reason) => {
+                write!(f, "invalid NUMA topology: {reason}")
+            }
+            ConfigError::NumaUnsupported(reason) => {
+                write!(f, "NUMA topology is unsupported: {reason}")
             }
             ConfigError::MissingKernel => write!(f, "missing kernel configuration"),
             ConfigError::InvalidKernelBundle(s) => write!(f, "invalid kernel bundle: {}", s),

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -52,7 +52,7 @@ pub use builders::VsockBuilder;
 pub use builders::WritebackLimit;
 pub use builders::{
     ConsoleBuilder, ExecBuilder, HostCpuId, HostMemoryPolicy, KernelBuilder, MachineBuilder,
-    NumaDistance, NumaNodeConfig, NumaTopology,
+    NumaBuilder, NumaDistance, NumaNodeBuilder, NumaNodeConfig, NumaTopology,
 };
 pub use error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use exit_handle::ExitHandle;

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -50,7 +50,10 @@ pub use builders::NetBuilder;
 pub use builders::VsockBuilder;
 #[cfg(feature = "blk")]
 pub use builders::WritebackLimit;
-pub use builders::{ConsoleBuilder, ExecBuilder, HostCpuId, KernelBuilder, MachineBuilder};
+pub use builders::{
+    ConsoleBuilder, ExecBuilder, HostCpuId, HostMemoryPolicy, KernelBuilder, MachineBuilder,
+    NumaDistance, NumaNodeConfig, NumaTopology,
+};
 pub use error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use exit_handle::ExitHandle;
 pub use metrics::{

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -54,7 +54,7 @@ pub use api::builders::VsockBuilder;
 pub use api::builders::WritebackLimit;
 pub use api::builders::{
     ConsoleBuilder, ExecBuilder, HostCpuId, HostMemoryPolicy, KernelBuilder, MachineBuilder,
-    NumaDistance, NumaNodeConfig, NumaTopology,
+    NumaBuilder, NumaDistance, NumaNodeBuilder, NumaNodeConfig, NumaTopology,
 };
 pub use api::error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use api::exit_handle::ExitHandle;

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -52,7 +52,10 @@ pub use api::builders::SyncMode;
 pub use api::builders::VsockBuilder;
 #[cfg(feature = "blk")]
 pub use api::builders::WritebackLimit;
-pub use api::builders::{ConsoleBuilder, ExecBuilder, HostCpuId, KernelBuilder, MachineBuilder};
+pub use api::builders::{
+    ConsoleBuilder, ExecBuilder, HostCpuId, HostMemoryPolicy, KernelBuilder, MachineBuilder,
+    NumaDistance, NumaNodeConfig, NumaTopology,
+};
 pub use api::error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use api::exit_handle::ExitHandle;
 pub use api::metrics::{

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -43,7 +43,7 @@ kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"
 aws-nitro = { package = "msb_krun_aws_nitro", path = "../aws_nitro", optional = true }
 nitro-enclaves = { version = "0.5.0", optional = true }
-vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
+vm-memory = { package = "msb-vm-memory", version = "=0.18.0-msb.1", default-features = false, features = ["backend-mmap"] }
 
 [lib]
 name = "krun"

--- a/src/smbios/Cargo.toml
+++ b/src/smbios/Cargo.toml
@@ -7,4 +7,4 @@ description = "SMBIOS table generation for msb_krun microVMs"
 repository = "https://github.com/containers/libkrun"
 
 [dependencies]
-vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
+vm-memory = { package = "msb-vm-memory", version = "=0.18.0-msb.1", default-features = false, features = ["backend-mmap"] }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -25,7 +25,7 @@ flate2 = "1.0.35"
 libc = ">=0.2.39"
 log = "0.4.0"
 nix = { version = "0.30.1", features = ["fs", "term"] }
-vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
+vm-memory = { package = "msb-vm-memory", version = "=0.18.0-msb.1", default-features = false, features = ["backend-mmap"] }
 krun_display = { package = "msb_krun_display", version = "0.1.28", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
 krun_input = { package = "msb_krun_input", version = "0.1.28", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -4374,7 +4374,10 @@ pub mod tests {
             .find(|line| line.starts_with(&address))
             .expect("the anonymous mapping should appear in numa_maps");
 
-        assert!(entry.contains("bind:0"), "unexpected policy: {entry}");
+        assert!(
+            entry.contains("bind=static:0"),
+            "unexpected policy: {entry}"
+        );
         assert!(
             entry.contains("N0="),
             "the faulted page is not on node 0: {entry}"

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -130,10 +130,12 @@ use polly::event_manager::{Error as EventManagerError, EventManager};
 use utils::eventfd::EventFd;
 use utils::worker_message::WorkerMessage;
 #[cfg(all(
-    target_arch = "x86_64",
-    not(feature = "efi"),
     not(feature = "tee"),
-    not(target_os = "windows")
+    any(
+        target_os = "linux",
+        target_os = "windows",
+        all(target_arch = "x86_64", not(target_os = "windows"))
+    )
 ))]
 use vm_memory::mmap::MmapRegion;
 #[cfg(not(feature = "tee"))]
@@ -141,9 +143,12 @@ use vm_memory::Address;
 use vm_memory::Bytes;
 use vm_memory::GuestMemoryBackend;
 #[cfg(all(
-    target_arch = "x86_64",
     not(feature = "tee"),
-    not(target_os = "windows")
+    any(
+        target_os = "linux",
+        target_os = "windows",
+        all(target_arch = "x86_64", not(target_os = "windows"))
+    )
 ))]
 use vm_memory::GuestRegionMmap;
 use vm_memory::{GuestAddress, GuestMemoryMmap};
@@ -179,6 +184,8 @@ pub enum StartMicrovmError {
     FirmwareRead(io::Error),
     /// Memory regions are overlapping or mmap fails.
     GuestMemoryMmapFromRanges(vm_memory::mmap::FromRangesError),
+    /// Applying a requested host memory policy failed before the guest touched the mapping.
+    HostMemoryPolicy(io::Error),
     /// Guest memory collection operation failed.
     GuestMemoryMmap(vm_memory::GuestMemoryError),
     /// Guest memory region construction failed.
@@ -394,6 +401,9 @@ impl Display for StartMicrovmError {
                 let mut err_msg = format!("{err:?}");
                 err_msg = err_msg.replace('\"', "");
                 write!(f, "Invalid Memory Configuration: {err_msg}")
+            }
+            HostMemoryPolicy(ref err) => {
+                write!(f, "Cannot apply host memory policy: {err}")
             }
             ImageBz2Decoder(ref err) => {
                 write!(f, "The BZIP2 decoder couldn't decompress the kernel. {err}")
@@ -2547,6 +2557,12 @@ pub fn create_guest_memory(
         }
     };
 
+    // Architecture regions are ordinary guest RAM. Shared filesystem/GPU windows added below must
+    // retain their legacy host policy, while a later virtio-mem range must follow guest RAM so live
+    // growth stays on the placement selected at VM creation.
+    #[cfg(not(feature = "tee"))]
+    let mut numa_managed_regions = vec![true; arch_mem_regions.len()];
+
     let mut shm_manager = ShmManager::new(&arch_mem_info);
 
     #[cfg(not(feature = "tee"))]
@@ -2575,7 +2591,10 @@ pub fn create_guest_memory(
             .map_err(StartMicrovmError::ShmCreate)?;
     }
 
-    arch_mem_regions.extend(shm_manager.regions());
+    let shared_regions = shm_manager.regions();
+    #[cfg(not(feature = "tee"))]
+    numa_managed_regions.resize(numa_managed_regions.len() + shared_regions.len(), false);
+    arch_mem_regions.extend(shared_regions);
 
     // Reserve the virtio-mem hotplug region above every other window. The
     // backing is anonymous and lazily faulted, so unplugged capacity costs no
@@ -2600,9 +2619,18 @@ pub fn create_guest_memory(
                 .set_region(base, hotplug_bytes)
                 .expect("hotplug region is block-aligned by construction");
             arch_mem_regions.push((GuestAddress(base), hotplug_bytes as usize));
+            numa_managed_regions.push(true);
         }
     }
 
+    #[cfg(not(feature = "tee"))]
+    let guest_mem = if let Some(topology) = &vm_resources.numa_topology {
+        create_numa_guest_memory(&arch_mem_regions, &numa_managed_regions, topology)?
+    } else {
+        GuestMemoryMmap::from_ranges(&arch_mem_regions)
+            .map_err(StartMicrovmError::GuestMemoryMmapFromRanges)?
+    };
+    #[cfg(feature = "tee")]
     let guest_mem = GuestMemoryMmap::from_ranges(&arch_mem_regions)
         .map_err(StartMicrovmError::GuestMemoryMmapFromRanges)?;
 
@@ -2632,6 +2660,178 @@ pub fn create_guest_memory(
     };
 
     Ok((guest_mem, arch_mem_info, shm_manager, payload_config))
+}
+
+#[cfg(all(target_os = "linux", not(feature = "tee")))]
+fn create_numa_guest_memory(
+    ranges: &[(GuestAddress, usize)],
+    numa_managed_regions: &[bool],
+    topology: &crate::resources::NumaTopology,
+) -> std::result::Result<GuestMemoryMmap, StartMicrovmError> {
+    debug_assert_eq!(ranges.len(), numa_managed_regions.len());
+    let mut regions = Vec::with_capacity(ranges.len());
+
+    for (&(guest_address, size), &numa_managed) in ranges.iter().zip(numa_managed_regions.iter()) {
+        let mapping = MmapRegion::new(size).map_err(|error| {
+            StartMicrovmError::GuestMemoryMmapFromRanges(
+                vm_memory::mmap::FromRangesError::MmapRegion(error),
+            )
+        })?;
+
+        // `MmapRegion::new` uses MAP_NORESERVE and has not touched the mapping. Installing the
+        // VMA policy here means payload writes below are its first page faults; there is nothing to
+        // prefault or migrate and the cold-start path remains lazy.
+        if let Some(policy) = numa_policy_for_region(numa_managed, topology) {
+            match policy {
+                crate::resources::HostMemoryPolicy::Bind { host_nodes } => {
+                    apply_linux_memory_binding(mapping.as_ptr(), mapping.size(), host_nodes)
+                        .map_err(StartMicrovmError::HostMemoryPolicy)?;
+                }
+                crate::resources::HostMemoryPolicy::Inherit => {}
+                crate::resources::HostMemoryPolicy::Preferred { .. } => {
+                    return Err(StartMicrovmError::HostMemoryPolicy(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        "preferred host memory is unavailable on Linux",
+                    )));
+                }
+            }
+        }
+
+        regions.push(
+            GuestRegionMmap::new(mapping, guest_address)
+                .ok_or(StartMicrovmError::GuestMemoryRegion)?,
+        );
+    }
+
+    GuestMemoryMmap::from_regions(regions).map_err(StartMicrovmError::GuestMemoryRegionCollection)
+}
+
+#[cfg(all(target_os = "windows", not(feature = "tee")))]
+fn create_numa_guest_memory(
+    ranges: &[(GuestAddress, usize)],
+    numa_managed_regions: &[bool],
+    topology: &crate::resources::NumaTopology,
+) -> std::result::Result<GuestMemoryMmap, StartMicrovmError> {
+    debug_assert_eq!(ranges.len(), numa_managed_regions.len());
+    let mut regions = Vec::with_capacity(ranges.len());
+
+    for (&(guest_address, size), &numa_managed) in ranges.iter().zip(numa_managed_regions.iter()) {
+        let mapping = if let Some(policy) = numa_policy_for_region(numa_managed, topology) {
+            match policy {
+                crate::resources::HostMemoryPolicy::Preferred { host_node } => {
+                    MmapRegion::new_on_numa_node(size, *host_node)
+                        .map_err(StartMicrovmError::HostMemoryPolicy)?
+                }
+                crate::resources::HostMemoryPolicy::Inherit => {
+                    MmapRegion::new(size).map_err(|error| {
+                        StartMicrovmError::GuestMemoryMmapFromRanges(
+                            vm_memory::mmap::FromRangesError::MmapRegion(error),
+                        )
+                    })?
+                }
+                crate::resources::HostMemoryPolicy::Bind { .. } => {
+                    return Err(StartMicrovmError::HostMemoryPolicy(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        "bound host memory is unavailable on Windows",
+                    )));
+                }
+            }
+        } else {
+            MmapRegion::new(size).map_err(|error| {
+                StartMicrovmError::GuestMemoryMmapFromRanges(
+                    vm_memory::mmap::FromRangesError::MmapRegion(error),
+                )
+            })?
+        };
+
+        regions.push(
+            GuestRegionMmap::new(mapping, guest_address)
+                .ok_or(StartMicrovmError::GuestMemoryRegion)?,
+        );
+    }
+
+    GuestMemoryMmap::from_regions(regions).map_err(StartMicrovmError::GuestMemoryRegionCollection)
+}
+
+#[cfg(all(not(feature = "tee"), any(target_os = "linux", target_os = "windows")))]
+fn numa_policy_for_region(
+    numa_managed: bool,
+    topology: &crate::resources::NumaTopology,
+) -> Option<&crate::resources::HostMemoryPolicy> {
+    numa_managed.then(|| &topology.nodes[0].host_memory)
+}
+
+#[cfg(all(
+    not(any(target_os = "linux", target_os = "windows")),
+    not(feature = "tee")
+))]
+fn create_numa_guest_memory(
+    ranges: &[(GuestAddress, usize)],
+    _numa_managed_regions: &[bool],
+    _topology: &crate::resources::NumaTopology,
+) -> std::result::Result<GuestMemoryMmap, StartMicrovmError> {
+    // Validation permits only inherited one-node topology on hosts without a backing hook. This is
+    // the explicit no-op profile; managed policies are rejected before VM resources are built.
+    GuestMemoryMmap::from_ranges(ranges).map_err(StartMicrovmError::GuestMemoryMmapFromRanges)
+}
+
+#[cfg(all(target_os = "linux", not(feature = "tee")))]
+fn apply_linux_memory_binding(
+    address: *mut u8,
+    length: usize,
+    host_nodes: &[u32],
+) -> io::Result<()> {
+    const MPOL_BIND: libc::c_int = 2;
+    const MPOL_F_STATIC_NODES: libc::c_int = 1 << 15;
+
+    let (node_mask, max_node_bits) = linux_node_mask(host_nodes)?;
+
+    // Supplying a whole-word bit count avoids the historical maxnode edge case at exact word
+    // boundaries. The static-node mode preserves the absolute host-node IDs resolved by the
+    // embedding runtime even when the caller has a restricted cpuset.
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_mbind,
+            address.cast::<libc::c_void>(),
+            length,
+            MPOL_BIND | MPOL_F_STATIC_NODES,
+            node_mask.as_ptr(),
+            max_node_bits,
+            0,
+        )
+    };
+    if result < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(all(target_os = "linux", not(feature = "tee")))]
+fn linux_node_mask(host_nodes: &[u32]) -> io::Result<(Vec<libc::c_ulong>, usize)> {
+    const MAX_HOST_NUMA_NODE_ID: u32 = u16::MAX as u32;
+
+    let highest_node = host_nodes
+        .iter()
+        .copied()
+        .max()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "empty NUMA node mask"))?;
+    if highest_node > MAX_HOST_NUMA_NODE_ID {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("host NUMA node IDs must not exceed {MAX_HOST_NUMA_NODE_ID}"),
+        ));
+    }
+
+    let bits_per_word = libc::c_ulong::BITS as usize;
+    let mut node_mask = vec![0 as libc::c_ulong; highest_node as usize / bits_per_word + 1];
+    for &node in host_nodes {
+        let node = node as usize;
+        node_mask[node / bits_per_word] |= (1 as libc::c_ulong) << (node % bits_per_word);
+    }
+
+    let max_node_bits = node_mask.len() * bits_per_word;
+    Ok((node_mask, max_node_bits))
 }
 
 #[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
@@ -4108,6 +4308,78 @@ pub mod tests {
     use super::*;
     #[cfg(not(target_os = "windows"))]
     use crate::vmm_config::kernel_bundle::KernelBundle;
+
+    #[cfg(all(not(feature = "tee"), any(target_os = "linux", target_os = "windows")))]
+    use crate::resources::{HostMemoryPolicy, NumaDistance, NumaNodeConfig, NumaTopology};
+
+    #[cfg(all(not(feature = "tee"), any(target_os = "linux", target_os = "windows")))]
+    fn one_node_numa_topology(host_memory: HostMemoryPolicy) -> NumaTopology {
+        NumaTopology {
+            nodes: vec![NumaNodeConfig {
+                guest_node_id: 0,
+                vcpu_indices: vec![0],
+                memory_mib: 128,
+                max_memory_mib: 128,
+                host_memory,
+            }],
+            distances: vec![NumaDistance {
+                from: 0,
+                to: 0,
+                value: 10,
+            }],
+        }
+    }
+
+    #[cfg(all(not(feature = "tee"), any(target_os = "linux", target_os = "windows")))]
+    #[test]
+    fn numa_policy_applies_only_to_managed_ram() {
+        let topology = one_node_numa_topology(HostMemoryPolicy::Inherit);
+
+        assert!(numa_policy_for_region(true, &topology).is_some());
+        assert!(numa_policy_for_region(false, &topology).is_none());
+    }
+
+    #[cfg(all(target_os = "linux", not(feature = "tee")))]
+    #[test]
+    fn linux_node_mask_uses_absolute_node_bits() {
+        let (mask, max_node_bits) = linux_node_mask(&[0, 65]).unwrap();
+
+        assert_eq!(max_node_bits, 2 * libc::c_ulong::BITS as usize);
+        assert_eq!(mask[0] & 1, 1);
+        assert_eq!(mask[1] & 2, 2);
+    }
+
+    #[cfg(all(target_os = "linux", not(feature = "tee")))]
+    #[test]
+    fn linux_node_mask_rejects_unbounded_node_ids() {
+        let error = linux_node_mask(&[u32::from(u16::MAX) + 1]).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[cfg(all(target_os = "linux", not(feature = "tee")))]
+    #[test]
+    #[ignore = "requires a native Linux host that permits NUMA policy syscalls"]
+    fn linux_numa_binding_reaches_faulted_pages() {
+        let mapping = MmapRegion::<()>::new(2 * 1024 * 1024).unwrap();
+        apply_linux_memory_binding(mapping.as_ptr(), mapping.size(), &[0]).unwrap();
+
+        // Fault one page only after the VMA policy is installed, matching the guest boot path.
+        unsafe { mapping.as_ptr().write_volatile(0x5a) };
+
+        let address = format!("{:x}", mapping.as_ptr() as usize);
+        let numa_maps = std::fs::read_to_string("/proc/self/numa_maps").unwrap();
+        let entry = numa_maps
+            .lines()
+            .find(|line| line.starts_with(&address))
+            .expect("the anonymous mapping should appear in numa_maps");
+
+        assert!(entry.contains("bind:0"), "unexpected policy: {entry}");
+        assert!(
+            entry.contains("N0="),
+            "the faulted page is not on node 0: {entry}"
+        );
+    }
 
     #[test]
     #[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -2675,7 +2675,7 @@ pub fn create_guest_memory(
 
 fn validate_vmm_numa_topology(
     vm_resources: &VmResources,
-    requested_memory_mib: usize,
+    _requested_memory_mib: usize,
 ) -> Result<(), StartMicrovmError> {
     if vm_resources.numa_topology.is_none() {
         return Ok(());
@@ -2707,9 +2707,9 @@ fn validate_vmm_numa_topology(
         let max_memory_mib = vm_config.max_mem_size_mib.unwrap_or(boot_memory_mib);
         let node = &topology.nodes[0];
 
-        if requested_memory_mib != boot_memory_mib {
+        if _requested_memory_mib != boot_memory_mib {
             return Err(StartMicrovmError::InvalidNumaTopology(format!(
-                "guest-memory request is {requested_memory_mib} MiB, expected {boot_memory_mib} MiB from VmResources"
+                "guest-memory request is {_requested_memory_mib} MiB, expected {boot_memory_mib} MiB from VmResources"
             )));
         }
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -4339,6 +4339,17 @@ pub mod tests {
         assert!(numa_policy_for_region(false, &topology).is_none());
     }
 
+    #[cfg(all(target_os = "windows", not(feature = "tee")))]
+    #[test]
+    fn windows_numa_mapping_allocates_accessible_memory() {
+        let mapping = MmapRegion::<()>::new_on_numa_node(2 * 1024 * 1024, 0).unwrap();
+
+        unsafe {
+            mapping.as_ptr().write_volatile(0x5a);
+            assert_eq!(mapping.as_ptr().read_volatile(), 0x5a);
+        }
+    }
+
     #[cfg(all(target_os = "linux", not(feature = "tee")))]
     #[test]
     fn linux_node_mask_uses_absolute_node_bits() {

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -7,6 +7,8 @@
 use crossbeam_channel::unbounded;
 use crossbeam_channel::Sender;
 use kernel::cmdline::Cmdline;
+#[cfg(not(feature = "tee"))]
+use std::collections::BTreeSet;
 #[cfg(target_os = "macos")]
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
@@ -186,6 +188,8 @@ pub enum StartMicrovmError {
     GuestMemoryMmapFromRanges(vm_memory::mmap::FromRangesError),
     /// Applying a requested host memory policy failed before the guest touched the mapping.
     HostMemoryPolicy(io::Error),
+    /// A low-level VMM caller supplied an invalid or unsupported NUMA topology.
+    InvalidNumaTopology(String),
     /// Guest memory collection operation failed.
     GuestMemoryMmap(vm_memory::GuestMemoryError),
     /// Guest memory region construction failed.
@@ -404,6 +408,9 @@ impl Display for StartMicrovmError {
             }
             HostMemoryPolicy(ref err) => {
                 write!(f, "Cannot apply host memory policy: {err}")
+            }
+            InvalidNumaTopology(ref reason) => {
+                write!(f, "Invalid NUMA topology: {reason}")
             }
             ImageBz2Decoder(ref err) => {
                 write!(f, "The BZIP2 decoder couldn't decompress the kernel. {err}")
@@ -2485,6 +2492,10 @@ pub fn create_guest_memory(
     (GuestMemoryMmap, ArchMemoryInfo, ShmManager, PayloadConfig),
     StartMicrovmError,
 > {
+    // `VmResources` is also a public low-level VMM interface, so do not rely exclusively on the
+    // higher-level `msb_krun` builder having validated this placement contract.
+    validate_vmm_numa_topology(vm_resources, mem_size)?;
+
     let mem_size = mem_size << 20;
 
     #[cfg(not(feature = "efi"))]
@@ -2660,6 +2671,142 @@ pub fn create_guest_memory(
     };
 
     Ok((guest_mem, arch_mem_info, shm_manager, payload_config))
+}
+
+fn validate_vmm_numa_topology(
+    vm_resources: &VmResources,
+    requested_memory_mib: usize,
+) -> Result<(), StartMicrovmError> {
+    if vm_resources.numa_topology.is_none() {
+        return Ok(());
+    }
+
+    // Confidential-memory backends use a separate allocator and must not silently ignore a policy
+    // attached through the public low-level `VmResources` API.
+    #[cfg(feature = "tee")]
+    return Err(StartMicrovmError::InvalidNumaTopology(
+        "host memory placement is unavailable with TEE memory".into(),
+    ));
+
+    #[cfg(not(feature = "tee"))]
+    {
+        let topology = vm_resources
+            .numa_topology
+            .as_ref()
+            .expect("the topology was checked above");
+        if topology.nodes.len() != 1 {
+            return Err(StartMicrovmError::InvalidNumaTopology(
+                "exactly one guest node is supported until guest NUMA tables are enabled".into(),
+            ));
+        }
+
+        let vm_config = vm_resources.vm_config();
+        let vcpu_count = vm_config.vcpu_count.unwrap_or(1);
+        let max_vcpus = vm_config.max_vcpu_count.unwrap_or(vcpu_count);
+        let boot_memory_mib = vm_config.mem_size_mib.unwrap_or(128);
+        let max_memory_mib = vm_config.max_mem_size_mib.unwrap_or(boot_memory_mib);
+        let node = &topology.nodes[0];
+
+        if requested_memory_mib != boot_memory_mib {
+            return Err(StartMicrovmError::InvalidNumaTopology(format!(
+                "guest-memory request is {requested_memory_mib} MiB, expected {boot_memory_mib} MiB from VmResources"
+            )));
+        }
+
+        if node.guest_node_id != 0 {
+            return Err(StartMicrovmError::InvalidNumaTopology(
+                "the one supported guest node must have ID zero".into(),
+            ));
+        }
+        if node.max_memory_mib < node.memory_mib {
+            return Err(StartMicrovmError::InvalidNumaTopology(
+                "node maximum memory is below boot memory".into(),
+            ));
+        }
+        if node.memory_mib & 1 != 0 || node.max_memory_mib & 1 != 0 {
+            return Err(StartMicrovmError::InvalidNumaTopology(
+                "node memory must be aligned to 2 MiB".into(),
+            ));
+        }
+        if node.memory_mib != boot_memory_mib || node.max_memory_mib != max_memory_mib {
+            return Err(StartMicrovmError::InvalidNumaTopology(format!(
+                "node memory is {}/{} MiB, expected {boot_memory_mib}/{max_memory_mib} MiB",
+                node.memory_mib, node.max_memory_mib
+            )));
+        }
+
+        let mut vcpus = BTreeSet::new();
+        for &vcpu in &node.vcpu_indices {
+            if vcpu >= max_vcpus || !vcpus.insert(vcpu) {
+                return Err(StartMicrovmError::InvalidNumaTopology(format!(
+                    "vCPU index {vcpu} is duplicated or outside 0..{max_vcpus}"
+                )));
+            }
+        }
+        if vcpus.len() != usize::from(max_vcpus) || vcpus.iter().copied().ne(0..max_vcpus) {
+            return Err(StartMicrovmError::InvalidNumaTopology(format!(
+                "vCPU membership must cover every index in 0..{max_vcpus} exactly once"
+            )));
+        }
+
+        match &node.host_memory {
+            crate::resources::HostMemoryPolicy::Inherit => {}
+            crate::resources::HostMemoryPolicy::Bind { host_nodes } => {
+                if host_nodes.is_empty() {
+                    return Err(StartMicrovmError::InvalidNumaTopology(
+                        "a bind policy requires at least one host node".into(),
+                    ));
+                }
+                if host_nodes
+                    .iter()
+                    .any(|&host_node| host_node > u16::MAX.into())
+                {
+                    return Err(StartMicrovmError::InvalidNumaTopology(format!(
+                        "host NUMA node IDs must not exceed {}",
+                        u16::MAX
+                    )));
+                }
+                if !cfg!(all(
+                    target_os = "linux",
+                    any(target_arch = "x86_64", target_arch = "aarch64")
+                )) {
+                    return Err(StartMicrovmError::InvalidNumaTopology(
+                        "bound host memory requires Linux on x86_64 or AArch64".into(),
+                    ));
+                }
+            }
+            crate::resources::HostMemoryPolicy::Preferred { host_node } => {
+                if *host_node > u16::MAX.into() {
+                    return Err(StartMicrovmError::InvalidNumaTopology(format!(
+                        "host NUMA node IDs must not exceed {}",
+                        u16::MAX
+                    )));
+                }
+                if !cfg!(all(
+                    target_os = "windows",
+                    any(target_arch = "x86_64", target_arch = "aarch64")
+                )) {
+                    return Err(StartMicrovmError::InvalidNumaTopology(
+                        "preferred host memory requires Windows on x86_64 or AArch64".into(),
+                    ));
+                }
+            }
+        }
+
+        if topology.distances.len() != 1 {
+            return Err(StartMicrovmError::InvalidNumaTopology(
+                "distance entries must cover the full square matrix".into(),
+            ));
+        }
+        let distance = topology.distances[0];
+        if distance.from != 0 || distance.to != 0 || distance.value != 10 {
+            return Err(StartMicrovmError::InvalidNumaTopology(
+                "the one-node distance matrix must contain exactly (0, 0, 10)".into(),
+            ));
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(all(target_os = "linux", not(feature = "tee")))]
@@ -4309,10 +4456,8 @@ pub mod tests {
     #[cfg(not(target_os = "windows"))]
     use crate::vmm_config::kernel_bundle::KernelBundle;
 
-    #[cfg(all(not(feature = "tee"), any(target_os = "linux", target_os = "windows")))]
     use crate::resources::{HostMemoryPolicy, NumaDistance, NumaNodeConfig, NumaTopology};
 
-    #[cfg(all(not(feature = "tee"), any(target_os = "linux", target_os = "windows")))]
     fn one_node_numa_topology(host_memory: HostMemoryPolicy) -> NumaTopology {
         NumaTopology {
             nodes: vec![NumaNodeConfig {
@@ -4328,6 +4473,96 @@ pub mod tests {
                 value: 10,
             }],
         }
+    }
+
+    #[test]
+    fn vmm_boundary_rejects_empty_numa_topology() {
+        let mut vm_resources = VmResources::default();
+        vm_resources.numa_topology = Some(NumaTopology {
+            nodes: Vec::new(),
+            distances: Vec::new(),
+        });
+
+        assert!(matches!(
+            validate_vmm_numa_topology(&vm_resources, 128),
+            Err(StartMicrovmError::InvalidNumaTopology(_))
+        ));
+    }
+
+    #[cfg(not(feature = "tee"))]
+    #[test]
+    fn vmm_boundary_rejects_multi_node_numa_topology() {
+        let mut vm_resources = VmResources::default();
+        let node = one_node_numa_topology(HostMemoryPolicy::Inherit).nodes[0].clone();
+        vm_resources.numa_topology = Some(NumaTopology {
+            nodes: vec![
+                node.clone(),
+                NumaNodeConfig {
+                    guest_node_id: 1,
+                    ..node
+                },
+            ],
+            distances: vec![
+                NumaDistance {
+                    from: 0,
+                    to: 0,
+                    value: 10,
+                },
+                NumaDistance {
+                    from: 0,
+                    to: 1,
+                    value: 20,
+                },
+                NumaDistance {
+                    from: 1,
+                    to: 0,
+                    value: 20,
+                },
+                NumaDistance {
+                    from: 1,
+                    to: 1,
+                    value: 10,
+                },
+            ],
+        });
+
+        assert!(matches!(
+            validate_vmm_numa_topology(&vm_resources, 128),
+            Err(StartMicrovmError::InvalidNumaTopology(_))
+        ));
+    }
+
+    #[cfg(not(feature = "tee"))]
+    #[test]
+    fn vmm_boundary_accepts_consistent_inherited_topology() {
+        let mut vm_resources = VmResources::default();
+        vm_resources.numa_topology = Some(one_node_numa_topology(HostMemoryPolicy::Inherit));
+
+        validate_vmm_numa_topology(&vm_resources, 128).unwrap();
+    }
+
+    #[cfg(not(feature = "tee"))]
+    #[test]
+    fn vmm_boundary_rejects_memory_argument_that_disagrees_with_resources() {
+        let mut vm_resources = VmResources::default();
+        vm_resources.numa_topology = Some(one_node_numa_topology(HostMemoryPolicy::Inherit));
+
+        assert!(matches!(
+            validate_vmm_numa_topology(&vm_resources, 256),
+            Err(StartMicrovmError::InvalidNumaTopology(_))
+        ));
+    }
+
+    #[cfg(feature = "tee")]
+    #[test]
+    fn vmm_boundary_rejects_numa_topology_with_tee_memory() {
+        let mut vm_resources = VmResources::default();
+        vm_resources.numa_topology = Some(one_node_numa_topology(HostMemoryPolicy::Inherit));
+
+        assert!(matches!(
+            validate_vmm_numa_topology(&vm_resources, 128),
+            Err(StartMicrovmError::InvalidNumaTopology(_))
+        ));
     }
 
     #[cfg(all(not(feature = "tee"), any(target_os = "linux", target_os = "windows")))]

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -152,6 +152,61 @@ pub enum VsockConfig {
     Disabled,
 }
 
+/// A fully resolved guest NUMA description supplied by the embedding runtime.
+///
+/// The VMM intentionally knows nothing about higher-level policies such as `auto` or
+/// `prefer_single`; it only validates and realizes this concrete topology.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NumaTopology {
+    /// Dense guest proximity domains in guest-node order.
+    pub nodes: Vec<NumaNodeConfig>,
+    /// Complete square distance matrix expressed with dense guest node IDs.
+    pub distances: Vec<NumaDistance>,
+}
+
+/// One dense guest proximity domain and the host policy for its backing memory.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NumaNodeConfig {
+    /// Dense zero-based guest proximity-domain identifier.
+    pub guest_node_id: u16,
+    /// Possible vCPU indices associated with this guest node.
+    pub vcpu_indices: Vec<u8>,
+    /// Memory available to the guest at boot, in MiB.
+    pub memory_mib: usize,
+    /// Maximum memory promised to this node after live growth, in MiB.
+    pub max_memory_mib: usize,
+    /// Host policy used for boot RAM and reserved hotplug capacity.
+    pub host_memory: HostMemoryPolicy,
+}
+
+/// One entry in the dense guest NUMA distance matrix.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NumaDistance {
+    /// Source guest proximity domain.
+    pub from: u16,
+    /// Destination guest proximity domain.
+    pub to: u16,
+    /// Relative distance, with `10` required for local entries.
+    pub value: u8,
+}
+
+/// Host backing policy for guest RAM belonging to a resolved node.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HostMemoryPolicy {
+    /// Preserve the operating system's ordinary allocation policy.
+    Inherit,
+    /// Restrict future Linux page faults to the selected host nodes.
+    Bind {
+        /// Absolute Linux host NUMA node IDs included in the binding mask.
+        host_nodes: Vec<u32>,
+    },
+    /// Prefer a Windows NUMA node while allowing the host to fall back.
+    Preferred {
+        /// Absolute Windows host NUMA node ID preferred for future page faults.
+        host_node: u32,
+    },
+}
+
 /// A data structure that encapsulates the device configurations
 /// held in the Vmm.
 pub struct VmResources {
@@ -160,6 +215,8 @@ pub struct VmResources {
     /// Resolved host logical processor for every possible vCPU thread.
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     pub vcpu_affinity: Option<Vec<HostCpuId>>,
+    /// Resolved guest and host memory topology. `None` retains the legacy memory path exactly.
+    pub numa_topology: Option<NumaTopology>,
     /// The firmware to be loaded into the microVM.
     pub firmware_config: Option<FirmwareConfig>,
     /// The kernel command line for this microVM.
@@ -251,6 +308,7 @@ impl Default for VmResources {
             vm_config: VmConfig::default(),
             #[cfg(any(target_os = "linux", target_os = "windows"))]
             vcpu_affinity: None,
+            numa_topology: None,
             firmware_config: None,
             kernel_cmdline: KernelCmdlineConfig::default(),
             kernel_bundle: None,


### PR DESCRIPTION
## TL;DR

Add an opt-in one-node NUMA placement contract so embedders can keep guest CPUs and RAM on the same host locality domain without changing the legacy memory path.

## Description

- Add a fluent NUMA builder that assigns dense node IDs, generates local distances, and defaults live capacity to boot memory.
- Keep `numa_topology(NumaTopology)` as a low-level escape hatch for callers that already produce a fully resolved topology.
- Validate vCPU coverage, memory totals, distances, platform policy, and live-memory capacity before VM construction.
- Bind Linux guest RAM with `mbind` before first touch and use absolute host node IDs.
- Prefer a Windows NUMA node through the published `msb-vm-memory 0.18.0-msb.1` `VirtualAlloc2` constructor.
- Keep every direct and transitive memory consumer on the same crate identity by using `msb-imago 0.1.5` and the published `msb-vm-memory` package throughout the workspace.
- Apply placement to boot RAM and reserved virtio-mem capacity while leaving shared filesystem and GPU windows on their existing policy.
- Reject multi-node guests and TEE placement until those backends can represent the same contract, and preserve the existing path when no topology is supplied.

```rust
use msb_krun::VmBuilder;

let vm = VmBuilder::new()
    .machine(|machine| {
        machine
            .vcpus(2)
            .max_vcpus(2)
            .memory_mib(4096)
            .max_memory_mib(8192)
            .numa(|numa| {
                numa.node(|node| {
                    node.vcpus([0, 1])
                        .memory_mib(4096)
                        .max_memory_mib(8192)
                        .bind_host_nodes([0])
                })
            })
    })
    .build()?;
```

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p msb_krun -p msb_krun_vmm --features blk,net -- -D warnings`
- [x] `cargo test -p msb_krun --lib --features blk,net` and `cargo test -p msb_krun_vmm --lib`
- [x] Verify the fluent builder matches the resolved topology and defaults node maximum memory correctly
- [x] Cross-check `msb_krun` for Linux AArch64 and Windows AArch64 with `blk,net`
- [x] Compile the AMD SEV and TEE validation path for Linux x86_64 with warnings denied
- [x] Run `linux_numa_binding_reaches_faulted_pages` on the four-node OVH host and confirm the faulted mapping reports `bind=static:0` and `N0`
- [x] Run `windows_numa_mapping_allocates_accessible_memory` on the native Windows x86_64 runner
- [x] Verify `msb-vm-memory 0.18.0-msb.1` is the workspace's only memory-crate identity, including through `msb-imago 0.1.5`
- [x] Rebase-equivalent merge of the latest `krun` branch and rerun the VMM unit suite plus the Windows AArch64 cross-check
