### PR TITLE
feat(console): add configurable port queues

### DIFF
--- a/src/devices/src/virtio/console/device.rs
+++ b/src/devices/src/virtio/console/device.rs
@@ -16,11 +16,11 @@ use super::{defs, defs::control_event, defs::uapi};
 use crate::virtio::console::console_control::{
     ConsoleControl, VirtioConsoleControl, VirtioConsoleResize,
 };
-use crate::virtio::console::defs::QUEUE_SIZE;
 use crate::virtio::console::port::Port;
 use crate::virtio::console::port_queue_mapping::{
     num_queues, port_id_to_queue_idx, QueueDirection,
 };
+use crate::virtio::console::{is_valid_queue_size, ConsoleError, DEFAULT_QUEUE_SIZE};
 use crate::virtio::{InterruptTransport, PortDescription, VmmExitObserver};
 
 pub(crate) const CONTROL_RXQ_INDEX: usize = 2;
@@ -78,9 +78,24 @@ impl Console {
         assert!(!ports.is_empty(), "Expected at least 1 port");
 
         let num_queues = num_queues(ports.len());
-        let queue_config: Vec<QueueConfig> = (0..num_queues)
-            .map(|_| QueueConfig::new(QUEUE_SIZE))
+        let mut queue_config: Vec<QueueConfig> = (0..num_queues)
+            .map(|_| QueueConfig::new(DEFAULT_QUEUE_SIZE))
             .collect();
+
+        // Control queues retain the default while each port independently sizes its RX/TX pair.
+        for (port_id, description) in ports.iter().enumerate() {
+            if !is_valid_queue_size(description.queue_size) {
+                return Err(ConsoleError::InvalidQueueSize {
+                    port_id,
+                    queue_size: description.queue_size,
+                });
+            }
+
+            queue_config[port_id_to_queue_idx(QueueDirection::Rx, port_id)] =
+                QueueConfig::new(description.queue_size);
+            queue_config[port_id_to_queue_idx(QueueDirection::Tx, port_id)] =
+                QueueConfig::new(description.queue_size);
+        }
 
         let ports: Vec<Port> = zip(0u32.., ports)
             .map(|(port_id, description)| Port::new(port_id, description))
@@ -380,5 +395,49 @@ impl VmmExitObserver for Console {
     fn on_vmm_exit(&mut self, _exit_code: i32) {
         self.reset();
         log::trace!("Console on_vmm_exit finished");
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn port(name: &'static str, queue_size: u16) -> PortDescription {
+        PortDescription {
+            name: name.into(),
+            input: None,
+            output: None,
+            terminal: None,
+            queue_size,
+        }
+    }
+
+    #[test]
+    fn console_assigns_independent_port_queue_sizes() {
+        let console = Console::new(vec![port("agent", 32), port("agent-bulk", 256)]).unwrap();
+        let sizes: Vec<u16> = console
+            .queue_config
+            .iter()
+            .map(|queue| queue.size)
+            .collect();
+
+        assert_eq!(sizes, vec![32, 32, 32, 32, 256, 256]);
+    }
+
+    #[test]
+    fn console_rejects_invalid_port_queue_sizes() {
+        for queue_size in [15, 24, 2048] {
+            match Console::new(vec![port("agent", queue_size)]) {
+                Err(ConsoleError::InvalidQueueSize {
+                    port_id: 0,
+                    queue_size: actual,
+                }) => assert_eq!(actual, queue_size),
+                _ => panic!("queue size {queue_size} should be rejected"),
+            }
+        }
     }
 }

--- a/src/devices/src/virtio/console/mod.rs
+++ b/src/devices/src/virtio/console/mod.rs
@@ -18,6 +18,19 @@ pub use self::defs::uapi::VIRTIO_ID_CONSOLE as TYPE_CONSOLE;
 pub use self::device::Console;
 pub use self::port::PortDescription;
 
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Default descriptor count for virtio-console control and port queues.
+pub const DEFAULT_QUEUE_SIZE: u16 = 32;
+
+/// Smallest supported per-port descriptor count.
+pub const MIN_QUEUE_SIZE: u16 = 16;
+
+/// Largest supported per-port descriptor count.
+pub const MAX_QUEUE_SIZE: u16 = 1024;
+
 #[cfg(unix)]
 pub(crate) fn eventfd_pollable(event: &EventFd) -> Pollable {
     event.as_raw_fd()
@@ -40,7 +53,6 @@ pub(crate) fn pollable_token(pollable: Pollable) -> u64 {
 
 mod defs {
     pub const CONSOLE_DEV_ID: &str = "virtio_console";
-    pub const QUEUE_SIZE: u16 = 32;
 
     pub mod uapi {
         /// The device conforms to the virtio spec version 1.0.
@@ -71,6 +83,17 @@ pub enum ConsoleError {
     EventFd(std::io::Error),
     /// Failed to create SIGWINCH pipe.
     SigwinchPipe(std::io::Error),
+    /// A port requested a queue size unsupported by the virtio-console device.
+    InvalidQueueSize { port_id: usize, queue_size: u16 },
 }
 
 type Result<T> = std::result::Result<T, ConsoleError>;
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Return whether a virtio-console port queue size is supported.
+pub fn is_valid_queue_size(queue_size: u16) -> bool {
+    (MIN_QUEUE_SIZE..=MAX_QUEUE_SIZE).contains(&queue_size) && queue_size.is_power_of_two()
+}

--- a/src/devices/src/virtio/console/port.rs
+++ b/src/devices/src/virtio/console/port.rs
@@ -10,6 +10,7 @@ use crate::virtio::console::console_control::ConsoleControl;
 use crate::virtio::console::port_io::{PortInput, PortOutput};
 use crate::virtio::console::process_rx::process_rx;
 use crate::virtio::console::process_tx::process_tx;
+use crate::virtio::console::DEFAULT_QUEUE_SIZE;
 use crate::virtio::port_io::PortTerminalProperties;
 use crate::virtio::{InterruptTransport, Queue};
 
@@ -18,6 +19,7 @@ pub struct PortDescription {
     pub input: Option<Box<dyn PortInput + Send>>,
     pub output: Option<Box<dyn PortOutput + Send>>,
     pub terminal: Option<Box<dyn PortTerminalProperties>>,
+    pub queue_size: u16,
 }
 
 impl PortDescription {
@@ -31,6 +33,7 @@ impl PortDescription {
             input,
             output,
             terminal: Some(terminal),
+            queue_size: DEFAULT_QUEUE_SIZE,
         }
     }
 
@@ -43,6 +46,7 @@ impl PortDescription {
             input: None,
             output: Some(output),
             terminal: None,
+            queue_size: DEFAULT_QUEUE_SIZE,
         }
     }
 
@@ -55,6 +59,7 @@ impl PortDescription {
             input: Some(input),
             output: None,
             terminal: None,
+            queue_size: DEFAULT_QUEUE_SIZE,
         }
     }
 }

--- a/src/devices/src/virtio/console/port_io.rs
+++ b/src/devices/src/virtio/console/port_io.rs
@@ -770,6 +770,12 @@ pub trait ConsolePortBackend: Send + Sync {
     ///
     /// Used by the console RX thread for `poll()`-based blocking. Typically the read end of a wake pipe.
     fn read_wake_fd(&self) -> RawFd;
+
+    /// Wait until [`write`](Self::write) may accept more guest bytes.
+    ///
+    /// The default is intentionally inert for compatibility with existing backends. Bounded
+    /// backends should override this hook so a full output buffer blocks instead of busy-spinning.
+    fn wait_until_writable(&self) {}
 }
 
 /// Adapter that wraps a [`ConsolePortBackend`] as a [`PortInput`].
@@ -846,9 +852,7 @@ impl PortOutput for ConsolePortBackendOutputAdapter {
     }
 
     fn wait_until_writable(&self) {
-        // Ring buffer push is lock-free and practically instant. If the ring
-        // is full, write() returns WouldBlock and the console TX thread's
-        // existing retry loop handles backpressure.
+        self.backend.wait_until_writable();
     }
 }
 
@@ -1063,6 +1067,48 @@ struct WS {
 
 #[cfg(unix)]
 ioctl_read_bad!(tiocgwinsz, TIOCGWINSZ, WS);
+
+#[cfg(all(test, unix))]
+mod unix_tests {
+    use super::*;
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct WritableWaitBackend {
+        waits: Arc<AtomicUsize>,
+    }
+
+    impl ConsolePortBackend for WritableWaitBackend {
+        fn read(&self, _buf: &mut [u8]) -> io::Result<usize> {
+            Err(io::ErrorKind::WouldBlock.into())
+        }
+
+        fn write(&self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::ErrorKind::WouldBlock.into())
+        }
+
+        fn read_wake_fd(&self) -> RawFd {
+            -1
+        }
+
+        fn wait_until_writable(&self) {
+            self.waits.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn custom_output_adapter_delegates_writable_wait() {
+        let waits = Arc::new(AtomicUsize::new(0));
+        let backend: Arc<dyn ConsolePortBackend> = Arc::new(WritableWaitBackend {
+            waits: Arc::clone(&waits),
+        });
+        let adapter = ConsolePortBackendOutputAdapter::new(backend);
+
+        PortOutput::wait_until_writable(&adapter);
+
+        assert_eq!(waits.load(Ordering::Relaxed), 1);
+    }
+}
 
 #[cfg(all(test, windows))]
 mod tests {

--- a/src/krun/src/api/builder.rs
+++ b/src/krun/src/api/builder.rs
@@ -37,6 +37,7 @@ use super::vm::Vm;
 
 #[cfg(feature = "blk")]
 use devices::virtio::block::ImageType;
+use devices::virtio::console::is_valid_queue_size;
 #[cfg(feature = "blk")]
 use devices::virtio::CacheType;
 #[cfg(feature = "blk")]
@@ -384,6 +385,18 @@ impl VmBuilder {
 
         if self.machine.memory_mib == 0 {
             return Err(Error::Config(ConfigError::InvalidMemorySize(0)));
+        }
+
+        if let Some(port) = self
+            .console
+            .ports
+            .iter()
+            .find(|port| !is_valid_queue_size(port.queue_size()))
+        {
+            return Err(Error::Config(ConfigError::Console(format!(
+                "queue size {} must be a power of two between 16 and 1024",
+                port.queue_size()
+            ))));
         }
 
         #[cfg(target_os = "windows")]
@@ -1121,8 +1134,28 @@ mod tests {
 
     use super::*;
     use crate::api::builders::{
-        HostCpuId, HostMemoryPolicy, NumaDistance, NumaNodeConfig, NumaTopology,
+        ConsolePortOptions, HostCpuId, HostMemoryPolicy, NumaDistance, NumaNodeConfig, NumaTopology,
     };
+    #[cfg(not(target_os = "windows"))]
+    use crate::backends::console::ConsolePortBackend;
+
+    #[cfg(not(target_os = "windows"))]
+    struct EmptyConsoleBackend;
+
+    #[cfg(not(target_os = "windows"))]
+    impl ConsolePortBackend for EmptyConsoleBackend {
+        fn read(&self, _buf: &mut [u8]) -> io::Result<usize> {
+            Err(io::ErrorKind::WouldBlock.into())
+        }
+
+        fn write(&self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::ErrorKind::WouldBlock.into())
+        }
+
+        fn read_wake_fd(&self) -> std::os::fd::RawFd {
+            -1
+        }
+    }
 
     fn one_node_topology(vcpus: Vec<u8>, memory_mib: usize) -> NumaTopology {
         NumaTopology {
@@ -1187,6 +1220,28 @@ mod tests {
         match err {
             Error::Config(ConfigError::InvalidVcpuCount(3)) => {}
             other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn build_rejects_invalid_console_port_queue_sizes() {
+        for queue_size in [15, 24, 2048] {
+            let err = VmBuilder::new()
+                .console(|console| {
+                    console.custom_with_options(
+                        "agent",
+                        Box::new(EmptyConsoleBackend),
+                        ConsolePortOptions::new().queue_size(queue_size),
+                    )
+                })
+                .build()
+                .err()
+                .expect("invalid console queue size must fail VM construction");
+
+            assert!(
+                matches!(err, Error::Config(ConfigError::Console(message)) if message.contains(&queue_size.to_string()))
+            );
         }
     }
 

--- a/src/krun/src/api/builders.rs
+++ b/src/krun/src/api/builders.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use devices::virtio::console::port_io::{
     ConsolePortBackend, ConsolePortBackendInputAdapter, ConsolePortBackendOutputAdapter,
 };
+use devices::virtio::console::DEFAULT_QUEUE_SIZE;
 use vmm::resources::PortConfig;
 pub use vmm::resources::{
     HostMemoryPolicy, MemoryPlacementResult, NumaDistance, NumaNodeConfig, NumaTopology,
@@ -309,6 +310,12 @@ pub struct ConsoleBuilder {
     pub(crate) gpu_virgl_flags: Option<u32>,
     #[cfg(feature = "gpu")]
     pub(crate) gpu_shm_size: Option<usize>,
+}
+
+/// Options for one named virtio-console port.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConsolePortOptions {
+    pub(crate) queue_size: u16,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1115,6 +1122,7 @@ impl ConsoleBuilder {
     pub fn virtio_output(mut self, path: impl AsRef<Path>) -> Self {
         self.ports.push(PortConfig::ConsoleOutputFile {
             path: path.as_ref().to_path_buf(),
+            queue_size: DEFAULT_QUEUE_SIZE,
         });
         self
     }
@@ -1123,10 +1131,22 @@ impl ConsoleBuilder {
     ///
     /// The guest sees the port as `/dev/virtio-ports/<name>`. The host connects to `pipe_name` as a client, so the helper should create the pipe server first.
     #[cfg(target_os = "windows")]
-    pub fn named_pipe(mut self, name: &str, pipe_name: impl Into<String>) -> Self {
+    pub fn named_pipe(self, name: &str, pipe_name: impl Into<String>) -> Self {
+        self.named_pipe_with_options(name, pipe_name, ConsolePortOptions::default())
+    }
+
+    /// Add a Windows named-pipe console port with explicit device queue options.
+    #[cfg(target_os = "windows")]
+    pub fn named_pipe_with_options(
+        mut self,
+        name: &str,
+        pipe_name: impl Into<String>,
+        options: ConsolePortOptions,
+    ) -> Self {
         self.ports.push(PortConfig::NamedPipe {
             name: name.to_string(),
             pipe_name: pipe_name.into(),
+            queue_size: options.queue_size,
         });
         self
     }
@@ -1163,6 +1183,7 @@ impl ConsoleBuilder {
             name: name.to_string(),
             input_fd,
             output_fd,
+            queue_size: DEFAULT_QUEUE_SIZE,
         });
         self
     }
@@ -1177,6 +1198,7 @@ impl ConsoleBuilder {
         self.ports.push(PortConfig::Tty {
             name: name.to_string(),
             tty_fd,
+            queue_size: DEFAULT_QUEUE_SIZE,
         });
         self
     }
@@ -1204,7 +1226,18 @@ impl ConsoleBuilder {
     ///     .console(|c| c.custom("agent", Box::new(my_backend)))
     /// ```
     #[cfg(not(target_os = "windows"))]
-    pub fn custom(mut self, name: &str, backend: Box<dyn ConsolePortBackend>) -> Self {
+    pub fn custom(self, name: &str, backend: Box<dyn ConsolePortBackend>) -> Self {
+        self.custom_with_options(name, backend, ConsolePortOptions::default())
+    }
+
+    /// Add a custom console port backend with explicit device queue options.
+    #[cfg(not(target_os = "windows"))]
+    pub fn custom_with_options(
+        mut self,
+        name: &str,
+        backend: Box<dyn ConsolePortBackend>,
+        options: ConsolePortOptions,
+    ) -> Self {
         let backend: Arc<dyn ConsolePortBackend> = Arc::from(backend);
         let input = Box::new(ConsolePortBackendInputAdapter::new(Arc::clone(&backend)));
         let output = Box::new(ConsolePortBackendOutputAdapter::new(backend));
@@ -1212,8 +1245,32 @@ impl ConsoleBuilder {
             name: name.to_string(),
             input,
             output,
+            queue_size: options.queue_size,
         });
         self
+    }
+}
+
+impl ConsolePortOptions {
+    /// Create options that preserve libkrun's existing queue size.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Request the descriptor count for both directions of this port.
+    ///
+    /// Validation happens during [`VmBuilder::build`](crate::VmBuilder::build).
+    pub fn queue_size(mut self, queue_size: u16) -> Self {
+        self.queue_size = queue_size;
+        self
+    }
+}
+
+impl Default for ConsolePortOptions {
+    fn default() -> Self {
+        Self {
+            queue_size: DEFAULT_QUEUE_SIZE,
+        }
     }
 }
 
@@ -1607,7 +1664,13 @@ mod tests {
 
         assert_eq!(builder.ports.len(), 1);
         match builder.ports.pop().unwrap() {
-            PortConfig::ConsoleOutputFile { path: actual } => assert_eq!(actual, path),
+            PortConfig::ConsoleOutputFile {
+                path: actual,
+                queue_size,
+            } => {
+                assert_eq!(actual, path);
+                assert_eq!(queue_size, DEFAULT_QUEUE_SIZE);
+            }
             _ => panic!("unexpected console port config"),
         }
     }
@@ -1619,9 +1682,14 @@ mod tests {
 
         assert_eq!(builder.ports.len(), 1);
         match builder.ports.pop().unwrap() {
-            PortConfig::NamedPipe { name, pipe_name } => {
+            PortConfig::NamedPipe {
+                name,
+                pipe_name,
+                queue_size,
+            } => {
                 assert_eq!(name, "agent");
                 assert_eq!(pipe_name, r"\\.\pipe\msb-agent-console");
+                assert_eq!(queue_size, DEFAULT_QUEUE_SIZE);
             }
             _ => panic!("unexpected console port config"),
         }

--- a/src/krun/src/api/mod.rs
+++ b/src/krun/src/api/mod.rs
@@ -51,9 +51,9 @@ pub use builders::VsockBuilder;
 #[cfg(feature = "blk")]
 pub use builders::WritebackLimit;
 pub use builders::{
-    ConsoleBuilder, ExecBuilder, HostCpuId, HostMemoryPolicy, KernelBuilder, MachineBuilder,
-    MemoryPlacementResult, NumaBuilder, NumaDistance, NumaNodeBuilder, NumaNodeConfig,
-    NumaTopology, PlacementReport, VcpuPlacementResult,
+    ConsoleBuilder, ConsolePortOptions, ExecBuilder, HostCpuId, HostMemoryPolicy, KernelBuilder,
+    MachineBuilder, MemoryPlacementResult, NumaBuilder, NumaDistance, NumaNodeBuilder,
+    NumaNodeConfig, NumaTopology, PlacementReport, VcpuPlacementResult,
 };
 pub use error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use exit_handle::ExitHandle;

--- a/src/krun/src/lib.rs
+++ b/src/krun/src/lib.rs
@@ -53,9 +53,9 @@ pub use api::builders::VsockBuilder;
 #[cfg(feature = "blk")]
 pub use api::builders::WritebackLimit;
 pub use api::builders::{
-    ConsoleBuilder, ExecBuilder, HostCpuId, HostMemoryPolicy, KernelBuilder, MachineBuilder,
-    MemoryPlacementResult, NumaBuilder, NumaDistance, NumaNodeBuilder, NumaNodeConfig,
-    NumaTopology, PlacementReport, VcpuPlacementResult,
+    ConsoleBuilder, ConsolePortOptions, ExecBuilder, HostCpuId, HostMemoryPolicy, KernelBuilder,
+    MachineBuilder, MemoryPlacementResult, NumaBuilder, NumaDistance, NumaNodeBuilder,
+    NumaNodeConfig, NumaTopology, PlacementReport, VcpuPlacementResult,
 };
 pub use api::error::{BuildError, ConfigError, Error, Result, RuntimeError};
 pub use api::exit_handle::ExitHandle;

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -2659,6 +2659,7 @@ pub unsafe extern "C" fn krun_add_console_port_tty(
                     ports.push(PortConfig::Tty {
                         name: name_str,
                         tty_fd,
+                        queue_size: devices::virtio::console::DEFAULT_QUEUE_SIZE,
                     });
                     KRUN_SUCCESS
                 }
@@ -2698,6 +2699,7 @@ pub unsafe extern "C" fn krun_add_console_port_inout(
                         name: name_str,
                         input_fd,
                         output_fd,
+                        queue_size: devices::virtio::console::DEFAULT_QUEUE_SIZE,
                     });
                     KRUN_SUCCESS
                 }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -256,6 +256,8 @@ pub enum StartMicrovmError {
     OpenConsoleFile(io::Error),
     /// Cannot open console named pipe.
     OpenConsolePipe(io::Error),
+    /// Cannot construct a virtio-console device.
+    CreateConsoleDevice(devices::virtio::console::ConsoleError),
     /// The GZIP decoder couldn't decompress the kernel.
     PeGzDecoder(io::Error),
     /// Cannot open the file containing the kernel code.
@@ -369,6 +371,9 @@ impl Display for StartMicrovmError {
                 write!(f, "Cannot create KVM in-kernel IrqChip: {err}")
             }
             CreateRateLimiter(ref err) => write!(f, "Cannot create RateLimiter: {err}"),
+            CreateConsoleDevice(ref err) => {
+                write!(f, "Cannot create virtio-console device: {err:?}")
+            }
             #[cfg(not(target_os = "windows"))]
             ElfOpenKernel(ref err) => {
                 write!(f, "Cannot open the file containing the kernel code: {err}")
@@ -4324,7 +4329,11 @@ fn create_explicit_ports(
 
     for port_cfg in port_configs {
         let port_desc = match port_cfg {
-            PortConfig::Tty { name, tty_fd } => {
+            PortConfig::Tty {
+                name,
+                tty_fd,
+                queue_size,
+            } => {
                 assert!(tty_fd > 0, "PortConfig::Tty must have a valid tty_fd");
                 let term_fd = unsafe { BorrowedFd::borrow_raw(tty_fd) };
                 setup_terminal_raw_mode(vmm, Some(term_fd), false);
@@ -4334,12 +4343,14 @@ fn create_explicit_ports(
                     input: Some(port_io::input_to_raw_fd_dup(tty_fd).unwrap()),
                     output: Some(port_io::output_to_raw_fd_dup(tty_fd).unwrap()),
                     terminal: Some(port_io::term_fd(tty_fd).unwrap()),
+                    queue_size,
                 }
             }
             PortConfig::InOut {
                 name,
                 input_fd,
                 output_fd,
+                queue_size,
             } => PortDescription {
                 name: name.into(),
                 input: if input_fd < 0 {
@@ -4353,16 +4364,19 @@ fn create_explicit_ports(
                     Some(port_io::output_to_raw_fd_dup(output_fd).unwrap())
                 },
                 terminal: None,
+                queue_size,
             },
             PortConfig::Custom {
                 name,
                 input,
                 output,
+                queue_size,
             } => PortDescription {
                 name: name.into(),
                 input: Some(input),
                 output: Some(output),
                 terminal: None,
+                queue_size,
             },
         };
 
@@ -4382,16 +4396,22 @@ fn create_explicit_ports(
 
     for port_cfg in port_configs {
         let port_desc = match port_cfg {
-            PortConfig::ConsoleOutputFile { path } => {
+            PortConfig::ConsoleOutputFile { path, queue_size } => {
                 let file = File::create(path).map_err(OpenConsoleFile)?;
 
-                PortDescription::console(
+                let mut description = PortDescription::console(
                     Some(port_io::input_empty().unwrap()),
                     Some(port_io::output_file(file).unwrap()),
                     port_io::term_fixed_size(0, 0),
-                )
+                );
+                description.queue_size = queue_size;
+                description
             }
-            PortConfig::NamedPipe { name, pipe_name } => {
+            PortConfig::NamedPipe {
+                name,
+                pipe_name,
+                queue_size,
+            } => {
                 let (input, output) = port_io::named_pipe(&pipe_name).map_err(OpenConsolePipe)?;
 
                 PortDescription {
@@ -4399,6 +4419,7 @@ fn create_explicit_ports(
                     input: Some(input),
                     output: Some(output),
                     terminal: None,
+                    queue_size,
                 }
             }
         };
@@ -4433,7 +4454,9 @@ fn attach_console_devices(
         Some(VirtioConsoleConfigMode::Explicit(ports)) => create_explicit_ports(vmm, ports)?,
     };
 
-    let console = Arc::new(Mutex::new(devices::virtio::Console::new(ports).unwrap()));
+    let console = Arc::new(Mutex::new(
+        devices::virtio::Console::new(ports).map_err(CreateConsoleDevice)?,
+    ));
 
     vmm.exit_observers.push(console.clone());
 
@@ -4466,7 +4489,9 @@ fn attach_console_devices(
         VirtioConsoleConfigMode::Explicit(ports) => create_explicit_ports(ports)?,
     };
 
-    let console = Arc::new(Mutex::new(devices::virtio::Console::new(ports).unwrap()));
+    let console = Arc::new(Mutex::new(
+        devices::virtio::Console::new(ports).map_err(CreateConsoleDevice)?,
+    ));
 
     vmm.exit_observers.push(console.clone());
 
@@ -5031,15 +5056,21 @@ pub mod tests {
             std::process::id()
         ));
 
-        let ports =
-            create_explicit_ports(vec![PortConfig::ConsoleOutputFile { path: path.clone() }])
-                .unwrap();
+        let ports = create_explicit_ports(vec![PortConfig::ConsoleOutputFile {
+            path: path.clone(),
+            queue_size: devices::virtio::console::DEFAULT_QUEUE_SIZE,
+        }])
+        .unwrap();
 
         assert_eq!(ports.len(), 1);
         assert!(ports[0].name.is_empty());
         assert!(ports[0].input.is_some());
         assert!(ports[0].output.is_some());
         assert!(ports[0].terminal.is_some());
+        assert_eq!(
+            ports[0].queue_size,
+            devices::virtio::console::DEFAULT_QUEUE_SIZE
+        );
 
         let _ = std::fs::remove_file(path);
     }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -120,23 +120,49 @@ pub enum PortConfig {
     Tty {
         name: String,
         tty_fd: RawFd,
+        queue_size: u16,
     },
     InOut {
         name: String,
         input_fd: RawFd,
         output_fd: RawFd,
+        queue_size: u16,
     },
     Custom {
         name: String,
         input: Box<dyn devices::virtio::port_io::PortInput + Send>,
         output: Box<dyn devices::virtio::port_io::PortOutput + Send>,
+        queue_size: u16,
     },
 }
 
 #[cfg(target_os = "windows")]
 pub enum PortConfig {
-    ConsoleOutputFile { path: PathBuf },
-    NamedPipe { name: String, pipe_name: String },
+    ConsoleOutputFile {
+        path: PathBuf,
+        queue_size: u16,
+    },
+    NamedPipe {
+        name: String,
+        pipe_name: String,
+        queue_size: u16,
+    },
+}
+
+impl PortConfig {
+    /// Return the descriptor count requested for both directions of this port.
+    pub fn queue_size(&self) -> u16 {
+        match self {
+            #[cfg(not(target_os = "windows"))]
+            Self::Tty { queue_size, .. }
+            | Self::InOut { queue_size, .. }
+            | Self::Custom { queue_size, .. } => *queue_size,
+            #[cfg(target_os = "windows")]
+            Self::ConsoleOutputFile { queue_size, .. } | Self::NamedPipe { queue_size, .. } => {
+                *queue_size
+            }
+        }
+    }
 }
 
 /// Configuration for the vsock device


### PR DESCRIPTION
## TL;DR

Adds default-preserving per-port virtio-console queue sizing and a backend writable-capacity wait hook required by the Microsandbox agent transport stack.

## Description

- Exposes `ConsolePortOptions` for custom Unix and named-pipe Windows console ports.
- Keeps the existing 32-descriptor queue size unless a caller explicitly overrides it.
- Validates queue sizes as powers of two in the supported 16–1024 range.
- Delegates `PortOutput::wait_until_writable` to bounded custom backends, avoiding a retry spin when their output queue is full.
- Provides the prerequisite API for [Microsandbox PR #1358](https://github.com/superradcompany/microsandbox/pull/1358) and [PR #1360](https://github.com/superradcompany/microsandbox/pull/1360).

## Test Plan

- [x] `cargo test --locked -p msb_krun_devices virtio::console`
- [x] `cargo test --locked -p msb_krun build_rejects_invalid_console_port_queue_sizes`
- [x] `cargo clippy --locked -p msb_krun_devices -p msb_krun_vmm -p msb_krun -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Full platform CI
