### PR TITLE
feat(placement): report effective host placement

### DIFF
--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -25,6 +25,7 @@ use super::builders::FsBuilder;
 use super::builders::FsConfig;
 #[cfg(not(feature = "tee"))]
 use super::builders::HostMemoryPolicy;
+use super::builders::PlacementReport;
 #[cfg(feature = "net")]
 use super::builders::{ConfiguredNet, NetBuilder, NetConfig};
 use super::builders::{ConsoleBuilder, ExecBuilder, KernelBuilder, MachineBuilder};
@@ -94,6 +95,7 @@ pub struct VmBuilder {
     #[cfg(feature = "blk")]
     disk: DiskBuilder,
     exit_observers: Vec<Box<dyn Fn(i32) + Send + 'static>>,
+    placement_observer: Option<Box<dyn FnOnce(&PlacementReport) + Send + 'static>>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -122,6 +124,7 @@ impl VmBuilder {
             #[cfg(feature = "blk")]
             disk: DiskBuilder::new(),
             exit_observers: Vec::new(),
+            placement_observer: None,
         }
     }
 
@@ -323,6 +326,15 @@ impl VmBuilder {
     /// ```
     pub fn on_exit(mut self, f: impl Fn(i32) + Send + 'static) -> Self {
         self.exit_observers.push(Box::new(f));
+        self
+    }
+
+    /// Register a callback for the effective host placement established before guest execution.
+    ///
+    /// The callback runs once after every vCPU thread has attempted affinity and while all vCPUs
+    /// are still paused. Best-effort affinity may produce a mix of pinned and inherited entries.
+    pub fn on_placement(mut self, f: impl FnOnce(&PlacementReport) + Send + 'static) -> Self {
+        self.placement_observer = Some(Box::new(f));
         self
     }
 
@@ -557,6 +569,7 @@ impl VmBuilder {
         #[cfg(any(target_os = "linux", target_os = "windows"))]
         {
             vmr.vcpu_affinity = self.machine.vcpu_affinity;
+            vmr.vcpu_affinity_required = self.machine.vcpu_affinity_required;
         }
         vmr.numa_topology = self.machine.numa_topology;
 
@@ -815,6 +828,7 @@ impl VmBuilder {
             self.kernel.initramfs_path,
             self.kernel.init_path,
             self.exit_observers,
+            self.placement_observer,
             exit_evt,
             exit_code,
             #[cfg(not(target_os = "windows"))]
@@ -986,7 +1000,8 @@ fn validate_numa_topology_inner(
 
         match &node.host_memory {
             HostMemoryPolicy::Inherit => {}
-            HostMemoryPolicy::Bind { host_nodes } => {
+            HostMemoryPolicy::Bind { host_nodes }
+            | HostMemoryPolicy::PreferredMany { host_nodes } => {
                 if host_nodes.is_empty() {
                     return Err(Error::Config(ConfigError::InvalidNumaTopology(
                         "a bind policy requires at least one host node".into(),
@@ -1454,6 +1469,24 @@ mod tests {
             error,
             Error::Config(ConfigError::NumaUnsupported(_))
         ));
+    }
+
+    #[cfg(all(
+        target_os = "linux",
+        any(target_arch = "x86_64", target_arch = "aarch64"),
+        not(feature = "tee")
+    ))]
+    #[test]
+    fn build_accepts_linux_soft_numa_preference() {
+        let mut topology = one_node_topology(vec![0], 512);
+        topology.nodes[0].host_memory = HostMemoryPolicy::PreferredMany {
+            host_nodes: vec![0],
+        };
+
+        VmBuilder::new()
+            .machine(|machine| machine.memory_mib(512).numa_topology(topology))
+            .build()
+            .expect("Linux should accept a spillable host-node preference");
     }
 
     #[cfg(all(not(feature = "tee"), not(target_os = "windows")))]

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -25,6 +25,7 @@ use super::builders::FsBuilder;
 use super::builders::FsConfig;
 #[cfg(not(feature = "tee"))]
 use super::builders::HostMemoryPolicy;
+use super::builders::PlacementObserver;
 use super::builders::PlacementReport;
 #[cfg(feature = "net")]
 use super::builders::{ConfiguredNet, NetBuilder, NetConfig};
@@ -95,7 +96,7 @@ pub struct VmBuilder {
     #[cfg(feature = "blk")]
     disk: DiskBuilder,
     exit_observers: Vec<Box<dyn Fn(i32) + Send + 'static>>,
-    placement_observer: Option<Box<dyn FnOnce(&PlacementReport) + Send + 'static>>,
+    placement_observer: Option<PlacementObserver>,
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -14,6 +14,8 @@ pub use vmm::resources::{
 };
 pub use vmm::vmm_config::machine_config::HostCpuId;
 
+pub(crate) type PlacementObserver = Box<dyn FnOnce(&PlacementReport) + Send + 'static>;
+
 #[cfg(feature = "blk")]
 pub use devices::virtio::block::WritebackLimit;
 

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -8,7 +8,10 @@ use devices::virtio::console::port_io::{
     ConsolePortBackend, ConsolePortBackendInputAdapter, ConsolePortBackendOutputAdapter,
 };
 use vmm::resources::PortConfig;
-pub use vmm::resources::{HostMemoryPolicy, NumaDistance, NumaNodeConfig, NumaTopology};
+pub use vmm::resources::{
+    HostMemoryPolicy, MemoryPlacementResult, NumaDistance, NumaNodeConfig, NumaTopology,
+    PlacementReport, VcpuPlacementResult,
+};
 pub use vmm::vmm_config::machine_config::HostCpuId;
 
 #[cfg(feature = "blk")]
@@ -64,6 +67,7 @@ pub struct MachineBuilder {
     pub(crate) msb_metrics: bool,
     pub(crate) enable_inet_hijack: bool,
     pub(crate) vcpu_affinity: Option<Vec<HostCpuId>>,
+    pub(crate) vcpu_affinity_required: bool,
     pub(crate) numa_topology: Option<NumaTopology>,
 }
 
@@ -460,6 +464,7 @@ impl MachineBuilder {
             msb_metrics: true,
             enable_inet_hijack: false,
             vcpu_affinity: None,
+            vcpu_affinity_required: true,
             numa_topology: None,
         }
     }
@@ -493,6 +498,17 @@ impl MachineBuilder {
     /// with [`max_vcpus`](Self::max_vcpus). This is supported on Linux and Windows hosts.
     pub fn vcpu_affinity(mut self, affinity: Vec<HostCpuId>) -> Self {
         self.vcpu_affinity = Some(affinity);
+        self.vcpu_affinity_required = true;
+        self
+    }
+
+    /// Prefer to pin each possible vCPU thread to one resolved host logical processor.
+    ///
+    /// The map has the same shape as [`vcpu_affinity`](Self::vcpu_affinity), but an operating
+    /// system rejection is treated as a placement fallback instead of a VM-start failure.
+    pub fn try_vcpu_affinity(mut self, affinity: Vec<HostCpuId>) -> Self {
+        self.vcpu_affinity = Some(affinity);
+        self.vcpu_affinity_required = false;
         self
     }
 
@@ -725,6 +741,15 @@ impl NumaNodeBuilder {
     /// Bind future Linux page faults to the selected absolute host NUMA node IDs.
     pub fn bind_host_nodes(mut self, nodes: impl IntoIterator<Item = u32>) -> Self {
         self.host_memory = HostMemoryPolicy::Bind {
+            host_nodes: nodes.into_iter().collect(),
+        };
+        self
+    }
+
+    /// Prefer Linux page faults on the selected host NUMA nodes without making VM startup depend
+    /// on the kernel accepting the binding.
+    pub fn prefer_host_nodes(mut self, nodes: impl IntoIterator<Item = u32>) -> Self {
+        self.host_memory = HostMemoryPolicy::PreferredMany {
             host_nodes: nodes.into_iter().collect(),
         };
         self
@@ -1464,6 +1489,29 @@ mod tests {
             .vcpu_affinity(affinity.clone());
 
         assert_eq!(builder.vcpu_affinity, Some(affinity));
+        assert!(builder.vcpu_affinity_required);
+    }
+
+    #[test]
+    fn machine_builder_records_best_effort_vcpu_affinity() {
+        let affinity = vec![HostCpuId::new(2), HostCpuId::new(6)];
+        let builder = MachineBuilder::new()
+            .vcpus(2)
+            .try_vcpu_affinity(affinity.clone());
+
+        assert_eq!(builder.vcpu_affinity, Some(affinity));
+        assert!(!builder.vcpu_affinity_required);
+    }
+
+    #[test]
+    fn numa_node_builder_records_best_effort_linux_memory_policy() {
+        let linux = NumaNodeBuilder::new().prefer_host_nodes([2, 3]);
+        assert_eq!(
+            linux.host_memory,
+            HostMemoryPolicy::PreferredMany {
+                host_nodes: vec![2, 3]
+            }
+        );
     }
 
     #[test]

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -52,7 +52,8 @@ pub use builders::VsockBuilder;
 pub use builders::WritebackLimit;
 pub use builders::{
     ConsoleBuilder, ExecBuilder, HostCpuId, HostMemoryPolicy, KernelBuilder, MachineBuilder,
-    NumaBuilder, NumaDistance, NumaNodeBuilder, NumaNodeConfig, NumaTopology,
+    MemoryPlacementResult, NumaBuilder, NumaDistance, NumaNodeBuilder, NumaNodeConfig,
+    NumaTopology, PlacementReport, VcpuPlacementResult,
 };
 pub use error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use exit_handle::ExitHandle;

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -19,7 +19,6 @@ use devices::virtio::vsock::VsockPortBackend;
 use log::error;
 use polly::event_manager::EventManager;
 use utils::eventfd::EventFd;
-use vmm::resources::PlacementReport;
 #[cfg(not(target_os = "windows"))]
 use vmm::resources::TsiFlags;
 use vmm::resources::VmResources;
@@ -28,6 +27,7 @@ use vmm::vmm_config::kernel_bundle::KernelBundle;
 use vmm::vmm_config::kernel_cmdline::KernelCmdlineConfig;
 use vmm::vmm_config::vsock::VsockDeviceConfig;
 
+use super::builders::PlacementObserver;
 use super::error::{BuildError, Error, Result, RuntimeError};
 use super::exit_handle::ExitHandle;
 use super::metrics::MetricsHandle;
@@ -57,7 +57,7 @@ pub struct Vm {
     initramfs_path: Option<PathBuf>,
     init_path: Option<String>,
     exit_observers: Vec<Box<dyn Fn(i32) + Send + 'static>>,
-    placement_observer: Option<Box<dyn FnOnce(&PlacementReport) + Send + 'static>>,
+    placement_observer: Option<PlacementObserver>,
     /// Pre-created exit event fd for triggering VM shutdown.
     exit_evt: EventFd,
     /// Shared exit code — written by the VMM, readable by exit observers.
@@ -151,7 +151,7 @@ impl Vm {
         initramfs_path: Option<PathBuf>,
         init_path: Option<String>,
         exit_observers: Vec<Box<dyn Fn(i32) + Send + 'static>>,
-        placement_observer: Option<Box<dyn FnOnce(&PlacementReport) + Send + 'static>>,
+        placement_observer: Option<PlacementObserver>,
         exit_evt: EventFd,
         exit_code: Arc<AtomicI32>,
         #[cfg(not(target_os = "windows"))] enable_inet_hijack: bool,

--- a/src/krun/src/api/vm.rs
+++ b/src/krun/src/api/vm.rs
@@ -19,6 +19,7 @@ use devices::virtio::vsock::VsockPortBackend;
 use log::error;
 use polly::event_manager::EventManager;
 use utils::eventfd::EventFd;
+use vmm::resources::PlacementReport;
 #[cfg(not(target_os = "windows"))]
 use vmm::resources::TsiFlags;
 use vmm::resources::VmResources;
@@ -56,6 +57,7 @@ pub struct Vm {
     initramfs_path: Option<PathBuf>,
     init_path: Option<String>,
     exit_observers: Vec<Box<dyn Fn(i32) + Send + 'static>>,
+    placement_observer: Option<Box<dyn FnOnce(&PlacementReport) + Send + 'static>>,
     /// Pre-created exit event fd for triggering VM shutdown.
     exit_evt: EventFd,
     /// Shared exit code — written by the VMM, readable by exit observers.
@@ -149,6 +151,7 @@ impl Vm {
         initramfs_path: Option<PathBuf>,
         init_path: Option<String>,
         exit_observers: Vec<Box<dyn Fn(i32) + Send + 'static>>,
+        placement_observer: Option<Box<dyn FnOnce(&PlacementReport) + Send + 'static>>,
         exit_evt: EventFd,
         exit_code: Arc<AtomicI32>,
         #[cfg(not(target_os = "windows"))] enable_inet_hijack: bool,
@@ -173,6 +176,7 @@ impl Vm {
             initramfs_path,
             init_path,
             exit_observers,
+            placement_observer,
             exit_evt,
             exit_code,
             #[cfg(not(target_os = "windows"))]
@@ -298,7 +302,7 @@ impl Vm {
         // Build the microVM
         let (sender, _receiver) = unbounded();
 
-        let _vmm = vmm::builder::build_microvm(
+        let (_vmm, placement_report) = vmm::builder::build_microvm_paused(
             &mut self.vmr,
             &mut event_manager,
             shutdown_efd,
@@ -308,6 +312,17 @@ impl Vm {
         )
         .map_err(|e| Error::Build(BuildError::Start(format!("build_microvm: {e:?}"))))?;
         trace.mark("build_microvm.ready");
+
+        if let Some(observer) = self.placement_observer.take() {
+            observer(&placement_report);
+        }
+        trace.mark("placement.reconciled");
+
+        _vmm.lock()
+            .expect("Poisoned VMM mutex")
+            .resume_vcpus()
+            .map_err(|e| Error::Build(BuildError::Start(format!("resume_vcpus: {e:?}"))))?;
+        trace.mark("vcpus.resumed");
 
         // Register user exit observers
         {
@@ -680,6 +695,7 @@ mod tests {
             None,
             None,
             Vec::new(),
+            None,
             EventFd::new(EFD_NONBLOCK).unwrap(),
             Arc::new(AtomicI32::new(i32::MAX)),
             #[cfg(not(target_os = "windows"))]
@@ -708,6 +724,7 @@ mod tests {
             None,
             None,
             Vec::new(),
+            None,
             EventFd::new(EFD_NONBLOCK).unwrap(),
             Arc::new(AtomicI32::new(i32::MAX)),
             enable_inet_hijack,

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -54,7 +54,8 @@ pub use api::builders::VsockBuilder;
 pub use api::builders::WritebackLimit;
 pub use api::builders::{
     ConsoleBuilder, ExecBuilder, HostCpuId, HostMemoryPolicy, KernelBuilder, MachineBuilder,
-    NumaBuilder, NumaDistance, NumaNodeBuilder, NumaNodeConfig, NumaTopology,
+    MemoryPlacementResult, NumaBuilder, NumaDistance, NumaNodeBuilder, NumaNodeConfig,
+    NumaTopology, PlacementReport, VcpuPlacementResult,
 };
 pub use api::error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use api::exit_handle::ExitHandle;

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -3214,6 +3214,11 @@ fn apply_linux_memory_preference(
 #[cfg(all(target_os = "linux", not(feature = "tee")))]
 fn apply_linux_inherited_memory_policy(address: *mut u8, length: usize) -> io::Result<()> {
     const MPOL_DEFAULT: libc::c_int = 0;
+    const MPOL_MF_MOVE: libc::c_int = 1 << 1;
+
+    // Payload loading may already have faulted kernel/init pages under the preference. Reset the
+    // VMA and migrate pages owned by this process so the acknowledgement describes both future
+    // faults and the small resident boot payload, not only allocations made after the barrier.
     let result = unsafe {
         libc::syscall(
             libc::SYS_mbind,
@@ -3222,7 +3227,7 @@ fn apply_linux_inherited_memory_policy(address: *mut u8, length: usize) -> io::R
             MPOL_DEFAULT,
             std::ptr::null::<libc::c_ulong>(),
             0,
-            0,
+            MPOL_MF_MOVE,
         )
     };
     if result < 0 {

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -2578,12 +2578,8 @@ impl MemoryPlacementState {
     }
 
     fn fallback_after_partial_cpu(&mut self) {
-        if !matches!(self.result, MemoryPlacementResult::Applied) {
-            return;
-        }
-
         #[cfg(all(target_os = "linux", not(feature = "tee")))]
-        {
+        if matches!(self.result, MemoryPlacementResult::Applied) {
             let mut failures = Vec::new();
             for &(address, length) in &self.managed_ranges {
                 if let Err(error) = apply_linux_inherited_memory_policy(address as *mut u8, length)
@@ -2605,6 +2601,9 @@ impl MemoryPlacementState {
                 }
             };
         }
+
+        #[cfg(not(all(target_os = "linux", not(feature = "tee"))))]
+        let _ = self;
     }
 }
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -88,6 +88,7 @@ use kbs_types::Tee;
 use crate::device_manager;
 #[cfg(unix)]
 use crate::exit_signal::register_exit_signal_handlers;
+use crate::resources::{MemoryPlacementResult, PlacementReport, VcpuPlacementResult};
 #[cfg(target_os = "linux")]
 use crate::signal_handler::register_sigint_handler;
 #[cfg(target_os = "linux")]
@@ -190,6 +191,8 @@ pub enum StartMicrovmError {
     HostMemoryPolicy(io::Error),
     /// A low-level VMM caller supplied an invalid or unsupported NUMA topology.
     InvalidNumaTopology(String),
+    /// A low-level VMM caller supplied an incomplete or unsupported vCPU-affinity map.
+    InvalidVcpuAffinity(String),
     /// Guest memory collection operation failed.
     GuestMemoryMmap(vm_memory::GuestMemoryError),
     /// Guest memory region construction failed.
@@ -411,6 +414,9 @@ impl Display for StartMicrovmError {
             }
             InvalidNumaTopology(ref reason) => {
                 write!(f, "Invalid NUMA topology: {reason}")
+            }
+            InvalidVcpuAffinity(ref reason) => {
+                write!(f, "Invalid vCPU affinity: {reason}")
             }
             ImageBz2Decoder(ref err) => {
                 write!(f, "The BZIP2 decoder couldn't decompress the kernel. {err}")
@@ -1154,24 +1160,55 @@ fn choose_payload(vm_resources: &VmResources) -> Result<Payload, StartMicrovmErr
 pub fn build_microvm(
     vm_resources: &mut super::resources::VmResources,
     event_manager: &mut EventManager,
+    shutdown_efd: Option<EventFd>,
+    sender: Sender<WorkerMessage>,
+    exit_evt: EventFd,
+    exit_code: Arc<AtomicI32>,
+) -> std::result::Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
+    let (vmm, _) = build_microvm_paused(
+        vm_resources,
+        event_manager,
+        shutdown_efd,
+        sender,
+        exit_evt,
+        exit_code,
+    )?;
+    vmm.lock()
+        .expect("poisoned VMM mutex before first resume")
+        .resume_vcpus()
+        .map_err(StartMicrovmError::Internal)?;
+    Ok(vmm)
+}
+
+/// Builds a microVM and applies host placement while keeping every vCPU paused.
+///
+/// This is the placement acknowledgement barrier used by embedding runtimes: the report contains
+/// the OS-visible result, and no guest instruction executes until the caller invokes
+/// [`Vmm::resume_vcpus`].
+pub fn build_microvm_paused(
+    vm_resources: &mut super::resources::VmResources,
+    event_manager: &mut EventManager,
     _shutdown_efd: Option<EventFd>,
     _sender: Sender<WorkerMessage>,
     exit_evt: EventFd,
     exit_code: Arc<AtomicI32>,
-) -> std::result::Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
+) -> std::result::Result<(Arc<Mutex<Vmm>>, PlacementReport), StartMicrovmError> {
     let mut trace = BootTrace::new("vmm");
     trace.mark("build_microvm.start");
 
+    validate_vmm_vcpu_affinity(vm_resources)?;
+
     let payload = choose_payload(vm_resources)?;
 
-    let (guest_memory, arch_memory_info, mut _shm_manager, payload_config) = create_guest_memory(
-        vm_resources
-            .vm_config()
-            .mem_size_mib
-            .ok_or(StartMicrovmError::MissingMemSizeConfig)?,
-        vm_resources,
-        &payload,
-    )?;
+    let (guest_memory, arch_memory_info, mut _shm_manager, payload_config, mut memory_placement) =
+        create_guest_memory_with_placement(
+            vm_resources
+                .vm_config()
+                .mem_size_mib
+                .ok_or(StartMicrovmError::MissingMemSizeConfig)?,
+            vm_resources,
+            &payload,
+        )?;
     trace.mark("guest_memory.ready");
 
     #[allow(unused_mut)]
@@ -1961,13 +1998,30 @@ pub fn build_microvm(
     if let Some(affinity) = &vm_resources.vcpu_affinity {
         // The public builder validates an exact map for the full possible topology.
         for (vcpu, host_cpu) in vcpus.iter_mut().zip(affinity.iter().copied()) {
-            vcpu.set_host_cpu(host_cpu);
+            vcpu.set_host_cpu(host_cpu, vm_resources.vcpu_affinity_required);
         }
     }
 
-    vmm.start_vcpus(vcpus)
+    let vcpu_placement = vmm
+        .start_vcpus_paused(vcpus)
         .map_err(StartMicrovmError::Internal)?;
-    trace.mark("vcpus.started");
+    trace.mark("vcpus.placement_ready");
+
+    if vcpu_placement.iter().any(|result| {
+        matches!(
+            result,
+            VcpuPlacementResult::Inherited {
+                requested_host_cpu: Some(_),
+                ..
+            }
+        )
+    }) {
+        memory_placement.fallback_after_partial_cpu();
+    }
+    let placement_report = PlacementReport {
+        vcpus: vcpu_placement,
+        memory: memory_placement.result,
+    };
 
     // Clippy thinks we don't need Arc<Mutex<...
     // but we don't want to change the event_manager interface
@@ -1978,7 +2032,31 @@ pub fn build_microvm(
         .map_err(StartMicrovmError::RegisterEvent)?;
     trace.mark("build_microvm.done");
 
-    Ok(vmm)
+    Ok((vmm, placement_report))
+}
+
+fn validate_vmm_vcpu_affinity(_vm_resources: &VmResources) -> Result<(), StartMicrovmError> {
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    if let Some(affinity) = &_vm_resources.vcpu_affinity {
+        let config = _vm_resources.vm_config();
+        let boot_vcpus = config.vcpu_count.unwrap_or(1);
+        let max_vcpus = config.max_vcpu_count.unwrap_or(boot_vcpus);
+        if affinity.len() != usize::from(max_vcpus) {
+            return Err(StartMicrovmError::InvalidVcpuAffinity(format!(
+                "affinity contains {} entries, expected exactly {max_vcpus}",
+                affinity.len()
+            )));
+        }
+
+        #[cfg(target_os = "linux")]
+        if let Some(host_cpu) = affinity.iter().find(|host_cpu| host_cpu.group != 0) {
+            return Err(StartMicrovmError::InvalidVcpuAffinity(format!(
+                "Linux host CPU {}:{} uses a nonzero processor group",
+                host_cpu.group, host_cpu.index
+            )));
+        }
+    }
+    Ok(())
 }
 
 struct BootTrace {
@@ -2484,12 +2562,77 @@ pub struct PayloadConfig {
     kernel_cmdline: Option<String>,
 }
 
+struct MemoryPlacementState {
+    result: MemoryPlacementResult,
+    #[cfg(all(target_os = "linux", not(feature = "tee")))]
+    managed_ranges: Vec<(usize, usize)>,
+}
+
+impl MemoryPlacementState {
+    fn inherited() -> Self {
+        Self {
+            result: MemoryPlacementResult::Inherited,
+            #[cfg(all(target_os = "linux", not(feature = "tee")))]
+            managed_ranges: Vec::new(),
+        }
+    }
+
+    fn fallback_after_partial_cpu(&mut self) {
+        if !matches!(self.result, MemoryPlacementResult::Applied) {
+            return;
+        }
+
+        #[cfg(all(target_os = "linux", not(feature = "tee")))]
+        {
+            let mut failures = Vec::new();
+            for &(address, length) in &self.managed_ranges {
+                if let Err(error) = apply_linux_inherited_memory_policy(address as *mut u8, length)
+                {
+                    failures.push(error.to_string());
+                }
+            }
+            self.result = if failures.is_empty() {
+                MemoryPlacementResult::Fallback {
+                    reason: "one or more vCPUs retained scheduler placement".into(),
+                }
+            } else {
+                warn!(
+                    "could not fully restore inherited memory policy after partial CPU placement: {}",
+                    failures.join("; ")
+                );
+                MemoryPlacementResult::Partial {
+                    reason: failures.join("; "),
+                }
+            };
+        }
+    }
+}
+
 pub fn create_guest_memory(
     mem_size: usize,
     vm_resources: &VmResources,
     payload: &Payload,
 ) -> std::result::Result<
     (GuestMemoryMmap, ArchMemoryInfo, ShmManager, PayloadConfig),
+    StartMicrovmError,
+> {
+    let (guest_memory, arch_memory_info, shm_manager, payload_config, _) =
+        create_guest_memory_with_placement(mem_size, vm_resources, payload)?;
+    Ok((guest_memory, arch_memory_info, shm_manager, payload_config))
+}
+
+fn create_guest_memory_with_placement(
+    mem_size: usize,
+    vm_resources: &VmResources,
+    payload: &Payload,
+) -> std::result::Result<
+    (
+        GuestMemoryMmap,
+        ArchMemoryInfo,
+        ShmManager,
+        PayloadConfig,
+        MemoryPlacementState,
+    ),
     StartMicrovmError,
 > {
     // `VmResources` is also a public low-level VMM interface, so do not rely exclusively on the
@@ -2635,15 +2778,21 @@ pub fn create_guest_memory(
     }
 
     #[cfg(not(feature = "tee"))]
-    let guest_mem = if let Some(topology) = &vm_resources.numa_topology {
+    let (guest_mem, memory_placement) = if let Some(topology) = &vm_resources.numa_topology {
         create_numa_guest_memory(&arch_mem_regions, &numa_managed_regions, topology)?
     } else {
-        GuestMemoryMmap::from_ranges(&arch_mem_regions)
-            .map_err(StartMicrovmError::GuestMemoryMmapFromRanges)?
+        (
+            GuestMemoryMmap::from_ranges(&arch_mem_regions)
+                .map_err(StartMicrovmError::GuestMemoryMmapFromRanges)?,
+            MemoryPlacementState::inherited(),
+        )
     };
     #[cfg(feature = "tee")]
-    let guest_mem = GuestMemoryMmap::from_ranges(&arch_mem_regions)
-        .map_err(StartMicrovmError::GuestMemoryMmapFromRanges)?;
+    let (guest_mem, memory_placement) = (
+        GuestMemoryMmap::from_ranges(&arch_mem_regions)
+            .map_err(StartMicrovmError::GuestMemoryMmapFromRanges)?,
+        MemoryPlacementState::inherited(),
+    );
 
     let (guest_mem, entry_addr, initrd_config, cmdline) =
         load_payload(vm_resources, guest_mem, &arch_mem_info, payload)?;
@@ -2670,7 +2819,13 @@ pub fn create_guest_memory(
         kernel_cmdline: cmdline.clone(),
     };
 
-    Ok((guest_mem, arch_mem_info, shm_manager, payload_config))
+    Ok((
+        guest_mem,
+        arch_mem_info,
+        shm_manager,
+        payload_config,
+        memory_placement,
+    ))
 }
 
 fn validate_vmm_numa_topology(
@@ -2751,7 +2906,8 @@ fn validate_vmm_numa_topology(
 
         match &node.host_memory {
             crate::resources::HostMemoryPolicy::Inherit => {}
-            crate::resources::HostMemoryPolicy::Bind { host_nodes } => {
+            crate::resources::HostMemoryPolicy::Bind { host_nodes }
+            | crate::resources::HostMemoryPolicy::PreferredMany { host_nodes } => {
                 if host_nodes.is_empty() {
                     return Err(StartMicrovmError::InvalidNumaTopology(
                         "a bind policy requires at least one host node".into(),
@@ -2814,9 +2970,17 @@ fn create_numa_guest_memory(
     ranges: &[(GuestAddress, usize)],
     numa_managed_regions: &[bool],
     topology: &crate::resources::NumaTopology,
-) -> std::result::Result<GuestMemoryMmap, StartMicrovmError> {
+) -> std::result::Result<(GuestMemoryMmap, MemoryPlacementState), StartMicrovmError> {
     debug_assert_eq!(ranges.len(), numa_managed_regions.len());
     let mut regions = Vec::with_capacity(ranges.len());
+    let mut state = match &topology.nodes[0].host_memory {
+        crate::resources::HostMemoryPolicy::Inherit => MemoryPlacementState::inherited(),
+        _ => MemoryPlacementState {
+            result: MemoryPlacementResult::Applied,
+            managed_ranges: Vec::new(),
+        },
+    };
+    let mut soft_policy_failed = false;
 
     for (&(guest_address, size), &numa_managed) in ranges.iter().zip(numa_managed_regions.iter()) {
         let mapping = MmapRegion::new(size).map_err(|error| {
@@ -2834,6 +2998,45 @@ fn create_numa_guest_memory(
                     apply_linux_memory_binding(mapping.as_ptr(), mapping.size(), host_nodes)
                         .map_err(StartMicrovmError::HostMemoryPolicy)?;
                 }
+                crate::resources::HostMemoryPolicy::PreferredMany { host_nodes } => {
+                    if !soft_policy_failed {
+                        if let Err(error) = apply_linux_memory_preference(
+                            mapping.as_ptr(),
+                            mapping.size(),
+                            host_nodes,
+                        ) {
+                            warn!(
+                                "host NUMA preference unavailable; continuing with inherited memory placement: {error}"
+                            );
+                            let mut reset_failures = Vec::new();
+                            for &(address, length) in &state.managed_ranges {
+                                if let Err(reset_error) =
+                                    apply_linux_inherited_memory_policy(address as *mut u8, length)
+                                {
+                                    reset_failures.push(reset_error.to_string());
+                                }
+                            }
+                            state.managed_ranges.clear();
+                            state.result = if reset_failures.is_empty() {
+                                MemoryPlacementResult::Fallback {
+                                    reason: error.to_string(),
+                                }
+                            } else {
+                                warn!(
+                                    "could not fully restore inherited memory policy after NUMA preference fallback: {}",
+                                    reset_failures.join("; ")
+                                );
+                                MemoryPlacementResult::Partial {
+                                    reason: format!(
+                                        "preference failed: {error}; reset failed: {}",
+                                        reset_failures.join("; ")
+                                    ),
+                                }
+                            };
+                            soft_policy_failed = true;
+                        }
+                    }
+                }
                 crate::resources::HostMemoryPolicy::Inherit => {}
                 crate::resources::HostMemoryPolicy::Preferred { .. } => {
                     return Err(StartMicrovmError::HostMemoryPolicy(io::Error::new(
@@ -2844,13 +3047,27 @@ fn create_numa_guest_memory(
             }
         }
 
+        if numa_managed
+            && matches!(state.result, MemoryPlacementResult::Applied)
+            && !matches!(
+                &topology.nodes[0].host_memory,
+                crate::resources::HostMemoryPolicy::Inherit
+            )
+        {
+            state
+                .managed_ranges
+                .push((mapping.as_ptr() as usize, mapping.size()));
+        }
+
         regions.push(
             GuestRegionMmap::new(mapping, guest_address)
                 .ok_or(StartMicrovmError::GuestMemoryRegion)?,
         );
     }
 
-    GuestMemoryMmap::from_regions(regions).map_err(StartMicrovmError::GuestMemoryRegionCollection)
+    let memory = GuestMemoryMmap::from_regions(regions)
+        .map_err(StartMicrovmError::GuestMemoryRegionCollection)?;
+    Ok((memory, state))
 }
 
 #[cfg(all(target_os = "windows", not(feature = "tee")))]
@@ -2858,9 +3075,13 @@ fn create_numa_guest_memory(
     ranges: &[(GuestAddress, usize)],
     numa_managed_regions: &[bool],
     topology: &crate::resources::NumaTopology,
-) -> std::result::Result<GuestMemoryMmap, StartMicrovmError> {
+) -> std::result::Result<(GuestMemoryMmap, MemoryPlacementState), StartMicrovmError> {
     debug_assert_eq!(ranges.len(), numa_managed_regions.len());
     let mut regions = Vec::with_capacity(ranges.len());
+    let result = match &topology.nodes[0].host_memory {
+        crate::resources::HostMemoryPolicy::Preferred { .. } => MemoryPlacementResult::Applied,
+        _ => MemoryPlacementResult::Inherited,
+    };
 
     for (&(guest_address, size), &numa_managed) in ranges.iter().zip(numa_managed_regions.iter()) {
         let mapping = if let Some(policy) = numa_policy_for_region(numa_managed, topology) {
@@ -2876,7 +3097,8 @@ fn create_numa_guest_memory(
                         )
                     })?
                 }
-                crate::resources::HostMemoryPolicy::Bind { .. } => {
+                crate::resources::HostMemoryPolicy::Bind { .. }
+                | crate::resources::HostMemoryPolicy::PreferredMany { .. } => {
                     return Err(StartMicrovmError::HostMemoryPolicy(io::Error::new(
                         io::ErrorKind::Unsupported,
                         "bound host memory is unavailable on Windows",
@@ -2897,7 +3119,9 @@ fn create_numa_guest_memory(
         );
     }
 
-    GuestMemoryMmap::from_regions(regions).map_err(StartMicrovmError::GuestMemoryRegionCollection)
+    let memory = GuestMemoryMmap::from_regions(regions)
+        .map_err(StartMicrovmError::GuestMemoryRegionCollection)?;
+    Ok((memory, MemoryPlacementState { result }))
 }
 
 #[cfg(all(not(feature = "tee"), any(target_os = "linux", target_os = "windows")))]
@@ -2916,10 +3140,12 @@ fn create_numa_guest_memory(
     ranges: &[(GuestAddress, usize)],
     _numa_managed_regions: &[bool],
     _topology: &crate::resources::NumaTopology,
-) -> std::result::Result<GuestMemoryMmap, StartMicrovmError> {
+) -> std::result::Result<(GuestMemoryMmap, MemoryPlacementState), StartMicrovmError> {
     // Validation permits only inherited one-node topology on hosts without a backing hook. This is
     // the explicit no-op profile; managed policies are rejected before VM resources are built.
-    GuestMemoryMmap::from_ranges(ranges).map_err(StartMicrovmError::GuestMemoryMmapFromRanges)
+    let memory = GuestMemoryMmap::from_ranges(ranges)
+        .map_err(StartMicrovmError::GuestMemoryMmapFromRanges)?;
+    Ok((memory, MemoryPlacementState::inherited()))
 }
 
 #[cfg(all(target_os = "linux", not(feature = "tee")))]
@@ -2944,6 +3170,58 @@ fn apply_linux_memory_binding(
             MPOL_BIND | MPOL_F_STATIC_NODES,
             node_mask.as_ptr(),
             max_node_bits,
+            0,
+        )
+    };
+    if result < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(all(target_os = "linux", not(feature = "tee")))]
+fn apply_linux_memory_preference(
+    address: *mut u8,
+    length: usize,
+    host_nodes: &[u32],
+) -> io::Result<()> {
+    // MPOL_PREFERRED_MANY was added in Linux 5.15. It keeps allocations near the requested CPUs
+    // while allowing page faults to spill to other nodes under pressure. Older kernels return
+    // EINVAL and the caller deliberately retains inherited placement.
+    const MPOL_PREFERRED_MANY: libc::c_int = 5;
+    const MPOL_F_STATIC_NODES: libc::c_int = 1 << 15;
+
+    let (node_mask, max_node_bits) = linux_node_mask(host_nodes)?;
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_mbind,
+            address.cast::<libc::c_void>(),
+            length,
+            MPOL_PREFERRED_MANY | MPOL_F_STATIC_NODES,
+            node_mask.as_ptr(),
+            max_node_bits,
+            0,
+        )
+    };
+    if result < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(all(target_os = "linux", not(feature = "tee")))]
+fn apply_linux_inherited_memory_policy(address: *mut u8, length: usize) -> io::Result<()> {
+    const MPOL_DEFAULT: libc::c_int = 0;
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_mbind,
+            address.cast::<libc::c_void>(),
+            length,
+            MPOL_DEFAULT,
+            std::ptr::null::<libc::c_ulong>(),
+            0,
             0,
         )
     };
@@ -4553,6 +4831,32 @@ pub mod tests {
         ));
     }
 
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[test]
+    fn vmm_boundary_rejects_incomplete_affinity_map() {
+        let mut vm_resources = VmResources::default();
+        vm_resources.vcpu_affinity = Some(Vec::new());
+
+        assert!(matches!(
+            validate_vmm_vcpu_affinity(&vm_resources),
+            Err(StartMicrovmError::InvalidVcpuAffinity(_))
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn vmm_boundary_rejects_linux_processor_groups() {
+        let mut vm_resources = VmResources::default();
+        vm_resources.vcpu_affinity = Some(vec![
+            crate::vmm_config::machine_config::HostCpuId::in_group(1, 0),
+        ]);
+
+        assert!(matches!(
+            validate_vmm_vcpu_affinity(&vm_resources),
+            Err(StartMicrovmError::InvalidVcpuAffinity(_))
+        ));
+    }
+
     #[cfg(feature = "tee")]
     #[test]
     fn vmm_boundary_rejects_numa_topology_with_tee_memory() {
@@ -4628,6 +4932,21 @@ pub mod tests {
             entry.contains("N0="),
             "the faulted page is not on node 0: {entry}"
         );
+    }
+
+    #[cfg(all(target_os = "linux", not(feature = "tee")))]
+    #[test]
+    #[ignore = "requires a native Linux host that permits NUMA policy syscalls"]
+    fn linux_numa_preference_allows_faulted_pages() {
+        let mapping = MmapRegion::<()>::new(2 * 1024 * 1024).unwrap();
+        apply_linux_memory_preference(mapping.as_ptr(), mapping.size(), &[0]).unwrap();
+
+        // A soft preference must remain faultable; unlike MPOL_BIND, pressure may spill this page
+        // to another allowed node rather than turning a locality preference into SIGBUS.
+        unsafe {
+            mapping.as_ptr().write_volatile(0x5a);
+            assert_eq!(mapping.as_ptr().read_volatile(), 0x5a);
+        }
     }
 
     #[test]

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -63,6 +63,7 @@ use crate::device_manager::mmio::MMIODeviceManager;
 use crate::vstate::VcpuEvent;
 use crate::vstate::{Vcpu, VcpuHandle, VcpuResponse, Vm};
 
+use crate::resources::VcpuPlacementResult;
 use arch::{ArchMemoryInfo, InitrdConfig};
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use crossbeam_channel::Sender;
@@ -246,8 +247,23 @@ impl Vmm {
     }
 
     /// Starts the microVM vcpus.
-    pub fn start_vcpus(&mut self, mut vcpus: Vec<Vcpu>) -> Result<()> {
+    pub fn start_vcpus(&mut self, vcpus: Vec<Vcpu>) -> Result<()> {
+        self.start_vcpus_paused(vcpus)?;
+
+        // The vcpus start off in the `Paused` state, let them run.
+        self.resume_vcpus()?;
+
+        Ok(())
+    }
+
+    /// Starts every vCPU thread and applies host affinity, but keeps the guest paused.
+    ///
+    /// The returned report is a barrier: every entry describes the effective affinity before any
+    /// guest instruction can execute. Callers may reconcile cooperative reservations and then call
+    /// [`resume_vcpus`](Self::resume_vcpus).
+    pub fn start_vcpus_paused(&mut self, mut vcpus: Vec<Vcpu>) -> Result<Vec<VcpuPlacementResult>> {
         let vcpu_count = vcpus.len();
+        let mut placement = Vec::with_capacity(vcpu_count);
 
         Vcpu::register_kick_signal_handler();
 
@@ -256,14 +272,26 @@ impl Vmm {
         for mut vcpu in vcpus.drain(..) {
             vcpu.set_mmio_bus(self.mmio_device_manager.bus.clone());
 
-            self.vcpus_handles
-                .push(vcpu.start_threaded().map_err(Error::VcpuHandle)?);
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            {
+                let (handle, result) = vcpu.start_threaded().map_err(Error::VcpuHandle)?;
+                self.vcpus_handles.push(handle);
+                placement.push(result);
+            }
+            #[cfg(target_os = "macos")]
+            {
+                let vcpu_index = vcpu.cpu_index();
+                self.vcpus_handles
+                    .push(vcpu.start_threaded().map_err(Error::VcpuHandle)?);
+                placement.push(VcpuPlacementResult::Inherited {
+                    vcpu_index,
+                    requested_host_cpu: None,
+                    reason: None,
+                });
+            }
         }
 
-        // The vcpus start off in the `Paused` state, let them run.
-        self.resume_vcpus()?;
-
-        Ok(())
+        Ok(placement)
     }
 
     /// Sends a resume command to the vcpus.

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -39,6 +39,7 @@ use kbs_types::Tee;
 
 #[cfg(feature = "tee")]
 use crate::resources::TeeConfig;
+use crate::resources::VcpuPlacementResult;
 use crate::vmm_config::machine_config::{CpuFeaturesTemplate, HostCpuId};
 #[cfg(target_arch = "x86_64")]
 use cpuid::{c3, filter_cpuid, t2, VmSpec};
@@ -930,6 +931,9 @@ pub struct Vcpu {
     id: u8,
     // Resolved host placement is applied inside the vCPU thread before KVM_RUN.
     host_cpu: Option<HostCpuId>,
+    // Required affinity failures abort startup; preferred affinity failures retain scheduler
+    // placement and let the VM continue.
+    host_cpu_required: bool,
     // Host-authoritative online ceiling; vCPUs at or above it park between
     // emulation steps regardless of guest cooperation.
     enforcement: Option<std::sync::Arc<devices::virtio::CpuEnforcement>>,
@@ -1088,6 +1092,7 @@ impl Vcpu {
             fd: kvm_vcpu,
             id,
             host_cpu: None,
+            host_cpu_required: true,
             enforcement: None,
             kick_slot: None,
             mmio_bus: None,
@@ -1129,6 +1134,7 @@ impl Vcpu {
             fd: kvm_vcpu,
             id,
             host_cpu: None,
+            host_cpu_required: true,
             enforcement: None,
             kick_slot: None,
             mmio_bus: None,
@@ -1165,6 +1171,7 @@ impl Vcpu {
             fd: kvm_vcpu,
             id,
             host_cpu: None,
+            host_cpu_required: true,
             enforcement: None,
             kick_slot: None,
             mmio_bus: None,
@@ -1183,8 +1190,9 @@ impl Vcpu {
     }
 
     /// Selects the host logical processor this vCPU thread must run on.
-    pub(crate) fn set_host_cpu(&mut self, host_cpu: HostCpuId) {
+    pub(crate) fn set_host_cpu(&mut self, host_cpu: HostCpuId, required: bool) {
         self.host_cpu = Some(host_cpu);
+        self.host_cpu_required = required;
     }
 
     pub fn set_enforcement(
@@ -1320,7 +1328,7 @@ impl Vcpu {
 
     /// Moves the vcpu to its own thread and constructs a VcpuHandle.
     /// The handle can be used to control the remote vcpu.
-    pub fn start_threaded(mut self) -> Result<VcpuHandle> {
+    pub fn start_threaded(mut self) -> Result<(VcpuHandle, VcpuPlacementResult)> {
         let event_sender = self.event_sender.take().unwrap();
         let response_receiver = self.response_receiver.take().unwrap();
         let (init_tls_sender, init_tls_receiver) = unbounded();
@@ -1329,7 +1337,7 @@ impl Vcpu {
             .spawn(move || {
                 let init_result = self
                     .apply_host_cpu_affinity()
-                    .and_then(|()| self.init_thread_local_data());
+                    .and_then(|placement| self.init_thread_local_data().map(|()| placement));
 
                 let initialized = init_result.is_ok();
                 init_tls_sender
@@ -1342,44 +1350,19 @@ impl Vcpu {
             })
             .map_err(Error::VcpuSpawn)?;
 
-        init_tls_receiver
+        let placement = init_tls_receiver
             .recv()
             .expect("Error waiting for vcpu initialization.")?;
 
-        Ok(VcpuHandle::new(
-            event_sender,
-            response_receiver,
-            vcpu_thread,
+        Ok((
+            VcpuHandle::new(event_sender, response_receiver, vcpu_thread),
+            placement,
         ))
     }
 
     /// Applies the resolved affinity from within the vCPU thread itself.
-    fn apply_host_cpu_affinity(&self) -> Result<()> {
-        let Some(host_cpu) = self.host_cpu else {
-            return Ok(());
-        };
-
-        let index = host_cpu.index as usize;
-        if index >= libc::CPU_SETSIZE as usize {
-            return Err(Error::VcpuAffinity(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("host CPU {index} exceeds CPU_SETSIZE"),
-            )));
-        }
-
-        // SAFETY: cpu_set_t is initialized before use, the validated index is in range, and pid 0
-        // asks Linux to bind only the current vCPU thread.
-        let result = unsafe {
-            let mut set: libc::cpu_set_t = std::mem::zeroed();
-            libc::CPU_ZERO(&mut set);
-            libc::CPU_SET(index, &mut set);
-            libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &set)
-        };
-        if result != 0 {
-            return Err(Error::VcpuAffinity(io::Error::last_os_error()));
-        }
-
-        Ok(())
+    fn apply_host_cpu_affinity(&self) -> Result<VcpuPlacementResult> {
+        apply_host_cpu_affinity(self.host_cpu, self.host_cpu_required, self.id)
     }
 
     #[allow(unused)]
@@ -1823,6 +1806,63 @@ impl Vcpu {
     }
 }
 
+fn apply_host_cpu_affinity(
+    host_cpu: Option<HostCpuId>,
+    required: bool,
+    vcpu_id: u8,
+) -> Result<VcpuPlacementResult> {
+    let Some(host_cpu) = host_cpu else {
+        return Ok(VcpuPlacementResult::Inherited {
+            vcpu_index: vcpu_id,
+            requested_host_cpu: None,
+            reason: None,
+        });
+    };
+
+    if let Err(error) = apply_required_host_cpu_affinity(host_cpu) {
+        if required {
+            return Err(error);
+        }
+        let reason = error.to_string();
+        warn!(
+            "vCPU {vcpu_id} host affinity unavailable; continuing with scheduler placement: {error}"
+        );
+        return Ok(VcpuPlacementResult::Inherited {
+            vcpu_index: vcpu_id,
+            requested_host_cpu: Some(host_cpu),
+            reason: Some(reason),
+        });
+    }
+    Ok(VcpuPlacementResult::Pinned {
+        vcpu_index: vcpu_id,
+        host_cpu,
+    })
+}
+
+fn apply_required_host_cpu_affinity(host_cpu: HostCpuId) -> Result<()> {
+    let index = host_cpu.index as usize;
+    if index >= libc::CPU_SETSIZE as usize {
+        return Err(Error::VcpuAffinity(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("host CPU {index} exceeds CPU_SETSIZE"),
+        )));
+    }
+
+    // SAFETY: cpu_set_t is initialized before use, the validated index is in range, and pid 0
+    // asks Linux to bind only the current vCPU thread.
+    let result = unsafe {
+        let mut set: libc::cpu_set_t = std::mem::zeroed();
+        libc::CPU_ZERO(&mut set);
+        libc::CPU_SET(index, &mut set);
+        libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &set)
+    };
+    if result != 0 {
+        return Err(Error::VcpuAffinity(io::Error::last_os_error()));
+    }
+
+    Ok(())
+}
+
 impl Drop for Vcpu {
     fn drop(&mut self) {
         let _ = self.reset_thread_local_data();
@@ -1909,6 +1949,19 @@ impl VcpuHandle {
     }
 }
 
+impl Drop for VcpuHandle {
+    fn drop(&mut self) {
+        // A startup barrier may abort after earlier vCPU threads reached Paused. Close their
+        // control channels and join them before the owning VM is destroyed.
+        let _ = self.send_event(VcpuEvent::Pause);
+        let (event_sender, _event_receiver) = unbounded();
+        self.event_sender = event_sender;
+        if let Some(thread) = self.vcpu_thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
 enum VcpuEmulation {
     Handled,
     Interrupted,
@@ -1933,17 +1986,15 @@ mod tests {
 
     use utils::signal::validate_signal_num;
 
-    // In tests we need to close any pending Vcpu threads on test completion.
-    impl Drop for VcpuHandle {
-        fn drop(&mut self) {
-            // Make sure the Vcpu is out of KVM_RUN.
-            self.send_event(VcpuEvent::Pause).unwrap();
-            // Close the original channel so that the Vcpu thread errors and goes to exit state.
-            let (event_sender, _event_receiver) = unbounded();
-            self.event_sender = event_sender;
-            // Wait for the Vcpu thread to finish execution
-            self.vcpu_thread.take().unwrap().join().unwrap();
-        }
+    #[test]
+    fn best_effort_host_affinity_reports_os_rejection_as_inherited() {
+        let unavailable = HostCpuId::new(libc::CPU_SETSIZE as u16);
+
+        assert!(apply_host_cpu_affinity(Some(unavailable), true, 0).is_err());
+        assert!(matches!(
+            apply_host_cpu_affinity(Some(unavailable), false, 0),
+            Ok(VcpuPlacementResult::Inherited { .. })
+        ));
     }
 
     // Auxiliary function being used throughout the tests.

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -1970,7 +1970,6 @@ enum VcpuEmulation {
 
 #[cfg(test)]
 mod tests {
-    use crossbeam_channel::unbounded;
     use std::sync::{Arc, Barrier};
 
     use super::*;

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -26,7 +26,6 @@ use crate::vmm_config::kernel_bundle::{KernelBundle, KernelBundleError};
 #[cfg(feature = "tee")]
 use crate::vmm_config::kernel_bundle::{QbootBundle, QbootBundleError};
 use crate::vmm_config::kernel_cmdline::{KernelCmdlineConfig, KernelCmdlineConfigError};
-#[cfg(any(target_os = "linux", target_os = "windows"))]
 use crate::vmm_config::machine_config::HostCpuId;
 use crate::vmm_config::machine_config::{VmConfig, VmConfigError};
 #[cfg(feature = "net")]
@@ -200,10 +199,65 @@ pub enum HostMemoryPolicy {
         /// Absolute Linux host NUMA node IDs included in the binding mask.
         host_nodes: Vec<u32>,
     },
+    /// Prefer the selected Linux host nodes while allowing page faults to spill elsewhere under
+    /// pressure. If the kernel lacks soft multi-node preference, ordinary host policy is retained.
+    PreferredMany {
+        /// Absolute Linux host NUMA node IDs included in the preference mask.
+        host_nodes: Vec<u32>,
+    },
     /// Prefer a Windows NUMA node while allowing the host to fall back.
     Preferred {
         /// Absolute Windows host NUMA node ID preferred for future page faults.
         host_node: u32,
+    },
+}
+
+/// The host placement that was actually established before guest execution begins.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PlacementReport {
+    /// One result for every possible vCPU, in guest-vCPU order.
+    pub vcpus: Vec<VcpuPlacementResult>,
+    /// Result of applying the requested host-memory policy.
+    pub memory: MemoryPlacementResult,
+}
+
+/// The effective host placement of one guest vCPU.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VcpuPlacementResult {
+    /// The vCPU thread was successfully pinned to the requested host processor.
+    Pinned {
+        /// Guest vCPU index.
+        vcpu_index: u8,
+        /// Host processor selected by the caller.
+        host_cpu: HostCpuId,
+    },
+    /// The vCPU remains under the host scheduler's inherited policy.
+    Inherited {
+        /// Guest vCPU index.
+        vcpu_index: u8,
+        /// Requested host processor, when affinity was attempted.
+        requested_host_cpu: Option<HostCpuId>,
+        /// Why the requested affinity was not established.
+        reason: Option<String>,
+    },
+}
+
+/// The effective host-memory placement of ordinary guest RAM and hotplug capacity.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MemoryPlacementResult {
+    /// No managed memory policy was requested.
+    Inherited,
+    /// The requested managed policy was established.
+    Applied,
+    /// A best-effort policy could not be retained and memory uses inherited placement.
+    Fallback {
+        /// Why the managed policy was abandoned.
+        reason: String,
+    },
+    /// Only part of the requested memory policy remains effective after best-effort fallback.
+    Partial {
+        /// Why the host could not establish one uniform policy.
+        reason: String,
     },
 }
 
@@ -215,6 +269,9 @@ pub struct VmResources {
     /// Resolved host logical processor for every possible vCPU thread.
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     pub vcpu_affinity: Option<Vec<HostCpuId>>,
+    /// Whether failure to apply the resolved vCPU affinity must abort VM startup.
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    pub vcpu_affinity_required: bool,
     /// Resolved guest and host memory topology. `None` retains the legacy memory path exactly.
     pub numa_topology: Option<NumaTopology>,
     /// The firmware to be loaded into the microVM.
@@ -308,6 +365,8 @@ impl Default for VmResources {
             vm_config: VmConfig::default(),
             #[cfg(any(target_os = "linux", target_os = "windows"))]
             vcpu_affinity: None,
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            vcpu_affinity_required: true,
             numa_topology: None,
             firmware_config: None,
             kernel_cmdline: KernelCmdlineConfig::default(),

--- a/src/vmm/src/windows/vstate.rs
+++ b/src/vmm/src/windows/vstate.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use crate::vmm_config::machine_config::{CpuFeaturesTemplate, HostCpuId};
 
+use crate::resources::VcpuPlacementResult;
 use arch::ArchMemoryInfo;
 #[cfg(target_arch = "x86_64")]
 use crossbeam_channel::RecvTimeoutError;
@@ -438,6 +439,7 @@ pub struct VcpuConfig {
 pub struct Vcpu {
     id: u8,
     host_cpu: Option<HostCpuId>,
+    host_cpu_required: bool,
     partition_handle: WHV_PARTITION_HANDLE,
     guest_mem: Option<GuestMemoryMmap>,
     mmio_bus: Option<devices::Bus>,
@@ -595,9 +597,9 @@ pub enum VcpuResponse {
 pub struct VcpuHandle {
     id: u8,
     partition_handle: WHV_PARTITION_HANDLE,
-    event_sender: Sender<VcpuEvent>,
+    event_sender: Option<Sender<VcpuEvent>>,
     response_receiver: Receiver<VcpuResponse>,
-    _vcpu_thread: thread::JoinHandle<()>,
+    vcpu_thread: Option<thread::JoinHandle<()>>,
 }
 
 #[derive(Default)]
@@ -857,6 +859,7 @@ impl Vcpu {
         Ok(Self {
             id,
             host_cpu: None,
+            host_cpu_required: true,
             partition_handle,
             guest_mem: None,
             mmio_bus: None,
@@ -878,8 +881,9 @@ impl Vcpu {
     }
 
     /// Selects the host processor group and logical processor for this vCPU thread.
-    pub(crate) fn set_host_cpu(&mut self, host_cpu: HostCpuId) {
+    pub(crate) fn set_host_cpu(&mut self, host_cpu: HostCpuId, required: bool) {
         self.host_cpu = Some(host_cpu);
+        self.host_cpu_required = required;
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -914,7 +918,7 @@ impl Vcpu {
         self.configure_x86_64(guest_mem, entry_addr)
     }
 
-    pub fn start_threaded(mut self) -> Result<VcpuHandle> {
+    pub fn start_threaded(mut self) -> Result<(VcpuHandle, VcpuPlacementResult)> {
         let event_sender = self
             .event_sender
             .take()
@@ -934,6 +938,7 @@ impl Vcpu {
 
         let id = self.id;
         let host_cpu = self.host_cpu;
+        let host_cpu_required = self.host_cpu_required;
         let partition_handle = self.partition_handle;
         let guest_mem = self
             .guest_mem
@@ -952,7 +957,7 @@ impl Vcpu {
         let vcpu_thread = thread::Builder::new()
             .name(format!("whp-vcpu-{id}"))
             .spawn(move || {
-                let init_result = apply_host_cpu_affinity(host_cpu);
+                let init_result = apply_host_cpu_affinity(host_cpu, host_cpu_required, id);
                 let initialized = init_result.is_ok();
                 init_sender
                     .send(init_result)
@@ -991,16 +996,19 @@ impl Vcpu {
 
         // Affinity is part of VM correctness: fail construction before any vCPU can execute if
         // Windows rejects a processor-group coordinate or the inherited host constraints.
-        init_receiver
+        let placement = init_receiver
             .recv()
             .expect("error waiting for WHP vCPU initialization")?;
 
-        Ok(VcpuHandle::new(
-            id,
-            partition_handle,
-            event_sender,
-            response_receiver,
-            vcpu_thread,
+        Ok((
+            VcpuHandle::new(
+                id,
+                partition_handle,
+                event_sender,
+                response_receiver,
+                vcpu_thread,
+            ),
+            placement,
         ))
     }
 
@@ -1111,10 +1119,39 @@ impl Vcpu {
 // Functions: Host CPU Affinity
 //--------------------------------------------------------------------------------------------------
 
-fn apply_host_cpu_affinity(host_cpu: Option<HostCpuId>) -> Result<()> {
+fn apply_host_cpu_affinity(
+    host_cpu: Option<HostCpuId>,
+    required: bool,
+    vcpu_id: u8,
+) -> Result<VcpuPlacementResult> {
     let Some(host_cpu) = host_cpu else {
-        return Ok(());
+        return Ok(VcpuPlacementResult::Inherited {
+            vcpu_index: vcpu_id,
+            requested_host_cpu: None,
+            reason: None,
+        });
     };
+    if let Err(error) = apply_required_host_cpu_affinity(host_cpu) {
+        if required {
+            return Err(error);
+        }
+        let reason = error.to_string();
+        warn!(
+            "WHP vCPU {vcpu_id} host affinity unavailable; continuing with scheduler placement: {error}"
+        );
+        return Ok(VcpuPlacementResult::Inherited {
+            vcpu_index: vcpu_id,
+            requested_host_cpu: Some(host_cpu),
+            reason: Some(reason),
+        });
+    }
+    Ok(VcpuPlacementResult::Pinned {
+        vcpu_index: vcpu_id,
+        host_cpu,
+    })
+}
+
+fn apply_required_host_cpu_affinity(host_cpu: HostCpuId) -> Result<()> {
     let affinity = group_affinity(host_cpu).map_err(Error::VcpuAffinity)?;
 
     // SAFETY: the pseudo-handle refers to this vCPU thread, `affinity` is initialized and remains
@@ -1159,15 +1196,17 @@ impl VcpuHandle {
         Self {
             id,
             partition_handle,
-            event_sender,
+            event_sender: Some(event_sender),
             response_receiver,
-            _vcpu_thread: vcpu_thread,
+            vcpu_thread: Some(vcpu_thread),
         }
     }
 
     pub fn send_event(&self, event: VcpuEvent) -> Result<()> {
         let should_cancel = matches!(event, VcpuEvent::Pause);
         self.event_sender
+            .as_ref()
+            .expect("vCPU event sender missing before handle drop")
             .send(event)
             .expect("event sender channel closed on vcpu end.");
         if should_cancel {
@@ -1186,6 +1225,13 @@ impl Drop for VcpuHandle {
         if self.partition_handle != 0 {
             if let Err(err) = cancel_run_virtual_processor(self.partition_handle, self.id) {
                 error!("{err}");
+            }
+            // Disconnect the control channel and wait for the vCPU loop to observe cancellation
+            // before deleting its WHP processor. This is required when a later vCPU fails the
+            // startup placement barrier and already-created processors unwind.
+            self.event_sender.take();
+            if let Some(thread) = self.vcpu_thread.take() {
+                let _ = thread.join();
             }
             let hresult =
                 unsafe { WHvDeleteVirtualProcessor(self.partition_handle, self.id as u32) };
@@ -2712,6 +2758,17 @@ mod tests {
     }
 
     #[test]
+    fn best_effort_host_affinity_reports_os_rejection_as_inherited() {
+        let unavailable = HostCpuId::new(usize::BITS as u16);
+
+        assert!(apply_host_cpu_affinity(Some(unavailable), true, 0).is_err());
+        assert!(matches!(
+            apply_host_cpu_affinity(Some(unavailable), false, 0),
+            Ok(VcpuPlacementResult::Inherited { .. })
+        ));
+    }
+
+    #[test]
     fn host_affinity_binds_the_current_thread_to_one_allowed_processor() {
         let mut inherited = GROUP_AFFINITY::default();
         let result = unsafe { GetThreadGroupAffinity(GetCurrentThread(), &mut inherited) };
@@ -2722,7 +2779,8 @@ mod tests {
         );
 
         let index = inherited.Mask.trailing_zeros() as u16;
-        apply_host_cpu_affinity(Some(HostCpuId::in_group(inherited.Group, index))).unwrap();
+        apply_host_cpu_affinity(Some(HostCpuId::in_group(inherited.Group, index)), true, 0)
+            .unwrap();
 
         let mut applied = GROUP_AFFINITY::default();
         let result = unsafe { GetThreadGroupAffinity(GetCurrentThread(), &mut applied) };


### PR DESCRIPTION
## TL;DR

Adds a pre-execution placement acknowledgement barrier so libkrun reports what CPU affinity and host-memory policy the OS actually applied. Best-effort placement preserves successful vCPU pins, reports rejected pins as inherited, and keeps every vCPU paused until the embedding runtime has reconciled the result.

## Description

- Add public `PlacementReport`, `VcpuPlacementResult`, and `MemoryPlacementResult` types plus `VmBuilder::on_placement`.
- Start all vCPU threads behind a paused barrier, apply affinity in each target thread, publish the effective result, then resume only after the observer returns.
- Preserve successful best-effort affinity while reporting only rejected vCPUs as inherited; required affinity remains fail-closed.
- Apply Linux soft NUMA preference before first faults and restore inherited policy when CPU placement is partial. Report a partial memory result if the OS refuses that restoration instead of failing an ordinary VM create.
- Keep ordinary Windows memory inherited because VirtualAlloc2 preferred-node placement cannot be undone after a later CPU fallback; strict preferred-node placement remains available.
- Validate the public low-level VMM affinity map at the VMM boundary and safely join paused vCPU threads during startup unwind on Linux and Windows.

## Example

The embedding runtime supplies a best-effort vCPU map and reconciles the result synchronously. The callback returns before libkrun releases any vCPU into guest execution.

```rust
use msb_krun::{HostCpuId, VmBuilder};

let vm = VmBuilder::new()
    .machine(|machine| {
        machine
            .vcpus(2)
            .try_vcpu_affinity(vec![HostCpuId::new(4), HostCpuId::new(20)])
    })
    .on_placement(move |report| {
        // Reconcile tentative scheduler reservations here. Successful pins remain active;
        // rejected entries are explicitly reported as inherited.
        reservations.reconcile(report);
    });
```

For example, if the OS accepts the first pin but rejects the second, and the full request also carried ordinary soft NUMA locality, the callback sees the equivalent of:

```text
vCPU 0 -> host CPU 4   pinned
vCPU 1 -> host CPU 20  inherited (affinity rejected)
memory                  fallback to inherited

guest execution         still paused
```

The runtime can keep the reservation for host CPU 4, remove only the tentative CPU 20 reservation, and drop the memory-locality promise before returning from the callback.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p msb_krun -p msb_krun_vmm`
- [x] `cargo clippy --locked -p msb_krun -p msb_krun_vmm -- -D warnings`
- [x] `cargo test -p msb_krun -p msb_krun_vmm --lib`
- [x] Native Linux (OVH SCALE-A4): VMM boundary tests, injected best-effort affinity rejection, and all `msb_krun` library tests
- [x] Native Windows x86_64 unit suite, including the NUMA allocation smoke test (GitHub CI)
