### PR TITLE
chore(krun): bump msb_krun crates to 0.1.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -931,11 +931,11 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.28"
+version = "0.1.29"
 
 [[package]]
 name = "msb_krun_aws_nitro"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "libc",
  "log",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_display"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "bindgen 0.72.0",
  "bitflags 2.10.0",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "crossbeam-channel",
  "libloading",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_input"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "bindgen 0.72.0",
  "bitflags 2.10.0",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "msb_krun_utils",
  "vm-memory",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_rutabaga_gfx"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1058,14 +1058,14 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -722,7 +722,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "msb_krun_display"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "bindgen",
  "bitflags 2.11.0",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_input"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "bindgen",
  "bitflags 2.11.0",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_arch"
-version = "0.1.28"
+version = "0.1.29"
 authors = ["The Chromium OS Authors"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
@@ -17,9 +17,9 @@ efi = []
 libc = ">=0.2.39"
 vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
 
-arch_gen = { package = "msb_krun_arch_gen", version = "0.1.28", path = "../arch_gen" }
-smbios = { package = "msb_krun_smbios", version = "0.1.28", path = "../smbios" }
-utils = { package = "msb_krun_utils", version = "0.1.28", path = "../utils" }
+arch_gen = { package = "msb_krun_arch_gen", version = "0.1.29", path = "../arch_gen" }
+smbios = { package = "msb_krun_smbios", version = "0.1.29", path = "../smbios" }
+utils = { package = "msb_krun_utils", version = "0.1.29", path = "../utils" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
@@ -27,4 +27,4 @@ kvm-ioctls = ">=0.21"
 tdx = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
-utils = { package = "msb_krun_utils", version = "0.1.28", path = "../utils" }
+utils = { package = "msb_krun_utils", version = "0.1.29", path = "../utils" }

--- a/src/arch_gen/Cargo.toml
+++ b/src/arch_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_arch_gen"
-version = "0.1.28"
+version = "0.1.29"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"

--- a/src/aws_nitro/Cargo.toml
+++ b/src/aws_nitro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_aws_nitro"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2021"
 license = "Apache-2.0"
 description = "AWS Nitro Enclaves support for msb_krun microVMs"
@@ -15,7 +15,7 @@ nix = { version = "0.30", features = ["poll"] }
 tar = "0.4"
 vsock = "0.5"
 
-devices = { package = "msb_krun_devices", version = "0.1.28", path = "../devices" }
+devices = { package = "msb_krun_devices", version = "0.1.29", path = "../devices" }
 log = "0.4"
 signal-hook = "0.3"
 

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_cpuid"
-version = "0.1.28"
+version = "0.1.29"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_devices"
-version = "0.1.28"
+version = "0.1.29"
 authors = ["The Chromium OS Authors"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
@@ -34,21 +34,21 @@ thiserror = { version = "2.0", optional = true }
 virtio-bindings = "0.2.0"
 vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
 zerocopy = { version = "0.8.26", optional = true, features = ["derive"] }
-krun_display = { package = "msb_krun_display", version = "0.1.28", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
-krun_input = { package = "msb_krun_input", version = "0.1.28", path = "../krun_input", features = ["bindgen_clang_runtime"], optional = true }
+krun_display = { package = "msb_krun_display", version = "0.1.29", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
+krun_input = { package = "msb_krun_input", version = "0.1.29", path = "../krun_input", features = ["bindgen_clang_runtime"], optional = true }
 
-arch = { package = "msb_krun_arch", version = "0.1.28", path = "../arch" }
-utils = { package = "msb_krun_utils", version = "0.1.28", path = "../utils" }
-polly = { package = "msb_krun_polly", version = "0.1.28", path = "../polly" }
-rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.28", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
+arch = { package = "msb_krun_arch", version = "0.1.29", path = "../arch" }
+utils = { package = "msb_krun_utils", version = "0.1.29", path = "../utils" }
+polly = { package = "msb_krun_polly", version = "0.1.29", path = "../polly" }
+rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.29", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
 imago = { package = "msb-imago", version = "0.1.4", features = ["sync-wrappers", "vm-memory"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "msb_krun_hvf", version = "0.1.28", path = "../hvf" }
+hvf = { package = "msb_krun_hvf", version = "0.1.29", path = "../hvf" }
 lru = ">=0.9"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.28", path = "../rutabaga_gfx", features = ["x"], optional = true }
+rutabaga_gfx = { package = "msb_krun_rutabaga_gfx", version = "0.1.29", path = "../rutabaga_gfx", features = ["x"], optional = true }
 capng = "0.2.3"
 caps = "0.5.5"
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }

--- a/src/hvf/Cargo.toml
+++ b/src/hvf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_hvf"
-version = "0.1.28"
+version = "0.1.29"
 authors = ["Sergio Lopez <slp@sinrega.org>"]
 edition = "2021"
 build = "build.rs"
@@ -13,4 +13,4 @@ crossbeam-channel = ">=0.5.15"
 libloading = "0.8"
 log = "0.4.0"
 
-arch = { package = "msb_krun_arch", version = "0.1.28", path = "../arch" }
+arch = { package = "msb_krun_arch", version = "0.1.29", path = "../arch" }

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_kernel"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
 description = "Kernel loading utilities for msb_krun microVMs"
@@ -9,4 +9,4 @@ repository = "https://github.com/containers/libkrun"
 [dependencies]
 vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
 
-utils = { package = "msb_krun_utils", version = "0.1.28", path = "../utils" }
+utils = { package = "msb_krun_utils", version = "0.1.29", path = "../utils" }

--- a/src/krun/Cargo.toml
+++ b/src/krun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun"
-version = "0.1.28"
+version = "0.1.29"
 authors = ["The libkrun Authors"]
 edition = "2021"
 description = "Native Rust API for libkrun microVMs"
@@ -26,21 +26,21 @@ libc = ">=0.2.39"
 libloading = "0.8"
 log = "0.4.0"
 
-devices = { package = "msb_krun_devices", version = "0.1.28", path = "../devices" }
-polly = { package = "msb_krun_polly", version = "0.1.28", path = "../polly" }
-utils = { package = "msb_krun_utils", version = "0.1.28", path = "../utils" }
-vmm = { package = "msb_krun_vmm", version = "0.1.28", path = "../vmm" }
+devices = { package = "msb_krun_devices", version = "0.1.29", path = "../devices" }
+polly = { package = "msb_krun_polly", version = "0.1.29", path = "../polly" }
+utils = { package = "msb_krun_utils", version = "0.1.29", path = "../utils" }
+vmm = { package = "msb_krun_vmm", version = "0.1.29", path = "../vmm" }
 
 # Optional dependencies
-krun_display = { package = "msb_krun_display", version = "0.1.28", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
-krun_input = { package = "msb_krun_input", version = "0.1.28", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
+krun_display = { package = "msb_krun_display", version = "0.1.29", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
+krun_input = { package = "msb_krun_input", version = "0.1.29", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "msb_krun_hvf", version = "0.1.28", path = "../hvf" }
+hvf = { package = "msb_krun_hvf", version = "0.1.29", path = "../hvf" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"
 vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
-aws-nitro = { package = "msb_krun_aws_nitro", version = "0.1.28", path = "../aws_nitro", optional = true }
+aws-nitro = { package = "msb_krun_aws_nitro", version = "0.1.29", path = "../aws_nitro", optional = true }
 nitro-enclaves = { version = "0.6.0", optional = true }

--- a/src/krun_display/Cargo.toml
+++ b/src/krun_display/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msb_krun_display"
 description = "Rust bindings for implemeting display backends in Rust for libkrun"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/containers/libkrun"

--- a/src/krun_input/Cargo.toml
+++ b/src/krun_input/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msb_krun_input"
 description = "Rust bindings for implementing input backends in Rust for libkrun"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/containers/libkrun"

--- a/src/polly/Cargo.toml
+++ b/src/polly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_polly"
-version = "0.1.28"
+version = "0.1.29"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -9,4 +9,4 @@ repository = "https://github.com/containers/libkrun"
 
 [dependencies]
 libc = ">=0.2.39"
-utils = { package = "msb_krun_utils", version = "0.1.28", path = "../utils" }
+utils = { package = "msb_krun_utils", version = "0.1.29", path = "../utils" }

--- a/src/rutabaga_gfx/Cargo.toml
+++ b/src/rutabaga_gfx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_rutabaga_gfx"
-version = "0.1.28"
+version = "0.1.29"
 authors = ["The ChromiumOS Authors + Android Open Source Project"]
 edition = "2021"
 description = "[highly unstable] Handling virtio-gpu protocols"

--- a/src/smbios/Cargo.toml
+++ b/src/smbios/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_smbios"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2021"
 license = "Apache-2.0"
 description = "SMBIOS table generation for msb_krun microVMs"

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_utils"
-version = "0.1.28"
+version = "0.1.29"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb_krun_vmm"
-version = "0.1.28"
+version = "0.1.29"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"
@@ -26,15 +26,15 @@ libc = ">=0.2.39"
 log = "0.4.0"
 nix = { version = "0.30.1", features = ["fs", "term"] }
 vm-memory = { version = "~0.18", default-features = false, features = ["backend-mmap"] }
-krun_display = { package = "msb_krun_display", version = "0.1.28", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
-krun_input = { package = "msb_krun_input", version = "0.1.28", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
+krun_display = { package = "msb_krun_display", version = "0.1.29", path = "../krun_display", optional = true, features = ["bindgen_clang_runtime"] }
+krun_input = { package = "msb_krun_input", version = "0.1.29", path = "../krun_input", optional = true, features = ["bindgen_clang_runtime"] }
 
-arch = { package = "msb_krun_arch", version = "0.1.28", path = "../arch" }
-arch_gen = { package = "msb_krun_arch_gen", version = "0.1.28", path = "../arch_gen" }
-devices = { package = "msb_krun_devices", version = "0.1.28", path = "../devices" }
-kernel = { package = "msb_krun_kernel", version = "0.1.28", path = "../kernel" }
-utils = { package = "msb_krun_utils", version = "0.1.28", path = "../utils" }
-polly = { package = "msb_krun_polly", version = "0.1.28", path = "../polly" }
+arch = { package = "msb_krun_arch", version = "0.1.29", path = "../arch" }
+arch_gen = { package = "msb_krun_arch_gen", version = "0.1.29", path = "../arch_gen" }
+devices = { package = "msb_krun_devices", version = "0.1.29", path = "../devices" }
+kernel = { package = "msb_krun_kernel", version = "0.1.29", path = "../kernel" }
+utils = { package = "msb_krun_utils", version = "0.1.29", path = "../utils" }
+polly = { package = "msb_krun_polly", version = "0.1.29", path = "../polly" }
 
 # Dependencies for amd-sev
 kbs-types = { version = "0.13.0", optional = true }
@@ -49,7 +49,7 @@ bzip2 = "0.5"
 zstd = "0.13"
 
 [target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dependencies]
-cpuid = { package = "msb_krun_cpuid", version = "0.1.28", path = "../cpuid" }
+cpuid = { package = "msb_krun_cpuid", version = "0.1.29", path = "../cpuid" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tdx = { version = "0.1.0", optional = true }
@@ -57,11 +57,11 @@ kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "msb_krun_hvf", version = "0.1.28", path = "../hvf" }
+hvf = { package = "msb_krun_hvf", version = "0.1.29", path = "../hvf" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 libloading = "0.8"
 windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_System_Hypervisor", "Win32_System_ProcessStatus", "Win32_System_SystemInformation", "Win32_System_Threading"] }
 
 [dev-dependencies]
-devices = { package = "msb_krun_devices", version = "0.1.28", path = "../devices", features = ["test_utils"] }
+devices = { package = "msb_krun_devices", version = "0.1.29", path = "../devices", features = ["test_utils"] }


### PR DESCRIPTION
## TL;DR

Version bump so virtio-net ingress and egress rate limiting ships to crates.io as the coordinated `msb_krun` 0.1.29 release.

## Description

- Bumps all 15 `msb_krun`-family crates from 0.1.28 to 0.1.29, including every internal dependency reference.
- Refreshes the root and examples lockfiles without changing unrelated dependencies.
- Carries per-direction bandwidth, burst, and operation rate limits for virtio-net.

## Test Plan

- [x] all 15 `msb_krun`-family packages report version 0.1.29 through `cargo metadata`
- [x] no `0.1.28` references remain in Cargo manifests or lockfiles
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --all --locked`
- [x] `cargo check --all --locked`
- [x] `cargo test --all --locked`
- [x] `cargo clippy --all --locked -- -D warnings`
- [x] `cargo publish --dry-run --workspace --locked --allow-dirty`
- [ ] publish the coordinated 0.1.29 release to crates.io after merge
