### PR TITLE
feat(net): enforce virtio network rate limits

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Unit tests
         run: cargo test
 
+      - name: Virtio-net rate-limit tests
+        run: cargo test --locked -p msb_krun_devices --features net virtio::net
+
   unit-tests-windows-x86_64:
     name: Unit tests (Windows x86_64)
     runs-on: windows-latest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Virtio-net rate-limit tests
         run: cargo test --locked -p msb_krun_devices --features net virtio::net
 
+      - name: Network builder rate-limit tests
+        run: cargo test --locked -p msb_krun --features net network_rate_limiters
+
   unit-tests-windows-x86_64:
     name: Unit tests (Windows x86_64)
     runs-on: windows-latest

--- a/src/devices/src/virtio/net/backend.rs
+++ b/src/devices/src/virtio/net/backend.rs
@@ -21,6 +21,7 @@ pub enum ConnectError {
     TunSetIff(io::Error),
     TunSetVnetHdrSz(io::Error),
     TunSetOffload(io::Error),
+    RateLimitTimer(io::Error),
 }
 
 #[allow(dead_code)]

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -14,6 +14,7 @@ use crate::virtio::{
 use crate::Error as DeviceError;
 
 use super::backend::{NetBackend, ReadError, WriteError};
+use super::rate_limit::RateLimiters;
 use super::worker::NetWorker;
 
 use std::cmp;
@@ -80,6 +81,7 @@ pub enum VirtioNetBackend {
 pub struct Net {
     id: String,
     pub cfg_backend: Option<VirtioNetBackend>,
+    rate_limiters: RateLimiters,
 
     avail_features: u64,
     acked_features: u64,
@@ -97,6 +99,28 @@ impl Net {
         mac: [u8; 6],
         features: u32,
     ) -> Result<Self> {
+        Self::new_with_rate_limiters(id, cfg_backend, mac, features, RateLimiters::default())
+    }
+
+    /// Create a virtio network device with receive and transmit rate limiters.
+    pub fn new_with_rate_limiters(
+        id: String,
+        cfg_backend: VirtioNetBackend,
+        mac: [u8; 6],
+        features: u32,
+        rate_limiters: RateLimiters,
+    ) -> Result<Self> {
+        if let Some(config) = &rate_limiters.rx {
+            config
+                .validate()
+                .map_err(super::Error::InvalidRxRateLimiter)?;
+        }
+        if let Some(config) = &rate_limiters.tx {
+            config
+                .validate()
+                .map_err(super::Error::InvalidTxRateLimiter)?;
+        }
+
         let avail_features = features as u64
             | (1 << VIRTIO_NET_F_MAC)
             | (1 << VIRTIO_RING_F_EVENT_IDX)
@@ -111,6 +135,7 @@ impl Net {
         Ok(Net {
             id,
             cfg_backend: Some(cfg_backend),
+            rate_limiters,
 
             avail_features,
             acked_features: 0u64,
@@ -188,6 +213,7 @@ impl VirtioDevice for Net {
             error!("Cannot activate net device: backend already taken");
             ActivateError::BadActivate
         })?;
+        let rate_limiters = std::mem::take(&mut self.rate_limiters);
 
         match NetWorker::new(
             rx_q,
@@ -196,6 +222,7 @@ impl VirtioDevice for Net {
             mem.clone(),
             self.acked_features,
             cfg_backend,
+            rate_limiters,
         ) {
             Ok(worker) => {
                 worker.run();

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -16,6 +16,7 @@ pub mod backend;
 pub mod device;
 #[cfg(windows)]
 pub mod namedpipe;
+pub mod rate_limit;
 #[cfg(target_os = "linux")]
 mod tap;
 #[cfg(unix)]
@@ -41,6 +42,10 @@ pub use self::device::Net;
 pub enum Error {
     /// EventFd error.
     EventFd(io::Error),
+    /// Invalid receive rate limiter.
+    InvalidRxRateLimiter(rate_limit::RateLimiterConfigError),
+    /// Invalid transmit rate limiter.
+    InvalidTxRateLimiter(rate_limit::RateLimiterConfigError),
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/src/devices/src/virtio/net/rate_limit.rs
+++ b/src/devices/src/virtio/net/rate_limit.rs
@@ -305,22 +305,94 @@ mod tests {
     }
 
     #[test]
-    fn oversized_frame_passes_once_then_repays_debt() {
+    fn oversized_frame_from_partial_balance_repays_exact_debt() {
         let start = Instant::now();
         let mut limiter = RateLimiter::new(&config((1_000, 0), 10), start).unwrap();
 
-        assert_eq!(limiter.try_consume_frame(1_500, start), Ok(()));
+        assert_eq!(limiter.try_consume_frame(600, start), Ok(()));
+        assert_eq!(limiter.try_consume_frame(2_500, start), Ok(()));
         assert_eq!(
-            limiter.try_consume_frame(1, start + Duration::from_millis(499)),
-            Err(start + Duration::from_millis(500))
+            limiter.try_consume_frame(1, start + Duration::from_millis(2_099)),
+            Err(start + Duration::from_millis(2_100))
         );
         assert_eq!(
-            limiter.try_consume_frame(1, start + Duration::from_millis(500)),
-            Err(start + Duration::from_millis(501))
+            limiter.try_consume_frame(1_000, start + Duration::from_millis(2_100)),
+            Err(start + Duration::from_millis(3_100))
         );
         assert_eq!(
-            limiter.try_consume_frame(1, start + Duration::from_millis(501)),
+            limiter.try_consume_frame(1_000, start + Duration::from_millis(3_100)),
             Ok(())
+        );
+    }
+
+    #[test]
+    fn fractional_refill_progress_carries_between_attempts() {
+        let start = Instant::now();
+        let config = RateLimiterConfig {
+            bandwidth: Some(TokenBucketConfig {
+                size: 3,
+                refill_time: Duration::from_secs(1),
+                one_time_burst: 0,
+            }),
+            ops: None,
+        };
+        let mut limiter = RateLimiter::new(&config, start).unwrap();
+
+        assert_eq!(limiter.try_consume_frame(3, start), Ok(()));
+        assert_eq!(
+            limiter.try_consume_frame(1, start + Duration::from_millis(333)),
+            Err(start + Duration::from_nanos(333_333_334))
+        );
+        assert_eq!(
+            limiter.try_consume_frame(1, start + Duration::from_millis(334)),
+            Ok(())
+        );
+        assert_eq!(
+            limiter.try_consume_frame(1, start + Duration::from_millis(667)),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn one_time_burst_is_spent_once_and_never_refills() {
+        let start = Instant::now();
+        let config = RateLimiterConfig {
+            bandwidth: Some(TokenBucketConfig {
+                size: 10,
+                refill_time: Duration::from_secs(1),
+                one_time_burst: 5,
+            }),
+            ops: None,
+        };
+        let mut limiter = RateLimiter::new(&config, start).unwrap();
+
+        assert_eq!(limiter.try_consume_frame(15, start), Ok(()));
+        let later = start + Duration::from_secs(60);
+        assert_eq!(limiter.try_consume_frame(10, later), Ok(()));
+        assert_eq!(
+            limiter.try_consume_frame(1, later),
+            Err(later + Duration::from_millis(100))
+        );
+    }
+
+    #[test]
+    fn full_bucket_does_not_bank_idle_refill() {
+        let start = Instant::now();
+        let config = RateLimiterConfig {
+            bandwidth: Some(TokenBucketConfig {
+                size: 1,
+                refill_time: Duration::from_secs(1),
+                one_time_burst: 0,
+            }),
+            ops: None,
+        };
+        let mut limiter = RateLimiter::new(&config, start).unwrap();
+        let idle = start + Duration::from_millis(1_999);
+
+        assert_eq!(limiter.try_consume_frame(1, idle), Ok(()));
+        assert_eq!(
+            limiter.try_consume_frame(1, idle + Duration::from_millis(1)),
+            Err(idle + Duration::from_secs(1))
         );
     }
 

--- a/src/devices/src/virtio/net/rate_limit.rs
+++ b/src/devices/src/virtio/net/rate_limit.rs
@@ -1,0 +1,347 @@
+// Copyright 2026 The libkrun Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Token-bucket rate limiting for virtio-net devices.
+
+use std::error::Error;
+use std::fmt;
+use std::time::{Duration, Instant};
+
+/// Configuration for one virtio-net traffic direction.
+///
+/// Bandwidth and operation limits are independent. When both are present, a
+/// frame is admitted only when both buckets can pay their charge atomically.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RateLimiterConfig {
+    /// Byte-based token bucket. One token pays for one Ethernet-frame byte.
+    pub bandwidth: Option<TokenBucketConfig>,
+    /// Operation-based token bucket. One token pays for one Ethernet frame.
+    pub ops: Option<TokenBucketConfig>,
+}
+
+/// Optional rate limiters for both virtio-net directions.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RateLimiters {
+    /// Frames received by the guest from the backend.
+    pub rx: Option<RateLimiterConfig>,
+    /// Frames transmitted by the guest to the backend.
+    pub tx: Option<RateLimiterConfig>,
+}
+
+/// Configuration for one continuously refilled token bucket.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenBucketConfig {
+    /// Maximum recurring token balance and tokens granted per refill period.
+    pub size: u64,
+    /// Time in which `size` tokens are granted continuously.
+    pub refill_time: Duration,
+    /// Extra startup-only tokens, spent first and never refilled.
+    pub one_time_burst: u64,
+}
+
+/// Invalid rate-limiter configuration.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RateLimiterConfigError {
+    /// Neither bandwidth nor operation limiting was configured.
+    Empty,
+    /// A configured bucket has zero capacity.
+    ZeroSize(&'static str),
+    /// A configured bucket has a zero refill period.
+    ZeroRefillTime(&'static str),
+}
+
+/// Runtime limiter for one virtio-net traffic direction.
+#[derive(Debug)]
+pub(crate) struct RateLimiter {
+    bandwidth: Option<TokenBucket>,
+    ops: Option<TokenBucket>,
+    blocked_until: Option<Instant>,
+}
+
+#[derive(Debug)]
+struct TokenBucket {
+    size: u64,
+    refill_time_ns: u128,
+    one_time_burst: u64,
+    balance: i128,
+    last_refill: Instant,
+}
+
+enum BucketCharge {
+    Ready,
+    Overdraft(Instant),
+    Blocked(Instant),
+}
+
+impl RateLimiterConfig {
+    /// Validate this limiter and both configured token buckets.
+    pub fn validate(&self) -> Result<(), RateLimiterConfigError> {
+        if self.bandwidth.is_none() && self.ops.is_none() {
+            return Err(RateLimiterConfigError::Empty);
+        }
+        if let Some(bucket) = &self.bandwidth {
+            bucket.validate("bandwidth")?;
+        }
+        if let Some(bucket) = &self.ops {
+            bucket.validate("ops")?;
+        }
+        Ok(())
+    }
+}
+
+impl RateLimiters {
+    /// Return true when neither direction is rate limited.
+    pub fn is_empty(&self) -> bool {
+        self.rx.is_none() && self.tx.is_none()
+    }
+}
+
+impl TokenBucketConfig {
+    fn validate(&self, name: &'static str) -> Result<(), RateLimiterConfigError> {
+        if self.size == 0 {
+            return Err(RateLimiterConfigError::ZeroSize(name));
+        }
+        if self.refill_time.is_zero() {
+            return Err(RateLimiterConfigError::ZeroRefillTime(name));
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for RateLimiterConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("rate limiter must configure bandwidth, ops, or both"),
+            Self::ZeroSize(bucket) => write!(f, "{bucket} bucket size must be greater than zero"),
+            Self::ZeroRefillTime(bucket) => {
+                write!(f, "{bucket} bucket refill time must be greater than zero")
+            }
+        }
+    }
+}
+
+impl Error for RateLimiterConfigError {}
+
+impl RateLimiter {
+    pub(crate) fn new(
+        config: &RateLimiterConfig,
+        now: Instant,
+    ) -> Result<Self, RateLimiterConfigError> {
+        config.validate()?;
+        Ok(Self {
+            bandwidth: config
+                .bandwidth
+                .as_ref()
+                .map(|bucket| TokenBucket::new(bucket, now)),
+            ops: config
+                .ops
+                .as_ref()
+                .map(|bucket| TokenBucket::new(bucket, now)),
+            blocked_until: None,
+        })
+    }
+
+    /// Atomically charge one Ethernet frame or return its retry deadline.
+    pub(crate) fn try_consume_frame(
+        &mut self,
+        frame_len: u64,
+        now: Instant,
+    ) -> Result<(), Instant> {
+        if let Some(deadline) = self.blocked_until {
+            if now < deadline {
+                return Err(deadline);
+            }
+            self.blocked_until = None;
+        }
+
+        if let Some(bucket) = &mut self.bandwidth {
+            bucket.refill(now);
+        }
+        if let Some(bucket) = &mut self.ops {
+            bucket.refill(now);
+        }
+
+        let charges = [
+            self.bandwidth.as_ref().map(|bucket| bucket.plan(frame_len)),
+            self.ops.as_ref().map(|bucket| bucket.plan(1)),
+        ];
+        if let Some(deadline) = charges
+            .iter()
+            .flatten()
+            .filter_map(|charge| match charge {
+                BucketCharge::Blocked(deadline) => Some(*deadline),
+                _ => None,
+            })
+            .max()
+        {
+            return Err(deadline);
+        }
+
+        let overdraft_until = charges
+            .iter()
+            .flatten()
+            .filter_map(|charge| match charge {
+                BucketCharge::Overdraft(deadline) => Some(*deadline),
+                _ => None,
+            })
+            .max();
+
+        if let Some(bucket) = &mut self.bandwidth {
+            bucket.commit(frame_len);
+        }
+        if let Some(bucket) = &mut self.ops {
+            bucket.commit(1);
+        }
+        self.blocked_until = overdraft_until;
+        Ok(())
+    }
+}
+
+impl TokenBucket {
+    fn new(config: &TokenBucketConfig, now: Instant) -> Self {
+        Self {
+            size: config.size,
+            refill_time_ns: config.refill_time.as_nanos(),
+            one_time_burst: config.one_time_burst,
+            balance: config.size as i128,
+            last_refill: now,
+        }
+    }
+
+    fn refill(&mut self, now: Instant) {
+        if self.balance >= self.size as i128 {
+            self.last_refill = now;
+            return;
+        }
+
+        let elapsed_ns = now.saturating_duration_since(self.last_refill).as_nanos();
+        let tokens = elapsed_ns.saturating_mul(self.size as u128) / self.refill_time_ns;
+        if tokens == 0 {
+            return;
+        }
+
+        self.balance = self
+            .balance
+            .saturating_add(i128::try_from(tokens).unwrap_or(i128::MAX));
+        if self.balance >= self.size as i128 {
+            self.balance = self.size as i128;
+            self.last_refill = now;
+            return;
+        }
+
+        let granted_ns = tokens.saturating_mul(self.refill_time_ns) / self.size as u128;
+        self.last_refill += Duration::from_nanos(u64::try_from(granted_ns).unwrap_or(u64::MAX));
+    }
+
+    fn plan(&self, tokens: u64) -> BucketCharge {
+        let balance_cost = tokens.saturating_sub(self.one_time_burst) as i128;
+        if balance_cost <= self.balance {
+            return BucketCharge::Ready;
+        }
+
+        let deadline = self.refill_deadline(balance_cost - self.balance);
+        if balance_cost > self.size as i128 {
+            BucketCharge::Overdraft(deadline)
+        } else {
+            BucketCharge::Blocked(deadline)
+        }
+    }
+
+    fn commit(&mut self, tokens: u64) {
+        let burst_spend = tokens.min(self.one_time_burst);
+        self.one_time_burst -= burst_spend;
+        self.balance -= (tokens - burst_spend) as i128;
+    }
+
+    fn refill_deadline(&self, tokens: i128) -> Instant {
+        let ns = (tokens.max(0) as u128)
+            .saturating_mul(self.refill_time_ns)
+            .div_ceil(self.size as u128);
+        self.last_refill + Duration::from_nanos(u64::try_from(ns).unwrap_or(u64::MAX))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(bandwidth: (u64, u64), ops: u64) -> RateLimiterConfig {
+        RateLimiterConfig {
+            bandwidth: Some(TokenBucketConfig {
+                size: bandwidth.0,
+                refill_time: Duration::from_secs(1),
+                one_time_burst: bandwidth.1,
+            }),
+            ops: Some(TokenBucketConfig {
+                size: ops,
+                refill_time: Duration::from_secs(1),
+                one_time_burst: 0,
+            }),
+        }
+    }
+
+    #[test]
+    fn enforces_bandwidth_burst_and_ops_atomically() {
+        let start = Instant::now();
+        let mut limiter = RateLimiter::new(&config((1_000, 500), 2), start).unwrap();
+
+        assert_eq!(limiter.try_consume_frame(1_200, start), Ok(()));
+        assert_eq!(limiter.try_consume_frame(100, start), Ok(()));
+
+        // Ops blocks this frame. Bandwidth must remain untouched while it waits.
+        assert_eq!(
+            limiter.try_consume_frame(200, start),
+            Err(start + Duration::from_millis(500))
+        );
+        assert_eq!(limiter.bandwidth.as_ref().unwrap().balance, 200);
+        assert_eq!(
+            limiter.try_consume_frame(200, start + Duration::from_millis(499)),
+            Err(start + Duration::from_millis(500))
+        );
+        assert_eq!(
+            limiter.try_consume_frame(200, start + Duration::from_millis(500)),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn oversized_frame_passes_once_then_repays_debt() {
+        let start = Instant::now();
+        let mut limiter = RateLimiter::new(&config((1_000, 0), 10), start).unwrap();
+
+        assert_eq!(limiter.try_consume_frame(1_500, start), Ok(()));
+        assert_eq!(
+            limiter.try_consume_frame(1, start + Duration::from_millis(499)),
+            Err(start + Duration::from_millis(500))
+        );
+        assert_eq!(
+            limiter.try_consume_frame(1, start + Duration::from_millis(500)),
+            Err(start + Duration::from_millis(501))
+        );
+        assert_eq!(
+            limiter.try_consume_frame(1, start + Duration::from_millis(501)),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_configurations() {
+        let start = Instant::now();
+        assert_eq!(
+            RateLimiter::new(&RateLimiterConfig::default(), start).unwrap_err(),
+            RateLimiterConfigError::Empty
+        );
+
+        let mut invalid = config((0, 0), 1);
+        assert_eq!(
+            RateLimiter::new(&invalid, start).unwrap_err(),
+            RateLimiterConfigError::ZeroSize("bandwidth")
+        );
+        invalid.bandwidth.as_mut().unwrap().size = 1;
+        invalid.ops.as_mut().unwrap().refill_time = Duration::ZERO;
+        assert_eq!(
+            RateLimiter::new(&invalid, start).unwrap_err(),
+            RateLimiterConfigError::ZeroRefillTime("ops")
+        );
+    }
+}

--- a/src/devices/src/virtio/net/worker.rs
+++ b/src/devices/src/virtio/net/worker.rs
@@ -12,6 +12,7 @@ use crate::virtio::{DeviceQueue, InterruptTransport};
 
 use super::backend::{NetBackend, ReadError, WriteError};
 use super::device::{FrontendError, RxError, TxError, VirtioNetBackend};
+use super::rate_limit::{RateLimiter, RateLimiters};
 use super::vnet_hdr_len;
 
 use std::io;
@@ -20,10 +21,12 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawHandle, RawHandle};
 use std::thread;
+use std::time::{Duration, Instant};
 use std::{cmp, result};
 use utils::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 use utils::event::{EventSource, RawEventSource};
 use utils::eventfd::EventFd;
+use utils::timerfd::TimerFd;
 use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
 
 #[cfg(unix)]
@@ -34,6 +37,7 @@ type Pollable = RawHandle;
 const RX_QUEUE_EVENT: u64 = 0;
 const TX_QUEUE_EVENT: u64 = 1;
 const BACKEND_EVENT: u64 = 2;
+const RATE_LIMIT_TIMER_EVENT: u64 = 3;
 
 pub struct NetWorker {
     rx_q: DeviceQueue,
@@ -46,10 +50,18 @@ pub struct NetWorker {
     rx_frame_buf: [u8; MAX_BUFFER_SIZE],
     rx_frame_buf_len: usize,
     rx_has_deferred_frame: bool,
+    rx_has_rate_limit_permit: bool,
+    rx_rate_limiter: Option<RateLimiter>,
+    rx_resume_at: Option<Instant>,
 
     tx_iovec: Vec<(GuestAddress, usize)>,
     tx_frame_buf: [u8; MAX_BUFFER_SIZE],
     tx_frame_len: usize,
+    tx_has_rate_limit_permit: bool,
+    tx_rate_limiter: Option<RateLimiter>,
+    tx_resume_at: Option<Instant>,
+
+    rate_limit_timer: Option<TimerFd>,
 }
 
 impl NetWorker {
@@ -60,6 +72,7 @@ impl NetWorker {
         mem: GuestMemoryMmap,
         _vnet_features: u64,
         cfg_backend: VirtioNetBackend,
+        rate_limiters: RateLimiters,
     ) -> Result<Self, ConnectError> {
         let backend = match cfg_backend {
             #[cfg(unix)]
@@ -95,6 +108,21 @@ impl NetWorker {
             VirtioNetBackend::Custom(backend) => backend,
         };
 
+        let now = Instant::now();
+        let rx_rate_limiter = rate_limiters
+            .rx
+            .as_ref()
+            .map(|config| RateLimiter::new(config, now).expect("validated RX rate limiter"));
+        let tx_rate_limiter = rate_limiters
+            .tx
+            .as_ref()
+            .map(|config| RateLimiter::new(config, now).expect("validated TX rate limiter"));
+        let rate_limit_timer = if rate_limiters.is_empty() {
+            None
+        } else {
+            Some(TimerFd::new().map_err(ConnectError::RateLimitTimer)?)
+        };
+
         Ok(Self {
             rx_q,
             tx_q,
@@ -106,10 +134,18 @@ impl NetWorker {
             rx_frame_buf: [0u8; MAX_BUFFER_SIZE],
             rx_frame_buf_len: 0,
             rx_has_deferred_frame: false,
+            rx_has_rate_limit_permit: false,
+            rx_rate_limiter,
+            rx_resume_at: None,
 
             tx_frame_buf: [0u8; MAX_BUFFER_SIZE],
             tx_frame_len: 0,
             tx_iovec: Vec::with_capacity(QUEUE_SIZE as usize),
+            tx_has_rate_limit_permit: false,
+            tx_rate_limiter,
+            tx_resume_at: None,
+
+            rate_limit_timer,
         })
     }
 
@@ -152,6 +188,13 @@ impl NetWorker {
                 BACKEND_EVENT,
             ),
         );
+        if let Some(timer) = &self.rate_limit_timer {
+            let _ = epoll.ctl(
+                ControlOperation::Add,
+                timerfd_pollable(timer),
+                &EpollEvent::new(EventSet::IN, RATE_LIMIT_TIMER_EVENT),
+            );
+        }
 
         loop {
             let mut epoll_events = vec![EpollEvent::new(EventSet::empty(), 0); 32];
@@ -182,6 +225,9 @@ impl NetWorker {
                                         self.process_backend_socket_writeable()
                                     }
                                 }
+                            }
+                            RATE_LIMIT_TIMER_EVENT if event_set.contains(EventSet::IN) => {
+                                self.process_rate_limit_timer_event();
                             }
                             _ => {
                                 log::warn!(
@@ -254,23 +300,37 @@ impl NetWorker {
     }
 
     fn process_rx(&mut self) -> result::Result<(), RxError> {
+        self.process_rx_at(Instant::now())
+    }
+
+    fn process_rx_at(&mut self, now: Instant) -> result::Result<(), RxError> {
+        let mut signal_queue = false;
+
         // if we have a deferred frame we try to process it first,
         // if that is not possible, we don't continue processing other frames
         if self.rx_has_deferred_frame {
+            if !self.reserve_rx_tokens(now) {
+                return Ok(());
+            }
             if self.write_frame_to_guest() {
                 self.rx_has_deferred_frame = false;
+                self.rx_has_rate_limit_permit = false;
+                signal_queue = true;
             } else {
                 return Ok(());
             }
         }
 
-        let mut signal_queue = false;
-
         // Read as many frames as possible.
         let result = loop {
             match self.read_into_rx_frame_buf_from_backend() {
                 Ok(()) => {
+                    if !self.reserve_rx_tokens(now) {
+                        self.rx_has_deferred_frame = true;
+                        break Ok(());
+                    }
                     if self.write_frame_to_guest() {
+                        self.rx_has_rate_limit_permit = false;
                         signal_queue = true;
                     } else {
                         self.rx_has_deferred_frame = true;
@@ -293,6 +353,30 @@ impl NetWorker {
         result
     }
 
+    fn reserve_rx_tokens(&mut self, now: Instant) -> bool {
+        if self.rx_has_rate_limit_permit {
+            return true;
+        }
+
+        let frame_len = self.rx_frame_buf_len.saturating_sub(vnet_hdr_len()) as u64;
+        if let Some(limiter) = &mut self.rx_rate_limiter {
+            match limiter.try_consume_frame(frame_len, now) {
+                Ok(()) => {}
+                Err(deadline) => {
+                    self.rx_resume_at = Some(deadline);
+                    self.arm_rate_limit_timer(now);
+                    return false;
+                }
+            }
+        }
+
+        self.rx_has_rate_limit_permit = true;
+        if self.rx_resume_at.take().is_some() {
+            self.arm_rate_limit_timer(now);
+        }
+        true
+    }
+
     fn process_tx_loop(&mut self) {
         loop {
             self.tx_q.queue.disable_notification(&self.mem).unwrap();
@@ -301,7 +385,8 @@ impl NetWorker {
                 log::error!("Failed to process rx: {e:?} (triggered by backend socket readable)");
             };
 
-            if !self.tx_q.queue.enable_notification(&self.mem).unwrap() {
+            let rate_limited = self.tx_resume_at.is_some();
+            if !self.tx_q.queue.enable_notification(&self.mem).unwrap() || rate_limited {
                 break;
             }
         }
@@ -321,6 +406,7 @@ impl NetWorker {
         }
 
         let mut raise_irq = false;
+        let mut rate_limit_changed = false;
 
         while let Some(head) = tx_queue.pop(&self.mem) {
             let head_index = head.index;
@@ -358,11 +444,27 @@ impl NetWorker {
 
             self.tx_frame_len = read_count;
             log::debug!("virtio-net tx descriptor: head={head_index}, bytes={read_count}");
+
+            if !self.tx_has_rate_limit_permit {
+                let frame_len = read_count.saturating_sub(vnet_hdr_len()) as u64;
+                if let Some(limiter) = &mut self.tx_rate_limiter {
+                    if let Err(deadline) = limiter.try_consume_frame(frame_len, Instant::now()) {
+                        self.tx_resume_at = Some(deadline);
+                        rate_limit_changed = true;
+                        tx_queue.undo_pop();
+                        break;
+                    }
+                }
+                self.tx_has_rate_limit_permit = true;
+                rate_limit_changed |= self.tx_resume_at.take().is_some();
+            }
+
             match self
                 .backend
                 .write_frame(vnet_hdr_len(), &mut self.tx_frame_buf[..read_count])
             {
                 Ok(()) => {
+                    self.tx_has_rate_limit_permit = false;
                     self.tx_frame_len = 0;
                     tx_queue
                         .add_used(&self.mem, head_index, 0)
@@ -374,6 +476,7 @@ impl NetWorker {
                     break;
                 }
                 Err(WriteError::PartialWrite) => {
+                    self.tx_has_rate_limit_permit = false;
                     log::trace!("process_tx: partial write");
                     /*
                     This situation should be pretty rare, assuming reasonably sized socket buffers.
@@ -404,7 +507,54 @@ impl NetWorker {
                 .map_err(TxError::DeviceError)?;
         }
 
+        if rate_limit_changed {
+            self.arm_rate_limit_timer(Instant::now());
+        }
+
         Ok(())
+    }
+
+    fn process_rate_limit_timer_event(&mut self) {
+        let Some(timer) = &self.rate_limit_timer else {
+            return;
+        };
+        if let Err(err) = timer.read() {
+            log::error!("failed to consume virtio-net rate-limit timer: {err}");
+            return;
+        }
+
+        let now = Instant::now();
+        let retry_rx = self.rx_resume_at.is_some_and(|deadline| deadline <= now);
+        let retry_tx = self.tx_resume_at.is_some_and(|deadline| deadline <= now);
+        if retry_rx {
+            self.rx_resume_at = None;
+            if let Err(err) = self.process_rx_at(now) {
+                log::error!("failed to process rate-limited RX frame: {err:?}");
+            }
+        }
+        if retry_tx {
+            self.tx_resume_at = None;
+            self.process_tx_loop();
+        }
+        self.arm_rate_limit_timer(Instant::now());
+    }
+
+    fn arm_rate_limit_timer(&mut self, now: Instant) {
+        let Some(timer) = &self.rate_limit_timer else {
+            return;
+        };
+        let deadline = self.rx_resume_at.into_iter().chain(self.tx_resume_at).min();
+        let result = match deadline {
+            Some(deadline) => timer.arm_oneshot(
+                deadline
+                    .saturating_duration_since(now)
+                    .max(Duration::from_nanos(1)),
+            ),
+            None => timer.disarm(),
+        };
+        if let Err(err) = result {
+            log::error!("failed to arm virtio-net rate-limit timer: {err}");
+        }
     }
 
     // Copies a single frame from `self.rx_frame_buf` into the guest.
@@ -492,6 +642,16 @@ fn eventfd_pollable(event: &EventFd) -> Pollable {
 #[cfg(windows)]
 fn eventfd_pollable(event: &EventFd) -> Pollable {
     event.as_raw_handle()
+}
+
+#[cfg(unix)]
+fn timerfd_pollable(timer: &TimerFd) -> Pollable {
+    timer.as_raw_fd()
+}
+
+#[cfg(windows)]
+fn timerfd_pollable(timer: &TimerFd) -> Pollable {
+    timer.as_raw_handle()
 }
 
 #[cfg(unix)]

--- a/src/devices/src/virtio/net/worker.rs
+++ b/src/devices/src/virtio/net/worker.rs
@@ -62,6 +62,7 @@ pub struct NetWorker {
     tx_resume_at: Option<Instant>,
 
     rate_limit_timer: Option<TimerFd>,
+    armed_rate_limit_deadline: Option<Instant>,
 }
 
 impl NetWorker {
@@ -146,6 +147,7 @@ impl NetWorker {
             tx_resume_at: None,
 
             rate_limit_timer,
+            armed_rate_limit_deadline: None,
         })
     }
 
@@ -300,21 +302,26 @@ impl NetWorker {
     }
 
     fn process_rx(&mut self) -> result::Result<(), RxError> {
-        self.process_rx_at(Instant::now())
+        let now = self.rx_rate_limiter.as_ref().map(|_| Instant::now());
+        self.process_rx_at(now)
     }
 
-    fn process_rx_at(&mut self, now: Instant) -> result::Result<(), RxError> {
+    fn process_rx_at(&mut self, now: Option<Instant>) -> result::Result<(), RxError> {
         let mut signal_queue = false;
 
         // if we have a deferred frame we try to process it first,
         // if that is not possible, we don't continue processing other frames
         if self.rx_has_deferred_frame {
-            if !self.reserve_rx_tokens(now) {
-                return Ok(());
+            if let Some(now) = now {
+                if !self.reserve_rx_tokens(now) {
+                    return Ok(());
+                }
             }
             if self.write_frame_to_guest() {
                 self.rx_has_deferred_frame = false;
-                self.rx_has_rate_limit_permit = false;
+                if now.is_some() {
+                    self.rx_has_rate_limit_permit = false;
+                }
                 signal_queue = true;
             } else {
                 return Ok(());
@@ -325,12 +332,16 @@ impl NetWorker {
         let result = loop {
             match self.read_into_rx_frame_buf_from_backend() {
                 Ok(()) => {
-                    if !self.reserve_rx_tokens(now) {
-                        self.rx_has_deferred_frame = true;
-                        break Ok(());
+                    if let Some(now) = now {
+                        if !self.reserve_rx_tokens(now) {
+                            self.rx_has_deferred_frame = true;
+                            break Ok(());
+                        }
                     }
                     if self.write_frame_to_guest() {
-                        self.rx_has_rate_limit_permit = false;
+                        if now.is_some() {
+                            self.rx_has_rate_limit_permit = false;
+                        }
                         signal_queue = true;
                     } else {
                         self.rx_has_deferred_frame = true;
@@ -393,10 +404,11 @@ impl NetWorker {
     }
 
     fn process_tx(&mut self) -> result::Result<(), TxError> {
-        self.process_tx_at(Instant::now())
+        let now = self.tx_rate_limiter.as_ref().map(|_| Instant::now());
+        self.process_tx_at(now)
     }
 
-    fn process_tx_at(&mut self, now: Instant) -> result::Result<(), TxError> {
+    fn process_tx_at(&mut self, now: Option<Instant>) -> result::Result<(), TxError> {
         let tx_queue = &mut self.tx_q.queue;
 
         if self.backend.has_unfinished_write()
@@ -449,18 +461,22 @@ impl NetWorker {
             self.tx_frame_len = read_count;
             log::debug!("virtio-net tx descriptor: head={head_index}, bytes={read_count}");
 
-            if !self.tx_has_rate_limit_permit {
-                let frame_len = read_count.saturating_sub(vnet_hdr_len()) as u64;
-                if let Some(limiter) = &mut self.tx_rate_limiter {
+            if let Some(now) = now {
+                if !self.tx_has_rate_limit_permit {
+                    let frame_len = read_count.saturating_sub(vnet_hdr_len()) as u64;
+                    let limiter = self
+                        .tx_rate_limiter
+                        .as_mut()
+                        .expect("timestamp requires a TX rate limiter");
                     if let Err(deadline) = limiter.try_consume_frame(frame_len, now) {
                         self.tx_resume_at = Some(deadline);
                         rate_limit_changed = true;
                         tx_queue.undo_pop();
                         break;
                     }
+                    self.tx_has_rate_limit_permit = true;
+                    rate_limit_changed |= self.tx_resume_at.take().is_some();
                 }
-                self.tx_has_rate_limit_permit = true;
-                rate_limit_changed |= self.tx_resume_at.take().is_some();
             }
 
             match self
@@ -468,7 +484,9 @@ impl NetWorker {
                 .write_frame(vnet_hdr_len(), &mut self.tx_frame_buf[..read_count])
             {
                 Ok(()) => {
-                    self.tx_has_rate_limit_permit = false;
+                    if now.is_some() {
+                        self.tx_has_rate_limit_permit = false;
+                    }
                     self.tx_frame_len = 0;
                     tx_queue
                         .add_used(&self.mem, head_index, 0)
@@ -480,7 +498,9 @@ impl NetWorker {
                     break;
                 }
                 Err(WriteError::PartialWrite) => {
-                    self.tx_has_rate_limit_permit = false;
+                    if now.is_some() {
+                        self.tx_has_rate_limit_permit = false;
+                    }
                     log::trace!("process_tx: partial write");
                     /*
                     This situation should be pretty rare, assuming reasonably sized socket buffers.
@@ -511,7 +531,7 @@ impl NetWorker {
                 .map_err(TxError::DeviceError)?;
         }
 
-        if rate_limit_changed {
+        if let (true, Some(now)) = (rate_limit_changed, now) {
             self.arm_rate_limit_timer(now);
         }
 
@@ -526,13 +546,14 @@ impl NetWorker {
             log::error!("failed to consume virtio-net rate-limit timer: {err}");
             return;
         }
+        self.armed_rate_limit_deadline = None;
 
         let now = Instant::now();
         let retry_rx = self.rx_resume_at.is_some_and(|deadline| deadline <= now);
         let retry_tx = self.tx_resume_at.is_some_and(|deadline| deadline <= now);
         if retry_rx {
             self.rx_resume_at = None;
-            if let Err(err) = self.process_rx_at(now) {
+            if let Err(err) = self.process_rx_at(Some(now)) {
                 log::error!("failed to process rate-limited RX frame: {err:?}");
             }
         }
@@ -548,6 +569,9 @@ impl NetWorker {
             return;
         };
         let deadline = self.rx_resume_at.into_iter().chain(self.tx_resume_at).min();
+        if deadline == self.armed_rate_limit_deadline {
+            return;
+        }
         let result = match deadline {
             Some(deadline) => timer.arm_oneshot(
                 deadline
@@ -556,8 +580,9 @@ impl NetWorker {
             ),
             None => timer.disarm(),
         };
-        if let Err(err) = result {
-            log::error!("failed to arm virtio-net rate-limit timer: {err}");
+        match result {
+            Ok(()) => self.armed_rate_limit_deadline = deadline,
+            Err(err) => log::error!("failed to arm virtio-net rate-limit timer: {err}"),
         }
     }
 
@@ -799,6 +824,7 @@ mod tests {
                 .map(|config| RateLimiter::new(config, now).unwrap()),
             tx_resume_at: None,
             rate_limit_timer: None,
+            armed_rate_limit_deadline: None,
         }
     }
 
@@ -834,11 +860,11 @@ mod tests {
             start,
         );
 
-        worker.process_tx_at(start).unwrap();
+        worker.process_tx_at(Some(start)).unwrap();
         assert_eq!(worker.tx_q.queue.next_used.0, 0);
         assert_eq!(state.lock().unwrap().tx_attempts, 1);
 
-        worker.process_tx_at(start).unwrap();
+        worker.process_tx_at(Some(start)).unwrap();
         assert_eq!(worker.tx_q.queue.next_used.0, 1);
         assert_eq!(worker.tx_resume_at, Some(start + REFILL_TIME));
         {
@@ -848,12 +874,12 @@ mod tests {
         }
 
         worker
-            .process_tx_at(start + REFILL_TIME - Duration::from_nanos(1))
+            .process_tx_at(Some(start + REFILL_TIME - Duration::from_nanos(1)))
             .unwrap();
         assert_eq!(worker.tx_q.queue.next_used.0, 1);
         assert_eq!(state.lock().unwrap().tx_attempts, 2);
 
-        worker.process_tx_at(start + REFILL_TIME).unwrap();
+        worker.process_tx_at(Some(start + REFILL_TIME)).unwrap();
         assert_eq!(worker.tx_q.queue.next_used.0, 2);
         assert_eq!(worker.tx_resume_at, None);
         let state = state.lock().unwrap();
@@ -892,18 +918,18 @@ mod tests {
             start,
         );
 
-        worker.process_rx_at(start).unwrap();
+        worker.process_rx_at(Some(start)).unwrap();
         assert_eq!(worker.rx_q.queue.next_used.0, 1);
         assert!(worker.rx_has_deferred_frame);
         assert_eq!(worker.rx_resume_at, Some(start + REFILL_TIME));
 
         worker
-            .process_rx_at(start + REFILL_TIME - Duration::from_nanos(1))
+            .process_rx_at(Some(start + REFILL_TIME - Duration::from_nanos(1)))
             .unwrap();
         assert_eq!(worker.rx_q.queue.next_used.0, 1);
         assert!(worker.rx_has_deferred_frame);
 
-        worker.process_rx_at(start + REFILL_TIME).unwrap();
+        worker.process_rx_at(Some(start + REFILL_TIME)).unwrap();
         assert_eq!(worker.rx_q.queue.next_used.0, 2);
         assert!(!worker.rx_has_deferred_frame);
         assert_eq!(worker.rx_resume_at, None);

--- a/src/devices/src/virtio/net/worker.rs
+++ b/src/devices/src/virtio/net/worker.rs
@@ -393,6 +393,10 @@ impl NetWorker {
     }
 
     fn process_tx(&mut self) -> result::Result<(), TxError> {
+        self.process_tx_at(Instant::now())
+    }
+
+    fn process_tx_at(&mut self, now: Instant) -> result::Result<(), TxError> {
         let tx_queue = &mut self.tx_q.queue;
 
         if self.backend.has_unfinished_write()
@@ -448,7 +452,7 @@ impl NetWorker {
             if !self.tx_has_rate_limit_permit {
                 let frame_len = read_count.saturating_sub(vnet_hdr_len()) as u64;
                 if let Some(limiter) = &mut self.tx_rate_limiter {
-                    if let Err(deadline) = limiter.try_consume_frame(frame_len, Instant::now()) {
+                    if let Err(deadline) = limiter.try_consume_frame(frame_len, now) {
                         self.tx_resume_at = Some(deadline);
                         rate_limit_changed = true;
                         tx_queue.undo_pop();
@@ -508,7 +512,7 @@ impl NetWorker {
         }
 
         if rate_limit_changed {
-            self.arm_rate_limit_timer(Instant::now());
+            self.arm_rate_limit_timer(now);
         }
 
         Ok(())
@@ -658,6 +662,259 @@ fn timerfd_pollable(timer: &TimerFd) -> Pollable {
 fn event_source_pollable(source: EventSource) -> io::Result<Pollable> {
     match source.raw() {
         RawEventSource::Fd(fd) => Ok(fd),
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::collections::VecDeque;
+    use std::os::fd::{AsRawFd, RawFd};
+    use std::sync::{Arc, Mutex};
+
+    use crate::legacy::DummyIrqChip;
+    use crate::virtio::net::rate_limit::{RateLimiterConfig, TokenBucketConfig};
+    use crate::virtio::queue::tests::VirtQueue;
+    use crate::virtio::queue::VIRTQ_DESC_F_WRITE;
+
+    use super::*;
+
+    const QUEUE_MEMORY_SIZE: usize = 0x1_0000;
+    const RX_QUEUE_ADDR: GuestAddress = GuestAddress(0);
+    const TX_QUEUE_ADDR: GuestAddress = GuestAddress(0x1000);
+    const RX_BUFFER_ADDRS: [GuestAddress; 2] = [GuestAddress(0x4000), GuestAddress(0x5000)];
+    const TX_BUFFER_ADDRS: [GuestAddress; 2] = [GuestAddress(0x6000), GuestAddress(0x7000)];
+    const BUFFER_SIZE: u32 = 0x1000;
+    const REFILL_TIME: Duration = Duration::from_millis(100);
+
+    #[derive(Default)]
+    struct BackendState {
+        rx_frames: VecDeque<Vec<u8>>,
+        tx_frames: Vec<Vec<u8>>,
+        tx_attempts: usize,
+        reject_next_tx: bool,
+    }
+
+    struct TestBackend {
+        event: EventFd,
+        state: Arc<Mutex<BackendState>>,
+    }
+
+    impl NetBackend for TestBackend {
+        fn read_frame(&mut self, buf: &mut [u8]) -> result::Result<usize, ReadError> {
+            let Some(frame) = self.state.lock().unwrap().rx_frames.pop_front() else {
+                return Err(ReadError::NothingRead);
+            };
+            buf[..frame.len()].copy_from_slice(&frame);
+            Ok(frame.len())
+        }
+
+        fn write_frame(
+            &mut self,
+            hdr_len: usize,
+            buf: &mut [u8],
+        ) -> result::Result<(), WriteError> {
+            let mut state = self.state.lock().unwrap();
+            state.tx_attempts += 1;
+            if state.reject_next_tx {
+                state.reject_next_tx = false;
+                return Err(WriteError::NothingWritten);
+            }
+            state.tx_frames.push(buf[hdr_len..].to_vec());
+            Ok(())
+        }
+
+        fn has_unfinished_write(&self) -> bool {
+            false
+        }
+
+        fn try_finish_write(
+            &mut self,
+            _hdr_len: usize,
+            _buf: &[u8],
+        ) -> result::Result<(), WriteError> {
+            Ok(())
+        }
+
+        fn raw_socket_fd(&self) -> RawFd {
+            self.event.as_raw_fd()
+        }
+    }
+
+    fn frame(payload: &[u8]) -> Vec<u8> {
+        let mut frame = vec![0; vnet_hdr_len()];
+        frame.extend_from_slice(payload);
+        frame
+    }
+
+    fn ops_limiter() -> RateLimiterConfig {
+        RateLimiterConfig {
+            bandwidth: None,
+            ops: Some(TokenBucketConfig {
+                size: 1,
+                refill_time: REFILL_TIME,
+                one_time_burst: 0,
+            }),
+        }
+    }
+
+    fn device_queue(queue: crate::virtio::Queue) -> DeviceQueue {
+        DeviceQueue::new(queue, Arc::new(EventFd::new(0).unwrap()))
+    }
+
+    fn worker(
+        mem: GuestMemoryMmap,
+        rx_q: DeviceQueue,
+        tx_q: DeviceQueue,
+        backend_state: Arc<Mutex<BackendState>>,
+        rate_limiters: RateLimiters,
+        now: Instant,
+    ) -> NetWorker {
+        let backend = TestBackend {
+            event: EventFd::new(0).unwrap(),
+            state: backend_state,
+        };
+        NetWorker {
+            rx_q,
+            tx_q,
+            interrupt: InterruptTransport::new(DummyIrqChip::new().into(), "test-net".into())
+                .unwrap(),
+            mem,
+            backend: Box::new(backend),
+            rx_frame_buf: [0; MAX_BUFFER_SIZE],
+            rx_frame_buf_len: 0,
+            rx_has_deferred_frame: false,
+            rx_has_rate_limit_permit: false,
+            rx_rate_limiter: rate_limiters
+                .rx
+                .as_ref()
+                .map(|config| RateLimiter::new(config, now).unwrap()),
+            rx_resume_at: None,
+            tx_iovec: Vec::with_capacity(QUEUE_SIZE as usize),
+            tx_frame_buf: [0; MAX_BUFFER_SIZE],
+            tx_frame_len: 0,
+            tx_has_rate_limit_permit: false,
+            tx_rate_limiter: rate_limiters
+                .tx
+                .as_ref()
+                .map(|config| RateLimiter::new(config, now).unwrap()),
+            tx_resume_at: None,
+            rate_limit_timer: None,
+        }
+    }
+
+    #[test]
+    fn tx_retries_backpressure_without_double_charging_and_resumes_at_deadline() {
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), QUEUE_MEMORY_SIZE)]).unwrap();
+        let rx_vq = VirtQueue::new(RX_QUEUE_ADDR, &mem, 8);
+        let tx_vq = VirtQueue::new(TX_QUEUE_ADDR, &mem, 8);
+        let frames = [frame(b"first"), frame(b"second")];
+        for (index, frame) in frames.iter().enumerate() {
+            mem.write_slice(frame, TX_BUFFER_ADDRS[index]).unwrap();
+            tx_vq.dtable[index].set(TX_BUFFER_ADDRS[index].0, frame.len() as u32, 0, 0);
+            tx_vq.avail.ring[index].set(index as u16);
+        }
+        tx_vq.avail.idx.set(frames.len() as u16);
+
+        let state = Arc::new(Mutex::new(BackendState {
+            reject_next_tx: true,
+            ..BackendState::default()
+        }));
+        let rx_q = device_queue(rx_vq.create_queue());
+        let tx_q = device_queue(tx_vq.create_queue());
+        let start = Instant::now();
+        let mut worker = worker(
+            mem.clone(),
+            rx_q,
+            tx_q,
+            Arc::clone(&state),
+            RateLimiters {
+                rx: None,
+                tx: Some(ops_limiter()),
+            },
+            start,
+        );
+
+        worker.process_tx_at(start).unwrap();
+        assert_eq!(worker.tx_q.queue.next_used.0, 0);
+        assert_eq!(state.lock().unwrap().tx_attempts, 1);
+
+        worker.process_tx_at(start).unwrap();
+        assert_eq!(worker.tx_q.queue.next_used.0, 1);
+        assert_eq!(worker.tx_resume_at, Some(start + REFILL_TIME));
+        {
+            let state = state.lock().unwrap();
+            assert_eq!(state.tx_attempts, 2);
+            assert_eq!(state.tx_frames, [b"first".to_vec()]);
+        }
+
+        worker
+            .process_tx_at(start + REFILL_TIME - Duration::from_nanos(1))
+            .unwrap();
+        assert_eq!(worker.tx_q.queue.next_used.0, 1);
+        assert_eq!(state.lock().unwrap().tx_attempts, 2);
+
+        worker.process_tx_at(start + REFILL_TIME).unwrap();
+        assert_eq!(worker.tx_q.queue.next_used.0, 2);
+        assert_eq!(worker.tx_resume_at, None);
+        let state = state.lock().unwrap();
+        assert_eq!(state.tx_attempts, 3);
+        assert_eq!(state.tx_frames, [b"first".to_vec(), b"second".to_vec()]);
+    }
+
+    #[test]
+    fn rx_preserves_deferred_frame_and_resumes_at_deadline() {
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), QUEUE_MEMORY_SIZE)]).unwrap();
+        let rx_vq = VirtQueue::new(RX_QUEUE_ADDR, &mem, 8);
+        let tx_vq = VirtQueue::new(TX_QUEUE_ADDR, &mem, 8);
+        for (index, address) in RX_BUFFER_ADDRS.iter().enumerate() {
+            rx_vq.dtable[index].set(address.0, BUFFER_SIZE, VIRTQ_DESC_F_WRITE, 0);
+            rx_vq.avail.ring[index].set(index as u16);
+        }
+        rx_vq.avail.idx.set(RX_BUFFER_ADDRS.len() as u16);
+
+        let frames = [frame(b"first"), frame(b"second")];
+        let state = Arc::new(Mutex::new(BackendState {
+            rx_frames: frames.iter().cloned().collect(),
+            ..BackendState::default()
+        }));
+        let rx_q = device_queue(rx_vq.create_queue());
+        let tx_q = device_queue(tx_vq.create_queue());
+        let start = Instant::now();
+        let mut worker = worker(
+            mem.clone(),
+            rx_q,
+            tx_q,
+            state,
+            RateLimiters {
+                rx: Some(ops_limiter()),
+                tx: None,
+            },
+            start,
+        );
+
+        worker.process_rx_at(start).unwrap();
+        assert_eq!(worker.rx_q.queue.next_used.0, 1);
+        assert!(worker.rx_has_deferred_frame);
+        assert_eq!(worker.rx_resume_at, Some(start + REFILL_TIME));
+
+        worker
+            .process_rx_at(start + REFILL_TIME - Duration::from_nanos(1))
+            .unwrap();
+        assert_eq!(worker.rx_q.queue.next_used.0, 1);
+        assert!(worker.rx_has_deferred_frame);
+
+        worker.process_rx_at(start + REFILL_TIME).unwrap();
+        assert_eq!(worker.rx_q.queue.next_used.0, 2);
+        assert!(!worker.rx_has_deferred_frame);
+        assert_eq!(worker.rx_resume_at, None);
+        for (index, expected) in frames.iter().enumerate() {
+            let mut actual = vec![0; expected.len()];
+            worker
+                .mem
+                .read_slice(&mut actual, RX_BUFFER_ADDRS[index])
+                .unwrap();
+            assert_eq!(&actual, expected);
+        }
     }
 }
 

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -21,9 +21,9 @@ use super::builders::DiskBuilder;
 use super::builders::FsBuilder;
 #[cfg(not(feature = "tee"))]
 use super::builders::FsConfig;
-use super::builders::{ConsoleBuilder, ExecBuilder, KernelBuilder, MachineBuilder};
 #[cfg(feature = "net")]
-use super::builders::{NetBuilder, NetConfig};
+use super::builders::{ConfiguredNet, NetBuilder, NetConfig};
+use super::builders::{ConsoleBuilder, ExecBuilder, KernelBuilder, MachineBuilder};
 use super::builders::{VsockBuilder, VsockRoute};
 
 use super::error::{BuildError, ConfigError, Error, Result};
@@ -657,6 +657,10 @@ impl VmBuilder {
         // Apply network configuration
         #[cfg(feature = "net")]
         for (i, config) in self.net.configs.into_iter().enumerate() {
+            let ConfiguredNet {
+                backend: config,
+                rate_limiters,
+            } = config;
             let (mac, backend) = match config {
                 #[cfg(unix)]
                 NetConfig::UnixgramFd { mac, fd } => {
@@ -691,6 +695,7 @@ impl VmBuilder {
                 backend,
                 mac,
                 features: 0,
+                rate_limiters,
             };
 
             vmr.net

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -27,6 +27,8 @@ use crate::backends::net::NetBackend;
 #[cfg(not(target_os = "windows"))]
 use crate::backends::vsock::VsockDatagramPortBackend;
 use crate::backends::vsock::VsockPortBackend;
+#[cfg(feature = "net")]
+use devices::virtio::net::rate_limit::{RateLimiterConfig, RateLimiters};
 
 //--------------------------------------------------------------------------------------------------
 // Types: Machine Builder
@@ -200,11 +202,19 @@ pub enum FsConfig {
 /// ```
 #[cfg(feature = "net")]
 pub struct NetBuilder {
-    pub(crate) configs: Vec<NetConfig>,
+    pub(crate) configs: Vec<ConfiguredNet>,
     current_mac: Option<[u8; 6]>,
+    current_rate_limiters: RateLimiters,
 }
 
 /// Configuration for a single network device.
+#[cfg(feature = "net")]
+pub(crate) struct ConfiguredNet {
+    pub(crate) backend: NetConfig,
+    pub(crate) rate_limiters: RateLimiters,
+}
+
+/// Backend configuration for a single network device.
 #[cfg(feature = "net")]
 pub enum NetConfig {
     /// Unixgram backend from a pre-opened fd.
@@ -765,6 +775,7 @@ impl NetBuilder {
         Self {
             configs: Vec::new(),
             current_mac: None,
+            current_rate_limiters: RateLimiters::default(),
         }
     }
 
@@ -774,11 +785,23 @@ impl NetBuilder {
         self
     }
 
+    /// Limit frames received by the guest on the next network device.
+    pub fn rx_rate_limiter(mut self, config: RateLimiterConfig) -> Self {
+        self.current_rate_limiters.rx = Some(config);
+        self
+    }
+
+    /// Limit frames transmitted by the guest on the next network device.
+    pub fn tx_rate_limiter(mut self, config: RateLimiterConfig) -> Self {
+        self.current_rate_limiters.tx = Some(config);
+        self
+    }
+
     /// Attach a unixgram network backend from a pre-opened fd.
     #[cfg(unix)]
     pub fn unixgram(mut self, fd: OwnedFd) -> Self {
         let mac = self.current_mac.take();
-        self.configs.push(NetConfig::UnixgramFd { mac, fd });
+        self.push_config(NetConfig::UnixgramFd { mac, fd });
         self
     }
 
@@ -786,7 +809,7 @@ impl NetBuilder {
     #[cfg(unix)]
     pub fn unixgram_path(mut self, path: impl AsRef<Path>, send_vfkit_magic: bool) -> Self {
         let mac = self.current_mac.take();
-        self.configs.push(NetConfig::UnixgramPath {
+        self.push_config(NetConfig::UnixgramPath {
             mac,
             path: path.as_ref().to_path_buf(),
             send_vfkit_magic,
@@ -798,7 +821,7 @@ impl NetBuilder {
     #[cfg(unix)]
     pub fn unixstream(mut self, fd: OwnedFd) -> Self {
         let mac = self.current_mac.take();
-        self.configs.push(NetConfig::UnixstreamFd { mac, fd });
+        self.push_config(NetConfig::UnixstreamFd { mac, fd });
         self
     }
 
@@ -806,7 +829,7 @@ impl NetBuilder {
     #[cfg(unix)]
     pub fn unixstream_path(mut self, path: impl AsRef<Path>) -> Self {
         let mac = self.current_mac.take();
-        self.configs.push(NetConfig::UnixstreamPath {
+        self.push_config(NetConfig::UnixstreamPath {
             mac,
             path: path.as_ref().to_path_buf(),
         });
@@ -817,7 +840,7 @@ impl NetBuilder {
     #[cfg(target_os = "linux")]
     pub fn tap(mut self, name: impl Into<String>) -> Self {
         let mac = self.current_mac.take();
-        self.configs.push(NetConfig::Tap {
+        self.push_config(NetConfig::Tap {
             mac,
             name: name.into(),
         });
@@ -828,7 +851,7 @@ impl NetBuilder {
     #[cfg(windows)]
     pub fn named_pipe(mut self, name: impl Into<String>) -> Self {
         let mac = self.current_mac.take();
-        self.configs.push(NetConfig::NamedPipe {
+        self.push_config(NetConfig::NamedPipe {
             mac,
             name: name.into(),
         });
@@ -838,8 +861,16 @@ impl NetBuilder {
     /// Use a custom network backend.
     pub fn custom(mut self, backend: Box<dyn NetBackend + Send>) -> Self {
         let mac = self.current_mac.take();
-        self.configs.push(NetConfig::Custom { mac, backend });
+        self.push_config(NetConfig::Custom { mac, backend });
         self
+    }
+
+    fn push_config(&mut self, backend: NetConfig) {
+        let rate_limiters = std::mem::take(&mut self.current_rate_limiters);
+        self.configs.push(ConfiguredNet {
+            backend,
+            rate_limiters,
+        });
     }
 }
 
@@ -1250,6 +1281,38 @@ mod tests {
         assert!(MachineBuilder::new().msb_metrics);
         assert!(!MachineBuilder::new().msb_metrics(false).msb_metrics);
         assert!(MachineBuilder::new().msb_metrics(true).msb_metrics);
+    }
+
+    #[cfg(all(feature = "net", unix))]
+    #[test]
+    fn network_rate_limiters_apply_only_to_the_next_device() {
+        use std::os::fd::OwnedFd;
+        use std::os::unix::net::UnixDatagram;
+
+        let (first, _) = UnixDatagram::pair().unwrap();
+        let (second, _) = UnixDatagram::pair().unwrap();
+        let limiter = RateLimiterConfig {
+            bandwidth: Some(devices::virtio::net::rate_limit::TokenBucketConfig {
+                size: 1_048_576,
+                refill_time: Duration::from_secs(1),
+                one_time_burst: 524_288,
+            }),
+            ops: Some(devices::virtio::net::rate_limit::TokenBucketConfig {
+                size: 1_000,
+                refill_time: Duration::from_secs(1),
+                one_time_burst: 0,
+            }),
+        };
+
+        let builder = NetBuilder::new()
+            .rx_rate_limiter(limiter.clone())
+            .tx_rate_limiter(limiter.clone())
+            .unixgram(OwnedFd::from(first))
+            .unixgram(OwnedFd::from(second));
+
+        assert_eq!(builder.configs[0].rate_limiters.rx, Some(limiter.clone()));
+        assert_eq!(builder.configs[0].rate_limiters.tx, Some(limiter));
+        assert!(builder.configs[1].rate_limiters.is_empty());
     }
 
     #[cfg(target_os = "windows")]

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -62,6 +62,10 @@ pub use api::metrics::{
 pub use api::vm::Vm;
 #[cfg(not(feature = "tee"))]
 pub use api::vm::{VmControl, VmCpuState, VmMemoryState};
+#[cfg(feature = "net")]
+pub use devices::virtio::net::rate_limit::{
+    RateLimiterConfig, RateLimiterConfigError, TokenBucketConfig,
+};
 
 #[cfg(not(target_os = "windows"))]
 pub use backends::console::ConsolePortBackend;

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -8,6 +8,8 @@ use devices::virtio::block::{ImageType, SyncMode};
 use devices::virtio::gpu::display::DisplayInfo;
 #[cfg(feature = "net")]
 use devices::virtio::net::device::VirtioNetBackend;
+#[cfg(feature = "net")]
+use devices::virtio::net::rate_limit::RateLimiters;
 #[cfg(feature = "blk")]
 use devices::virtio::CacheType;
 use env_logger::{Env, Target};
@@ -2120,6 +2122,7 @@ fn create_virtio_net(
         backend,
         mac,
         features,
+        rate_limiters: RateLimiters::default(),
     };
     ctx_cfg.net_index += 1;
     ctx_cfg

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -7,6 +7,7 @@ use std::result;
 use std::sync::{Arc, Mutex};
 
 use devices::virtio::net::device::VirtioNetBackend;
+use devices::virtio::net::rate_limit::RateLimiters;
 use devices::virtio::Net;
 
 pub struct NetworkInterfaceConfig {
@@ -18,6 +19,8 @@ pub struct NetworkInterfaceConfig {
     pub mac: [u8; 6],
     /// virtio-net features for the network interface.
     pub features: u32,
+    /// Optional receive and transmit rate limiters.
+    pub rate_limiters: RateLimiters,
 }
 
 /// Errors associated with `NetworkInterfaceConfig`.
@@ -65,7 +68,13 @@ impl NetBuilder {
     /// Creates a Net device from a NetworkInterfaceConfig.
     pub fn create_net(cfg: NetworkInterfaceConfig) -> Result<Net> {
         // Create and return the Net device
-        Net::new(cfg.iface_id, cfg.backend, cfg.mac, cfg.features)
-            .map_err(NetworkInterfaceError::CreateNetworkDevice)
+        Net::new_with_rate_limiters(
+            cfg.iface_id,
+            cfg.backend,
+            cfg.mac,
+            cfg.features,
+            cfg.rate_limiters,
+        )
+        .map_err(NetworkInterfaceError::CreateNetworkDevice)
     }
 }


### PR DESCRIPTION
## Summary

- Add independent RX and TX rate limiters to virtio-net devices.
- Enforce bandwidth and frame-operation token buckets atomically.
- Delay RX delivery and backpressure TX virtqueues until tokens refill.
- Expose per-device rate-limit configuration through the Rust `NetBuilder`.

## Why

Enforcing limits at the virtio boundary prevents upstream queue growth and applies ingress limits immediately before guest delivery.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p msb_krun_devices --features net --lib`
- `cargo test -p msb_krun --features net --lib`
- `cargo clippy -p msb_krun_devices -p msb_krun --features net -- -D warnings`