### PR TITLE
fix(console): wait for guest port open before starting io

### DIFF
--- a/src/devices/src/virtio/console/device.rs
+++ b/src/devices/src/virtio/console/device.rs
@@ -30,12 +30,6 @@ pub(crate) const AVAIL_FEATURES: u64 = (1 << uapi::VIRTIO_CONSOLE_F_SIZE as u64)
     | (1 << uapi::VIRTIO_CONSOLE_F_MULTIPORT as u64)
     | (1 << uapi::VIRTIO_F_VERSION_1 as u64);
 
-fn port_io_start_requested(cmd: &VirtioConsoleControl) -> bool {
-    // PORT_READY only confirms that the guest driver recognizes the port. Generic ports are not
-    // safe for host-to-guest delivery until guest userspace opens them and sends PORT_OPEN.
-    cmd.event == control_event::VIRTIO_CONSOLE_PORT_OPEN && cmd.value == 1
-}
-
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(C, packed)]
 pub struct VirtioConsoleConfig {
@@ -236,9 +230,11 @@ impl Console {
                     }
                 }
                 control_event::VIRTIO_CONSOLE_PORT_OPEN => {
-                    let opened = match cmd.value {
-                        0 => false,
-                        1 => true,
+                    match cmd.value {
+                        0 => log::debug!("Guest closed port {}", cmd.id),
+                        // PORT_READY only confirms that the guest driver recognizes the port.
+                        // Host-to-guest delivery is safe once guest userspace sends PORT_OPEN.
+                        1 => ports_to_start.push(cmd.id as usize),
                         _ => {
                             log::error!(
                                 "Invalid value ({}) for VIRTIO_CONSOLE_PORT_OPEN on port {}",
@@ -247,17 +243,9 @@ impl Console {
                             );
                             continue;
                         }
-                    };
-
-                    if !opened {
-                        log::debug!("Guest closed port {}", cmd.id);
                     }
                 }
                 _ => log::warn!("Unknown console control event {:x}", cmd.event),
-            }
-
-            if port_io_start_requested(&cmd) {
-                ports_to_start.push(cmd.id as usize);
             }
         }
 
@@ -378,36 +366,5 @@ impl VmmExitObserver for Console {
     fn on_vmm_exit(&mut self, _exit_code: i32) {
         self.reset();
         log::trace!("Console on_vmm_exit finished");
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
-// Tests
-//--------------------------------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn console_starts_port_io_only_after_guest_opens_port() {
-        let port_ready = VirtioConsoleControl {
-            id: 0,
-            event: control_event::VIRTIO_CONSOLE_PORT_READY,
-            value: 1,
-        };
-        let port_open = VirtioConsoleControl {
-            id: 0,
-            event: control_event::VIRTIO_CONSOLE_PORT_OPEN,
-            value: 1,
-        };
-        let port_closed = VirtioConsoleControl {
-            value: 0,
-            ..port_open
-        };
-
-        assert!(!port_io_start_requested(&port_ready));
-        assert!(port_io_start_requested(&port_open));
-        assert!(!port_io_start_requested(&port_closed));
     }
 }

--- a/src/devices/src/virtio/console/device.rs
+++ b/src/devices/src/virtio/console/device.rs
@@ -30,6 +30,12 @@ pub(crate) const AVAIL_FEATURES: u64 = (1 << uapi::VIRTIO_CONSOLE_F_SIZE as u64)
     | (1 << uapi::VIRTIO_CONSOLE_F_MULTIPORT as u64)
     | (1 << uapi::VIRTIO_F_VERSION_1 as u64);
 
+fn port_io_start_requested(cmd: &VirtioConsoleControl) -> bool {
+    // PORT_READY only confirms that the guest driver recognizes the port. Generic ports are not
+    // safe for host-to-guest delivery until guest userspace opens them and sends PORT_OPEN.
+    cmd.event == control_event::VIRTIO_CONSOLE_PORT_OPEN && cmd.value == 1
+}
+
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(C, packed)]
 pub struct VirtioConsoleConfig {
@@ -228,15 +234,6 @@ impl Console {
                     if !name.is_empty() {
                         self.control.port_name(cmd.id, name)
                     }
-
-                    #[cfg(target_os = "windows")]
-                    {
-                        // The WHP/Linux virtio-console path may report the
-                        // port ready without a later PORT_OPEN event. Start
-                        // data queues once the guest has acknowledged the
-                        // port so early PID 1 handshakes can flow.
-                        ports_to_start.push(cmd.id as usize);
-                    }
                 }
                 control_event::VIRTIO_CONSOLE_PORT_OPEN => {
                     let opened = match cmd.value {
@@ -254,12 +251,13 @@ impl Console {
 
                     if !opened {
                         log::debug!("Guest closed port {}", cmd.id);
-                        continue;
                     }
-
-                    ports_to_start.push(cmd.id as usize);
                 }
                 _ => log::warn!("Unknown console control event {:x}", cmd.event),
+            }
+
+            if port_io_start_requested(&cmd) {
+                ports_to_start.push(cmd.id as usize);
             }
         }
 
@@ -380,5 +378,36 @@ impl VmmExitObserver for Console {
     fn on_vmm_exit(&mut self, _exit_code: i32) {
         self.reset();
         log::trace!("Console on_vmm_exit finished");
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn console_starts_port_io_only_after_guest_opens_port() {
+        let port_ready = VirtioConsoleControl {
+            id: 0,
+            event: control_event::VIRTIO_CONSOLE_PORT_READY,
+            value: 1,
+        };
+        let port_open = VirtioConsoleControl {
+            id: 0,
+            event: control_event::VIRTIO_CONSOLE_PORT_OPEN,
+            value: 1,
+        };
+        let port_closed = VirtioConsoleControl {
+            value: 0,
+            ..port_open
+        };
+
+        assert!(!port_io_start_requested(&port_ready));
+        assert!(port_io_start_requested(&port_open));
+        assert!(!port_io_start_requested(&port_closed));
     }
 }

--- a/src/devices/src/virtio/mem/device.rs
+++ b/src/devices/src/virtio/mem/device.rs
@@ -208,9 +208,7 @@ impl Mem {
     fn handle_unplug_all(&mut self) -> VirtioMemResp {
         let addr = self.config.addr;
         let size = self.config.region_size;
-        for block in &mut self.plugged_blocks {
-            *block = false;
-        }
+        self.plugged_blocks.fill(false);
         self.config.plugged_size = 0;
         self.discard_range(addr, size);
         resp(VIRTIO_MEM_RESP_ACK, 0)


### PR DESCRIPTION
## TL;DR
Wait for the guest to open a virtio-console port before starting data queues, so early bootstrap frames are not discarded on Windows hosts.

## Description
- Remove the Windows-specific path that started port I/O on `VIRTIO_CONSOLE_PORT_READY`.
- Start port I/O only after an affirmative `VIRTIO_CONSOLE_PORT_OPEN` event.
- Add a regression test covering ready, open, and closed port states.
- Fix superradcompany/microsandbox#1426.

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p msb_krun_devices`
- [x] `cargo check -p msb_krun_devices --target aarch64-pc-windows-msvc`
- [x] `cargo clippy -p msb_krun_devices --lib -- -D warnings`
- [x] Unpatched v0.6.12 reproduces the guest bootstrap timeout on Windows ARM64 WHP.
- [x] The patched build passes 10 cold boots and 3 persistent exec calls on Windows ARM64 WHP.