### PR TITLE
refactor(net): borrow rate-limiter config during activation

### DIFF
--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -213,8 +213,6 @@ impl VirtioDevice for Net {
             error!("Cannot activate net device: backend already taken");
             ActivateError::BadActivate
         })?;
-        let rate_limiters = std::mem::take(&mut self.rate_limiters);
-
         match NetWorker::new(
             rx_q,
             tx_q,
@@ -222,7 +220,7 @@ impl VirtioDevice for Net {
             mem.clone(),
             self.acked_features,
             cfg_backend,
-            rate_limiters,
+            &self.rate_limiters,
         ) {
             Ok(worker) => {
                 worker.run();

--- a/src/devices/src/virtio/net/worker.rs
+++ b/src/devices/src/virtio/net/worker.rs
@@ -73,7 +73,7 @@ impl NetWorker {
         mem: GuestMemoryMmap,
         _vnet_features: u64,
         cfg_backend: VirtioNetBackend,
-        rate_limiters: RateLimiters,
+        rate_limiters: &RateLimiters,
     ) -> Result<Self, ConnectError> {
         let backend = match cfg_backend {
             #[cfg(unix)]


### PR DESCRIPTION
## TL;DR

Borrow the static network rate-limiter configuration while constructing the virtio-net worker instead of moving it out of the device.

## Description

- Pass `RateLimiters` to `NetWorker::new` by immutable reference.
- Remove the `std::mem::take` from device activation.
- Preserve the configuration on `Net` without cloning it.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test --locked -p msb_krun_devices --features net virtio::net`
- `cargo test --locked -p msb_krun --features net network_rate_limiters`
- `LIBCLANG_PATH=/Library/Developer/CommandLineTools/usr/lib cargo clippy --locked --features efi,gpu -- -D warnings`
